### PR TITLE
Fix symmetric tolerance display

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -71,23 +71,23 @@
 	</variable>
 	<variable name="ToleranceRange" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[// Helper-Funktion für numerische Prüfung
-	        (
-	            ($F{tol_neg} != null && $F{tol_pos} != null &&
-	             $F{tol_neg}.replace(",", ".").matches("-?\\d+(\\.\\d+)?") &&
-	             $F{tol_pos}.replace(",", ".").matches("-?\\d+(\\.\\d+)?") &&
-	             Math.abs(
-	                 Double.parseDouble($F{tol_neg}.replace(",", "."))
-	                 - Double.parseDouble($F{tol_pos}.replace(",", "."))
-	             ) < 1e-9
-	            )
-	            // Wenn numerisch und gleich -> nur positiver Wert
-	            ? $F{tol_pos}.trim()
-	            // Sonst einfach beide Zeilen (egal ob Zahl oder nicht)
-	            : (
-	                ($F{tol_neg} != null ? $F{tol_neg}.trim() : "")
-	                + "\n"
-	                + ($F{tol_pos} != null ? $F{tol_pos}.trim() : "")
-	            )
+                (
+                    $F{tol_neg} != null && $F{tol_pos} != null &&
+                    $F{tol_neg}.replace(",", ".").matches("-?\\d+(\\.\\d+)?") &&
+                    $F{tol_pos}.replace(",", ".").matches("-?\\d+(\\.\\d+)?") &&
+                    Math.abs(
+                        Math.abs(Double.parseDouble($F{tol_neg}.replace(",", "."))) -
+                        Math.abs(Double.parseDouble($F{tol_pos}.replace(",", ".")))
+                    ) < 1e-9
+                )
+                    // Wenn numerisch und der Betrag gleich ist -> ein Wert mit ±
+                    ? "± " + $F{tol_pos}.trim().replaceFirst("^[+-]", "")
+                    // Sonst beide Werte ausgeben (egal ob Zahl oder nicht)
+                    : (
+                        ($F{tol_neg} != null ? $F{tol_neg}.trim() : "") +
+                        "\n" +
+                        ($F{tol_pos} != null ? $F{tol_pos}.trim() : "")
+                    )
 	        ).trim()]]></variableExpression>
 	</variable>
 	<variable name="RoundedTolErr" class="java.lang.String">


### PR DESCRIPTION
## Summary
- update `ToleranceRange` logic in Results.jrxml
  - show a single value with ± when positive and negative parts share the same magnitude

## Testing
- `xmllint --noout DAKKS-SAMPLE/subreports/Results.jrxml`

------
https://chatgpt.com/codex/tasks/task_e_685a8a786e28832ba234c91a9e5ace09