### PR TITLE
feat: publish report zips as release assets

### DIFF
--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -19,17 +19,17 @@ jobs:
 
       - name: Create ZIP archives
         run: |
-          mkdir -p release_zips
-          zip -r release_zips/dakks-sample.zip \
+          mkdir -p output
+          zip -r output/dakks-sample.zip \
             DAKKS-SAMPLE/main_reports DAKKS-SAMPLE/subreports -x "*.zip"
-          zip -r release_zips/order-sample.zip \
+          zip -r output/order-sample.zip \
             ORDER-SAMPLE/main_reports ORDER-SAMPLE/subreports -x "*.zip"
-          zip -r release_zips/inventory-sample.zip \
+          zip -r output/inventory-sample.zip \
             INVENTORY-SAMPLE/main_reports INVENTORY-SAMPLE/subreports -x "*.zip"
 
       - name: Publish release on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
-          files: release_zips/*.zip
+          files: output/*.zip
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- build report ZIPs in an `output` folder
- publish generated archives as assets when a tag or manual release is triggered

## Testing
- `yamllint .github/workflows/release-reports.yml`
- `bash scripts/check_jasper_version.sh` *(fails: Expected JasperReports Library version 6.20.6)*

------
https://chatgpt.com/codex/tasks/task_e_68c80f8631f8832ba32ac9dedcecb100