### PR TITLE
Avoid unnecessary blank page in DAKKS report

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -222,7 +222,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<variable name="Page_count" class="java.lang.Integer">
 		<variableExpression><![CDATA[$V{PAGE_NUMBER}]]></variableExpression>
 	</variable>
-	<group name="Group1" isStartNewPage="true">
+        <group name="Group1" isStartNewPage="false">
 		<groupHeader>
 			<band height="60">
 				<property name="com.jaspersoft.studio.unit.height" value="pixel"/>


### PR DESCRIPTION
## Summary
- disable the Group1 `isStartNewPage` setting in the DAKKS sample report to prevent an empty second page

## Testing
- `bash scripts/check_jasper_version.sh`
- `jasperstarter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8303f8204832b9dcf376ead3b0968