### PR TITLE
Align DAKKS subreport width with main report

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Standard" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="12" bottomMargin="12" isFloatColumnFooter="true" uuid="ff73abd8-b53d-41bb-b8b6-96000693b8ef">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Standard" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="12" bottomMargin="12" isFloatColumnFooter="true" uuid="ff73abd8-b53d-41bb-b8b6-96000693b8ef">
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="CalHelp Data Adapter "/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>


### PR DESCRIPTION
## Summary
- ensure DAKKS subreport page/column widths are 535 to match main report

## Testing
- `MAVEN_OPTS="-Djava.net.preferIPv4Stack=true" mvn -q -s /tmp/jaspercompile/settings.xml -f /tmp/jaspercompile/pom.xml -e compile` *(fails: Could not transfer artifacts; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fbdaa214832ba08c05b2e0567b71