### PR TITLE
Fix missing Standard subreport in DAKKS sample

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -429,7 +429,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 						<subreportParameterExpression><![CDATA[$P{P_CTAG}]]></subreportParameterExpression>
 					</subreportParameter>
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Standard.jasper"]]></subreportExpression>
+					<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Standard.jrxml"]]></subreportExpression>
 				</subreport>
 			</band>
 			<band height="160">
@@ -584,7 +584,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 						<subreportParameterExpression><![CDATA[$P{P_Image_Path}]]></subreportParameterExpression>
 					</subreportParameter>
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Results.jasper"]]></subreportExpression>
+					<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Results.jrxml"]]></subreportExpression>
 				</subreport>
 			</band>
 		</groupHeader>


### PR DESCRIPTION
## Summary
- Ensure DAKKS main report loads Standard and Results subreports directly from JRXML instead of expecting precompiled Jasper files

## Testing
- `./scripts/check_jasper_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c82ea0183c832ba1a110b965057692