### PR TITLE
Improve ISO uncertainty fields

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -190,25 +190,25 @@
 				<text><![CDATA[TOL %]]></text>
 			</staticText>
                         <staticText>
-                                <reportElement x="450" y="18" width="30" height="17" uuid="cd094d04-c8d5-4314-bf7f-1969a1135d94"/>
+                                <reportElement x="450" y="18" width="45" height="17" uuid="cd094d04-c8d5-4314-bf7f-1969a1135d94"/>
                                 <textElement>
                                         <font fontName="Arial" size="9" isBold="true"/>
                                 </textElement>
                                 <text><![CDATA[MU-E]]></text>
                         </staticText>
                         <staticText>
-                                <reportElement x="480" y="18" width="30" height="17" uuid="ec32bb46-f2ab-4c57-a80a-f5b7ad02ba94"/>
+                                <reportElement x="495" y="18" width="45" height="17" uuid="ec32bb46-f2ab-4c57-a80a-f5b7ad02ba94"/>
                                 <textElement>
                                         <font fontName="Arial" size="9" isBold="true"/>
                                 </textElement>
                                 <text><![CDATA[MU-P]]></text>
                         </staticText>
                         <staticText>
-                                <reportElement x="510" y="18" width="31" height="17" uuid="46d4edac-188a-41bc-8743-a23bac3dd1d8"/>
+                                <reportElement x="540" y="18" width="20" height="17" uuid="46d4edac-188a-41bc-8743-a23bac3dd1d8"/>
                                 <textElement textAlignment="Right">
                                         <font fontName="Arial" size="9" isBold="true"/>
                                 </textElement>
-				<text><![CDATA[CONF]]></text>
+                                <text><![CDATA[]]></text>
 			</staticText>
 		</band>
 	</columnHeader>
@@ -266,21 +266,21 @@
 				<textFieldExpression><![CDATA[$V{RoundedTolErr}]]></textFieldExpression>
 			</textField>
                         <textField textAdjust="StretchHeight">
-                                <reportElement x="450" y="0" width="30" height="20" uuid="29af6774-21c4-43ea-a10d-ebb47a6ebed6"/>
+                                <reportElement x="450" y="0" width="45" height="20" uuid="29af6774-21c4-43ea-a10d-ebb47a6ebed6"/>
                                 <textElement markup="html">
                                         <font fontName="Arial" size="8"/>
                                 </textElement>
-                                <textFieldExpression><![CDATA[$F{exp_uncert_iso_e}]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[$F{exp_uncert_iso_e} == null || $F{exp_uncert_iso_e}.trim().isEmpty() ? "" : $F{exp_uncert_iso_e}]]></textFieldExpression>
                         </textField>
                         <textField textAdjust="StretchHeight">
-                                <reportElement x="480" y="0" width="30" height="20" uuid="ff778a2d-5eb9-4097-a4cc-1bd98afd0535"/>
+                                <reportElement x="495" y="0" width="45" height="20" uuid="ff778a2d-5eb9-4097-a4cc-1bd98afd0535"/>
                                 <textElement markup="html">
                                         <font fontName="Arial" size="8"/>
                                 </textElement>
-                                <textFieldExpression><![CDATA[$F{exp_uncert_iso_p}]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[$F{exp_uncert_iso_p} == null || $F{exp_uncert_iso_p}.trim().isEmpty() ? "" : $F{exp_uncert_iso_p}]]></textFieldExpression>
                         </textField>
                         <textField>
-                                <reportElement x="510" y="0" width="31" height="20" uuid="1f48e5bb-6d8e-4037-ac69-c1bb1f29e4af"/>
+                                <reportElement x="540" y="0" width="20" height="20" uuid="1f48e5bb-6d8e-4037-ac69-c1bb1f29e4af"/>
                                 <textElement textAlignment="Right">
                                         <font fontName="Arial" size="8"/>
                                 </textElement>


### PR DESCRIPTION
## Summary
- adjust MU-E and MU-P column widths
- shrink CONF column and hide its header
- suppress empty ISO uncertainty values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a6d4ef344832bb360ae4dc1b78724