### PR TITLE
Remove default table prefix from subreports

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -12,9 +12,9 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<parameter name="PrefixTable" class="java.lang.String">
-		<defaultValueExpression><![CDATA["thermo_"]]></defaultValueExpression>
-	</parameter>
+        <parameter name="PrefixTable" class="java.lang.String">
+                <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+        </parameter>
 	<parameter name="Sprache" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
 	</parameter>

--- a/ORDER-SAMPLE/subreports/Statistics.jrxml
+++ b/ORDER-SAMPLE/subreports/Statistics.jrxml
@@ -7,9 +7,9 @@
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="156"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="837"/>
-	<parameter name="PrefixTable" class="java.lang.String">
-		<defaultValueExpression><![CDATA["thermo_"]]></defaultValueExpression>
-	</parameter>
+        <parameter name="PrefixTable" class="java.lang.String">
+                <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+        </parameter>
 	<parameter name="Sprache" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
 	</parameter>


### PR DESCRIPTION
## Summary
- drop obsolete `thermo_` table prefix from Standard and Statistics subreports

## Testing
- `./scripts/check_jasper_version.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c82998d72c832bb4a68119d011003e