### PR TITLE
chore: remove JasperReports version check

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -47,9 +47,6 @@ jobs:
           echo "📂 Inhalt von INVENTORY-SAMPLE:"
           find INVENTORY-SAMPLE
 
-      - name: Check JasperReports version
-        run: bash scripts/check_jasper_version.sh
-
       - name: Create ZIPs of all folders (excluding existing ZIPs)
         run: |
           mkdir -p zip_output


### PR DESCRIPTION
## Summary
- remove JasperReports version check step from package workflow

## Testing
- `yamllint .github/workflows/package-reports.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c8114b6030832bb12d7a260e7688eb