### PR TITLE
Zip sample directories from within

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -50,12 +50,9 @@ jobs:
       - name: Create ZIPs of all folders (excluding existing ZIPs)
         run: |
           mkdir -p zip_output
-          zip -r zip_output/dakks-sample.zip \
-            DAKKS-SAMPLE/main_reports DAKKS-SAMPLE/subreports -x "*.zip"
-          zip -r zip_output/order-sample.zip \
-            ORDER-SAMPLE/main_reports ORDER-SAMPLE/subreports -x "*.zip"
-          zip -r zip_output/inventory-sample.zip \
-            INVENTORY-SAMPLE/main_reports INVENTORY-SAMPLE/subreports -x "*.zip"
+          (cd DAKKS-SAMPLE && zip -r ../zip_output/dakks-sample.zip main_reports subreports -x "*.zip")
+          (cd ORDER-SAMPLE && zip -r ../zip_output/order-sample.zip main_reports subreports -x "*.zip")
+          (cd INVENTORY-SAMPLE && zip -r ../zip_output/inventory-sample.zip main_reports subreports -x "*.zip")
 
       - name: Show ZIP contents (Debug)
         run: |


### PR DESCRIPTION
## Summary
- ensure packaging workflow zips from inside each sample directory so archives contain only main_reports and subreports

## Testing
- `yamllint .github/workflows/package-reports.yml`
- `unzip -l zip_output/dakks-sample.zip`
- `unzip -l zip_output/order-sample.zip`
- `unzip -l zip_output/inventory-sample.zip`


------
https://chatgpt.com/codex/tasks/task_e_68c82921f960832b9d13fb1570ba8c2f