### PR TITLE
Adjust calibration mark column width in DAKKS Standard report

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -103,7 +103,7 @@ GROUP BY t.C2430]]>
 				<textFieldExpression><![CDATA[$V{Duedate}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="490" y="0" width="105" height="21" backcolor="#F2F2F2" uuid="bba1fa61-8bea-4d3c-a7e7-1a1483c1458d"/>
+				<reportElement x="490" y="0" width="45" height="21" backcolor="#F2F2F2" uuid="bba1fa61-8bea-4d3c-a7e7-1a1483c1458d"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
@@ -156,7 +156,7 @@ GROUP BY t.C2430]]>
 				<textFieldExpression><![CDATA[$F{C2303}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="490" y="0" width="105" height="19" uuid="9075fa2a-aa64-472c-b973-3d44a95d0c0b"/>
+				<reportElement x="490" y="0" width="45" height="19" uuid="9075fa2a-aa64-472c-b973-3d44a95d0c0b"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>


### PR DESCRIPTION
## Summary
- Limit calibration mark column to 45 px in both header and detail bands of `Standard.jrxml` so columns fit within 535 px page width.

## Testing
- `bash scripts/check_jasper_version.sh` *(fails: ./INVENTORY-SAMPLE/main_reports/Inventory_Sample.jrxml: Expected JasperReports Library version 6.20.6; ./INVENTORY-SAMPLE/subreports/Calibration.jrxml: Expected JasperReports Library version 6.20.6)*
- `(cd DAKKS-SAMPLE && bash ../scripts/check_jasper_version.sh)`


------
https://chatgpt.com/codex/tasks/task_e_68c803ecab88832bae8534cf084d5495