### PR TITLE
Add JasperReports version check

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -28,18 +28,21 @@ jobs:
             ORDER-SAMPLE/subreports
           if-no-files-found: error
 
-      - name: List files before zipping (Debug)
-        run: |
-          echo "📂 Inhalt von DAKKS-SAMPLE:"
-          find DAKKS-SAMPLE
-          echo "📂 Inhalt von ORDER-SAMPLE:"
-          find ORDER-SAMPLE
+        - name: List files before zipping (Debug)
+          run: |
+            echo "📂 Inhalt von DAKKS-SAMPLE:"
+            find DAKKS-SAMPLE
+            echo "📂 Inhalt von ORDER-SAMPLE:"
+            find ORDER-SAMPLE
 
-      - name: Create ZIPs of both folders (excluding existing ZIPs)
-        run: |
-          mkdir -p zip_output
-          zip -r zip_output/dakks-sample.zip DAKKS-SAMPLE/main_reports DAKKS-SAMPLE/subreports -x "*.zip"
-          zip -r zip_output/order-sample.zip ORDER-SAMPLE/main_reports ORDER-SAMPLE/subreports -x "*.zip"
+        - name: Check JasperReports version
+          run: bash scripts/check_jasper_version.sh
+
+        - name: Create ZIPs of both folders (excluding existing ZIPs)
+          run: |
+            mkdir -p zip_output
+            zip -r zip_output/dakks-sample.zip DAKKS-SAMPLE/main_reports DAKKS-SAMPLE/subreports -x "*.zip"
+            zip -r zip_output/order-sample.zip ORDER-SAMPLE/main_reports ORDER-SAMPLE/subreports -x "*.zip"
 
       - name: Show ZIP contents (Debug)
         run: |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ scripts/
 
 * Aktive calServer-Instanz (Cloud oder On-Premise)
 * Zugang zur **Reportverwaltung** im calServer (Admin-Berechtigung)
-* JasperReports Editor (z. B. Jaspersoft Studio) zur Bearbeitung der JRXML-Dateien
+* JasperReports Editor (z. B. Jaspersoft Studio) zur Bearbeitung der JRXML-Dateien. 
+  Stelle sicher, dass die Vorlagen mit **JasperReports Library 6.20.6** exportiert werden. 
+  Das Skript `scripts/check_jasper_version.sh` bricht andernfalls mit der Meldung 
+  `Expected JasperReports Library version 6.20.6` ab.
 * Grundkenntnisse in Git und (optional) GitHub Actions
 
 ---

--- a/scripts/check_jasper_version.sh
+++ b/scripts/check_jasper_version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_comment="JasperReports Library version 6.20.6"
+error_found=0
+
+while IFS= read -r -d '' file; do
+  if ! grep -q "$expected_comment" "$file"; then
+    echo "❌ $file: Expected $expected_comment" >&2
+    error_found=1
+  fi
+done < <(find . -name "*.jrxml" -print0)
+
+if [ "$error_found" -ne 0 ]; then
+  echo "Found JRXML files not built with $expected_comment" >&2
+  exit 1
+fi
+
+echo "All JRXML files use $expected_comment"


### PR DESCRIPTION
## Summary
- add `scripts/check_jasper_version.sh` to verify JRXML templates were created with JasperReports Library 6.20.6
- run version check in package-reports workflow before creating ZIPs
- document required JasperReports version and failure message in README

## Testing
- `bash scripts/check_jasper_version.sh` *(fails: ./ORDER-SAMPLE/main_reports/Angebot_V0.8.jrxml: Expected JasperReports Library version 6.20.6)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ff7cb970832b9d32bdb2051eb898