### PR TITLE
Add release workflow with tag input

### DIFF
--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -1,0 +1,30 @@
+name: Release Reports
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (e.g., v1.2.3)'
+        required: true
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create ZIP archives
+        run: |
+          mkdir -p release_zips
+          zip -r release_zips/dakks-sample.zip DAKKS-SAMPLE/main_reports DAKKS-SAMPLE/subreports -x "*.zip"
+          zip -r release_zips/order-sample.zip ORDER-SAMPLE/main_reports ORDER-SAMPLE/subreports -x "*.zip"
+
+      - name: Publish release on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          files: release_zips/*.zip
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ Das Skript erstellt automatisch ein ZIP-Archiv und lädt es via `curl` zur API d
 
 ---
 
+## 📦 Download der aktuellen Reportpakete
+
+Alle aktuellen und früheren ZIP-Archive mit Reportvorlagen stehen als Release-Pakete zur Verfügung:
+
+- [Letztes Release herunterladen (empfohlen)](https://github.com/calhelp/calServer-reports/releases/latest)
+- [Alle Releases durchsuchen](https://github.com/calhelp/calServer-reports/releases)
+
+Für Entwickler:innen und zum Testen der jeweils frisch gebauten Version gibt es zusätzlich temporäre „Artifacts“ im Bereich  
+[GitHub Actions](https://github.com/calhelp/calServer-reports/actions).
+
+---
+
 ## Contributing & Community
 
 **Wir freuen uns auf deine Beiträge!**


### PR DESCRIPTION
## Summary
- add input for manual releases in workflow
- provide tag name when publishing release

## Testing
- `echo "No tests configured"`


------
https://chatgpt.com/codex/tasks/task_e_685dabc2fd90832ba340565af38b30da