### PR TITLE
Add location subreport fields and headers

### DIFF
--- a/INVENTORY-SAMPLE/subreports/Location.jrxml
+++ b/INVENTORY-SAMPLE/subreports/Location.jrxml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Location" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="0" bottomMargin="0" uuid="00000000-0000-0000-0000-000000000001">
+    <property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+    <property name="com.jaspersoft.studio.data.defaultdataadapter" value="CalHelp Data Adapter "/>
+    <property name="com.jaspersoft.studio.unit." value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+    <parameter name="PrefixTable" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="Sprache" class="java.lang.String">
+        <defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
+    </parameter>
+    <parameter name="P_MTAG" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <queryString language="SQL">
+        <![CDATA[SELECT L2801, L2802, L2803, L2804, L2806, L2807, L2809, L2815, L2816 FROM $P!{PrefixTable}location WHERE MTAG=$P{P_MTAG}]]>
+    </queryString>
+    <field name="L2801" class="java.lang.String"/>
+    <field name="L2802" class="java.lang.String"/>
+    <field name="L2803" class="java.lang.String"/>
+    <field name="L2804" class="java.lang.String"/>
+    <field name="L2806" class="java.lang.String"/>
+    <field name="L2807" class="java.lang.String"/>
+    <field name="L2809" class="java.lang.String"/>
+    <field name="L2815" class="java.lang.String"/>
+    <field name="L2816" class="java.lang.String"/>
+    <variable name="Loc1" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 1" : "Location 1"]]></variableExpression>
+    </variable>
+    <variable name="Loc2" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 2" : "Location 2"]]></variableExpression>
+    </variable>
+    <variable name="Loc3" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 3" : "Location 3"]]></variableExpression>
+    </variable>
+    <variable name="Loc4" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 4" : "Location 4"]]></variableExpression>
+    </variable>
+    <variable name="Loc6" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 6" : "Location 6"]]></variableExpression>
+    </variable>
+    <variable name="Loc7" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 7" : "Location 7"]]></variableExpression>
+    </variable>
+    <variable name="Loc9" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 9" : "Location 9"]]></variableExpression>
+    </variable>
+    <variable name="Loc15" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 15" : "Location 15"]]></variableExpression>
+    </variable>
+    <variable name="Loc16" class="java.lang.String" resetType="None">
+        <variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort 16" : "Location 16"]]></variableExpression>
+    </variable>
+    <pageHeader>
+        <band height="34">
+            <textField>
+                <reportElement mode="Opaque" x="12" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="11111111-1111-1111-1111-111111111111"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc1}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="72" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="22222222-2222-2222-2222-222222222222"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc2}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="132" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="33333333-3333-3333-3333-333333333333"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc3}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="192" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="44444444-4444-4444-4444-444444444444"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc4}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="252" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="55555555-5555-5555-5555-555555555555"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc6}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="312" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="66666666-6666-6666-6666-666666666666"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc7}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="372" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="77777777-7777-7777-7777-777777777777"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc9}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="432" y="9" width="60" height="25" backcolor="#E8E6E6" uuid="88888888-8888-8888-8888-888888888888"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc15}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement mode="Opaque" x="492" y="9" width="63" height="25" backcolor="#E8E6E6" uuid="99999999-9999-9999-9999-999999999999"/>
+                <box padding="5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{Loc16}]]></textFieldExpression>
+            </textField>
+        </band>
+    </pageHeader>
+    <detail>
+        <band height="25" splitType="Stretch">
+            <textField isStretchWithOverflow="true">
+                <reportElement x="12" y="0" width="60" height="25" uuid="aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2801}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="72" y="0" width="60" height="25" uuid="aaaaaaa2-aaaa-aaaa-aaaa-aaaaaaaaaaa2"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2802}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="132" y="0" width="60" height="25" uuid="aaaaaaa3-aaaa-aaaa-aaaa-aaaaaaaaaaa3"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2803}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="192" y="0" width="60" height="25" uuid="aaaaaaa4-aaaa-aaaa-aaaa-aaaaaaaaaaa4"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2804}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="252" y="0" width="60" height="25" uuid="aaaaaaa5-aaaa-aaaa-aaaa-aaaaaaaaaaa5"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2806}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="312" y="0" width="60" height="25" uuid="aaaaaaa6-aaaa-aaaa-aaaa-aaaaaaaaaaa6"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2807}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="372" y="0" width="60" height="25" uuid="aaaaaaa7-aaaa-aaaa-aaaa-aaaaaaaaaaa7"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2809}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="432" y="0" width="60" height="25" uuid="aaaaaaa8-aaaa-aaaa-aaaa-aaaaaaaaaaa8"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2815}]]></textFieldExpression>
+            </textField>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="492" y="0" width="63" height="25" uuid="aaaaaaa9-aaaa-aaaa-aaaa-aaaaaaaaaaa9"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{L2816}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+</jasperReport>


### PR DESCRIPTION
## Summary
- create Location subreport with fields L2801-L2816
- render localized column headers for location data
- display location column values in detail band

## Testing
- `./scripts/check_jasper_version.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c8378238b0832b9fd02ec41f85d7c5