### PR TITLE
Fix syntax error in Results.jrxml

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -88,7 +88,7 @@
                         "\n" +
                         ($F{tol_pos} != null ? $F{tol_pos}.trim() : "")
                     )
-                )).trim()]]></variableExpression>
+                ).trim()]]></variableExpression>
 	</variable>
 	<variable name="RoundedTolErr" class="java.lang.String">
 		<variableExpression><![CDATA[$F{tol_err}.trim().isEmpty()


### PR DESCRIPTION
## Summary
- remove an extraneous parenthesis in `Results.jrxml`

## Testing
- `xmllint --noout DAKKS-SAMPLE/subreports/Results.jrxml`
- `mvn -q compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a9031286c832b886a78908a646b88