### PR TITLE
Add ExpUncType below measurement results heading

### DIFF
--- a/DAKKS-SAMPLE/main_reports/Calibration_V0.8.1.jrxml
+++ b/DAKKS-SAMPLE/main_reports/Calibration_V0.8.1.jrxml
@@ -77,9 +77,12 @@
 	<parameter name="Cert_field" class="java.lang.String">
 		<defaultValueExpression><![CDATA["C2396"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="P_Image_Path" class="java.lang.String">
-		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-	</parameter>
+        <parameter name="P_Image_Path" class="java.lang.String">
+                <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+        </parameter>
+        <parameter name="ExpUncType" class="java.lang.String">
+                <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+        </parameter>
 	<queryString language="SQL">
 		<![CDATA[SELECT COALESCE(c.$P!{Cert_field}, "") AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C2327, DATE_FORMAT(C2301, '%Y-%m') AS cal_date, CONCAT(cu.K4602, IF(cu.K4603 IS NOT NULL, CONCAT("\n", cu.K4603), ""), "\n", cu.K4606, " ", cu.k4604) AS customer,
 COALESCE(i.I4204, "") AS I4204, COALESCE(i.I4202, "") AS I4202, COALESCE(i.I4203, "") AS I4203, COALESCE(i.I4201, "") AS I4201, COALESCE(i.I4206, "") AS I4206, IF(i.I4224 IS NOT NULL AND i.I4224 != "", DATE_FORMAT(i.I4224, '%Y-%m-%d'), NULL) AS I4224,
@@ -540,22 +543,31 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 					<textFieldExpression><![CDATA[$P{Additional_information}]]></textFieldExpression>
 				</textField>
 			</band>
-			<band height="41" splitType="Prevent">
-				<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-				<textField>
-					<reportElement x="16" y="0" width="535" height="20" uuid="edc84cd0-a056-4c0e-b9a9-04211d67e48f">
-						<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					</reportElement>
-					<textElement verticalAlignment="Middle">
-						<font size="11" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{Group_header_4a}]]></textFieldExpression>
-				</textField>
-				<subreport>
-					<reportElement x="0" y="21" width="560" height="20" uuid="5b421b52-027f-4f4d-8460-fd59f9c17f36">
-						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					</reportElement>
+                        <band height="62" splitType="Prevent">
+                                <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                <textField>
+                                        <reportElement x="16" y="0" width="535" height="20" uuid="edc84cd0-a056-4c0e-b9a9-04211d67e48f">
+                                                <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+                                                <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+                                        </reportElement>
+                                        <textElement verticalAlignment="Middle">
+                                                <font size="11" isBold="true"/>
+                                        </textElement>
+                                        <textFieldExpression><![CDATA[$V{Group_header_4a}]]></textFieldExpression>
+                                </textField>
+                                <textField textAdjust="StretchHeight">
+                                        <reportElement x="16" y="21" width="535" height="20" uuid="EXPUNCTYPE-PLACEHOLDER">
+                                                <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        </reportElement>
+                                        <textElement>
+                                                <font size="11"/>
+                                        </textElement>
+                                        <textFieldExpression><![CDATA[$P{ExpUncType}]]></textFieldExpression>
+                                </textField>
+                                <subreport>
+                                        <reportElement x="0" y="42" width="560" height="20" uuid="5b421b52-027f-4f4d-8460-fd59f9c17f36">
+                                                <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        </reportElement>
 					<subreportParameter name="PrefixTable">
 						<subreportParameterExpression><![CDATA[$P{PrefixTable}]]></subreportParameterExpression>
 					</subreportParameter>


### PR DESCRIPTION
## Summary
- define new report parameter `ExpUncType`
- display the parameter below the "Messergebnisse" heading

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a8f3d9ef0832ba695dd483bc25e6a