### PR TITLE
fix: ensure Jasper version check scans repo root

### DIFF
--- a/scripts/check_jasper_version.sh
+++ b/scripts/check_jasper_version.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
 expected_comment="JasperReports Library version 6.20.6"
 error_found=0
 
@@ -9,7 +12,7 @@ while IFS= read -r -d '' file; do
     echo "❌ $file: Expected $expected_comment" >&2
     error_found=1
   fi
-done < <(find . -name "*.jrxml" -print0)
+done < <(find "$repo_root" -name "*.jrxml" -print0)
 
 if [ "$error_found" -ne 0 ]; then
   echo "Found JRXML files not built with $expected_comment" >&2


### PR DESCRIPTION
## Summary
- ensure check_jasper_version.sh scans entire repo regardless of working directory

## Testing
- `cd scripts && ./check_jasper_version.sh || true`


------
https://chatgpt.com/codex/tasks/task_e_68c80eb8d5ec832b90d1c55661d0db2b