### PR TITLE
Allow title band to stretch and float fields

### DIFF
--- a/DAKKS-SAMPLE/main_reports/Calibration_V0.8.2.jrxml
+++ b/DAKKS-SAMPLE/main_reports/Calibration_V0.8.2.jrxml
@@ -589,7 +589,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<title>
                <!-- allow more space on the start page so bigger field
                     contents do not trigger a page break -->
-               <band height="818" splitType="Prevent">
+               <band height="818" splitType="Stretch">
 			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
 			<textField textAdjust="StretchHeight">
 				<reportElement x="17" y="370" width="134" height="30" uuid="6e73786e-fde1-4967-9ccb-5258187d7a90">
@@ -840,94 +840,94 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
 			</textField>
-			<textField textAdjust="StretchHeight">
-				<reportElement x="329" y="423" width="222" height="237" uuid="63ba20c4-fdad-4cef-8538-a07589d41d75"/>
+                        <textField isStretchWithOverflow="true" textAdjust="StretchHeight">
+                                <reportElement positionType="Float" x="329" y="423" width="222" height="237" uuid="63ba20c4-fdad-4cef-8538-a07589d41d75"/>
 				<textElement textAlignment="Justified">
 					<font size="9"/>
 				</textElement>
 				<textFieldExpression><![CDATA[new String($P{Cert_description}.replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8").replace("_00E4_", "ä").replace("_00F6_", "ö").replace("_00FC_", "ü").replace("_00C4_", "Ä").replace("_00D6_", "Ö").replace("_00DC_", "Ü").replace("_00DF_", "ß")]]></textFieldExpression>
 			</textField>
-			<textField textAdjust="StretchHeight">
-				<reportElement x="16" y="677" width="535" height="21" uuid="470997ee-2360-4f40-8dc0-1cd01e68aa01">
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-				</reportElement>
-				<textElement textAlignment="Justified">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new String($P{Cert_description_1}.replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8").replace("_00E4_", "ä").replace("_00F6_", "ö").replace("_00FC_", "ü").replace("_00C4_", "Ä").replace("_00D6_", "Ö").replace("_00DC_", "Ü").replace("_00DF_", "ß")]]></textFieldExpression>
-			</textField>
+                        <textField isStretchWithOverflow="true" textAdjust="StretchHeight">
+                                <reportElement positionType="Float" x="16" y="677" width="535" height="21" uuid="470997ee-2360-4f40-8dc0-1cd01e68aa01">
+                                        <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+                                </reportElement>
+                                <textElement textAlignment="Justified">
+                                        <font size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[new String($P{Cert_description_1}.replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8").replace("_00E4_", "ä").replace("_00F6_", "ö").replace("_00FC_", "ü").replace("_00C4_", "Ä").replace("_00D6_", "Ö").replace("_00DC_", "Ü").replace("_00DF_", "ß")]]></textFieldExpression>
+                        </textField>
 			<line>
 				<reportElement positionType="Float" x="16" y="700" width="535" height="1" uuid="7180f2cc-b318-42fe-8297-222a27072378">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
 			</line>
-			<textField>
-				<reportElement stretchType="ContainerHeight" x="16" y="703" width="134" height="20" uuid="46c04130-b64c-43e6-9a51-d831732c69dc">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{Datum}]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight" pattern="dd.MM.yyyy" isBlankWhenNull="true">
-				<reportElement stretchType="ContainerHeight" x="16" y="726" width="134" height="20" uuid="e0db9184-37b0-441a-9c29-bf6775d558f7">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement x="16" y="773" width="535" height="1" uuid="d14783c6-e3cc-4217-a64f-df17f8f3e82a">
-					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-				</reportElement>
-			</line>
-			<textField>
-				<reportElement stretchType="ContainerHeight" x="204" y="703" width="149" height="20" uuid="6142ebc6-b46e-4e8e-a702-9b9d810d885f">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{Kalibrierlabor}]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight">
-				<reportElement stretchType="ContainerHeight" x="204" y="726" width="149" height="20" uuid="374d1e1f-60cd-4376-8b3d-006adc0bc73f">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{C2327}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement stretchType="ContainerHeight" x="408" y="703" width="143" height="20" uuid="f0491c98-4de4-4515-9038-a2a20eae9865">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{Person_in_charge}]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight">
-				<reportElement stretchType="ContainerHeight" x="408" y="726" width="143" height="20" uuid="ec31e771-b9cd-4088-8317-5f5f22b50907">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{C2307}]]></textFieldExpression>
-			</textField>
+                        <textField>
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="16" y="703" width="134" height="20" uuid="46c04130-b64c-43e6-9a51-d831732c69dc">
+                                        <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+                                </reportElement>
+                                <textElement verticalAlignment="Middle">
+                                        <font size="10" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{Datum}]]></textFieldExpression>
+                        </textField>
+                        <textField textAdjust="StretchHeight" pattern="dd.MM.yyyy" isBlankWhenNull="true">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="16" y="726" width="134" height="20" uuid="e0db9184-37b0-441a-9c29-bf6775d558f7">
+                                        <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+                                </reportElement>
+                                <textElement verticalAlignment="Middle">
+                                        <font size="10"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
+                        </textField>
+                        <line>
+                                <reportElement positionType="Float" x="16" y="773" width="535" height="1" uuid="d14783c6-e3cc-4217-a64f-df17f8f3e82a">
+                                        <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+                                </reportElement>
+                        </line>
+                        <textField>
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="204" y="703" width="149" height="20" uuid="6142ebc6-b46e-4e8e-a702-9b9d810d885f">
+                                        <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+                                </reportElement>
+                                <textElement verticalAlignment="Middle">
+                                        <font size="10" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{Kalibrierlabor}]]></textFieldExpression>
+                        </textField>
+                        <textField textAdjust="StretchHeight">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="204" y="726" width="149" height="20" uuid="374d1e1f-60cd-4376-8b3d-006adc0bc73f">
+                                        <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                </reportElement>
+                                <textElement verticalAlignment="Middle">
+                                        <font size="10"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$F{C2327}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="408" y="703" width="143" height="20" uuid="f0491c98-4de4-4515-9038-a2a20eae9865">
+                                        <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+                                        <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+                                </reportElement>
+                                <textElement verticalAlignment="Middle">
+                                        <font size="10" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{Person_in_charge}]]></textFieldExpression>
+                        </textField>
+                        <textField textAdjust="StretchHeight">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="408" y="726" width="143" height="20" uuid="ec31e771-b9cd-4088-8317-5f5f22b50907">
+                                        <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                </reportElement>
+                                <textElement verticalAlignment="Middle">
+                                        <font size="10"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$F{C2307}]]></textFieldExpression>
+                        </textField>
 			<textField>
 				<reportElement x="498" y="349" width="51" height="24" uuid="de2ec427-896e-4411-86b3-d78b5eb6e1dc">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>


### PR DESCRIPTION
## Summary
- Allow title band to stretch across pages instead of forcing a break
- Enable Cert_description fields to stretch with overflow and float within the band
- Float subsequent elements so layout adapts to long parameter values

## Testing
- `xmllint --noout DAKKS-SAMPLE/main_reports/Calibration_V0.8.2.jrxml`


------
https://chatgpt.com/codex/tasks/task_e_68c7fc0ce554832b9b5556e4bf73d9cb