### PR TITLE
Add report version header field

### DIFF
--- a/DAKKS-SAMPLE/main_reports/Calibration_V0.8.2.jrxml
+++ b/DAKKS-SAMPLE/main_reports/Calibration_V0.8.2.jrxml
@@ -77,13 +77,16 @@
 	<parameter name="Cert_field" class="java.lang.String">
 		<defaultValueExpression><![CDATA["C2396"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="P_Image_Path" class="java.lang.String">
-		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-	</parameter>
-	<parameter name="ExpUncType" class="java.lang.String">
-		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-	</parameter>
-	<queryString language="SQL">
+<parameter name="P_Image_Path" class="java.lang.String">
+<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+</parameter>
+        <parameter name="ExpUncType" class="java.lang.String">
+                <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+        </parameter>
+        <parameter name="ReportVersion" class="java.lang.String">
+                <defaultValueExpression><![CDATA["V0.8.2"]]></defaultValueExpression>
+        </parameter>
+        <queryString language="SQL">
 		<![CDATA[SELECT COALESCE(c.$P!{Cert_field}, "") AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C2327, DATE_FORMAT(C2301, '%Y-%m') AS cal_date, CONCAT(cu.K4602, IF(cu.K4603 IS NOT NULL, CONCAT("\n", cu.K4603), ""), "\n", cu.K4606, " ", cu.k4604) AS customer,
 COALESCE(i.I4204, "") AS I4204, COALESCE(i.I4202, "") AS I4202, COALESCE(i.I4203, "") AS I4203, COALESCE(i.I4201, "") AS I4201, COALESCE(i.I4206, "") AS I4206, IF(i.I4224 IS NOT NULL AND i.I4224 != "", DATE_FORMAT(i.I4224, '%Y-%m-%d'), NULL) AS I4224,
 c.C2301, COALESCE(c.C2314, "--") AS C2314, COALESCE(c.C2308, "") AS C2308, COALESCE(c.C2311, "--") AS C2311, COALESCE(c.C2312, "--") AS C2312
@@ -590,8 +593,18 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                <!-- allow more space on the start page so bigger field
                     contents do not trigger a page break -->
                <band height="818" splitType="Stretch">
-			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
-			<textField textAdjust="StretchHeight">
+                       <property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+                       <textField>
+                               <reportElement x="0" y="0" width="100" height="10" forecolor="#808080" uuid="09fbdd07-84e0-421a-8062-48071b34af67">
+                                       <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+                                       <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+                               </reportElement>
+                               <textElement>
+                                       <font size="8"/>
+                               </textElement>
+                               <textFieldExpression><![CDATA[$P{ReportVersion}]]></textFieldExpression>
+                       </textField>
+                       <textField textAdjust="StretchHeight">
 				<reportElement x="17" y="370" width="134" height="30" uuid="6e73786e-fde1-4967-9ccb-5258187d7a90">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>

--- a/INVENTORY-SAMPLE/main_reports/Inventory_Sample.jrxml
+++ b/INVENTORY-SAMPLE/main_reports/Inventory_Sample.jrxml
@@ -22,10 +22,13 @@
 	<parameter name="P_MTAG" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="CurrentDate" class="java.util.Date" isForPrompting="false">
-		<defaultValueExpression><![CDATA[new Date()]]></defaultValueExpression>
-	</parameter>
-	<queryString>
+        <parameter name="CurrentDate" class="java.util.Date" isForPrompting="false">
+                <defaultValueExpression><![CDATA[new Date()]]></defaultValueExpression>
+        </parameter>
+        <parameter name="ReportVersion" class="java.lang.String">
+                <defaultValueExpression><![CDATA["V0.1"]]></defaultValueExpression>
+        </parameter>
+        <queryString>
 		<![CDATA[SELECT i.MTAG, COALESCE(i.I4201, "") AS I4201, COALESCE(i.I4202, "") AS I4202, COALESCE(i.I4203, "") AS I4203, COALESCE(i.I4204, "") AS I4204, COALESCE(i.I4206, "") AS I4206, COALESCE(i.I4232, "") AS I4232, COALESCE(i.I4228, "") AS I4228, COALESCE(i.I4229, "") AS I4229, COALESCE(i.I4299, "") AS I4299,
 COALESCE(c.K4602, "") AS K4602, COALESCE(c.K4603, "") AS K4603, COALESCE(c.K4604, "") AS K4604, COALESCE(c.K4605, "") AS K4605, COALESCE(c.K4606, "") AS K4606, b.barcode_type, b.barcode_value
 FROM $P!{PrefixTable}inventory i
@@ -101,10 +104,20 @@ WHERE i.MTAG=$P{P_MTAG}]]>
 	<variable name="Zip" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "PLZ" : "Zip"]]></variableExpression>
 	</variable>
-	<title>
-		<band height="285" splitType="Stretch">
-			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
-			<rectangle>
+<title>
+<band height="285" splitType="Stretch">
+<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+<textField>
+<reportElement x="0" y="0" width="100" height="10" forecolor="#808080" uuid="a0f8c523-c365-4853-93e8-85e6f5d4d77d">
+<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+</reportElement>
+<textElement>
+<font size="8"/>
+</textElement>
+<textFieldExpression><![CDATA[$P{ReportVersion}]]></textFieldExpression>
+</textField>
+<rectangle>
 				<reportElement stretchType="RelativeToBandHeight" mode="Transparent" x="17" y="151" width="543" height="124" uuid="57f8e2b7-41b1-4221-868f-1fd20a9d76ae">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>

--- a/ORDER-SAMPLE/main_reports/Angebot_V0.8.jrxml
+++ b/ORDER-SAMPLE/main_reports/Angebot_V0.8.jrxml
@@ -46,10 +46,13 @@
 	<parameter name="Report_phone_number" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Report_description" class="java.lang.String">
-		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-	</parameter>
-	<queryString>
+<parameter name="Report_description" class="java.lang.String">
+<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+</parameter>
+<parameter name="ReportVersion" class="java.lang.String">
+<defaultValueExpression><![CDATA["V0.8"]]></defaultValueExpression>
+</parameter>
+<queryString>
 		<![CDATA[SELECT b.uID, a.uID AS article_id, c.K4601, CONCAT_WS(" ", c.K4613, c.K4602) AS K4602, c.K4603, c.K4604, c.K4605, c.K4606, c.K4633, b.W4102,b.W4103, b.date, b.number, b.W4106, b.W4101, b.W4104, b.customer_KTAG, DATE_FORMAT(b.W4105, "%d.%m.%Y") AS W4105, W4108, IF(W4109 IS NULL OR TRIM(W4109) = "", "", DATE_FORMAT(STR_TO_DATE(W4109, '%Y-%m-%d'), '%d.%m.%Y')) AS W4109,
 bc.K4601 as BK4601, CONCAT_WS(" ", bc.K4613, bc.K4602) AS BK4602, bc.K4603 AS BK4603, bc.K4604 AS BK4604, bc.K4605 AS BK4605, bc.K4606 AS BK4606, dc.K4601 AS DK4601, CONCAT_WS(" ", dc.K4613, dc.K4602) AS DK4602, dc.K4603 AS DK4603, dc.K4604 AS DK4604, dc.K4605 AS DK4605, dc.K4606 AS DK4606,
 CONCAT_WS(" ", IF(c.K4606 IS NULL OR TRIM(c.K4606) = "", NULL, c.K4606), IF(c.K4604 IS NULL OR TRIM(c.K4604) = "", NULL, c.K4604)) AS order_address, CONCAT_WS(" ", bc.K4606, bc.K4604) AS billing_company, CONCAT_WS(" ", dc.K4606, dc.K4604) AS delivery_company, b.customer_contact_id, tc.type AS contact_type,
@@ -465,10 +468,20 @@ ORDER BY a.pos_number ASC,
 	<background>
 		<band splitType="Stretch"/>
 	</background>
-	<title>
-		<band height="271" splitType="Stretch">
-			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<rectangle>
+<title>
+<band height="271" splitType="Stretch">
+<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+<textField>
+<reportElement x="0" y="0" width="100" height="10" forecolor="#808080" uuid="d930268a-b0ba-4b82-986f-ee1a71a70c4d">
+<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+</reportElement>
+<textElement>
+<font size="8"/>
+</textElement>
+<textFieldExpression><![CDATA[$P{ReportVersion}]]></textFieldExpression>
+</textField>
+<rectangle>
 				<reportElement stretchType="RelativeToBandHeight" mode="Transparent" x="25" y="108" width="254" height="124" uuid="5878cf48-be6d-4789-b99c-acfa4d90ca21">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>


### PR DESCRIPTION
## Summary
- show report version in the first page header of Calibration, Inventory, and Angebot reports

## Testing
- `scripts/check_jasper_version.sh` *(fails: Expected JasperReports Library version 6.20.6)*

------
https://chatgpt.com/codex/tasks/task_e_68c81d83b6e4832b8a98756f4d46f5d7