### PR TITLE
Fix Inventory sample subreport stacking

### DIFF
--- a/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
+++ b/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
@@ -371,7 +371,7 @@ WHERE i.MTAG=$P{P_MTAG}]]>
 	<detail>
                <band height="40" splitType="Stretch">
                        <subreport isUsingCache="false">
-                               <reportElement x="-17" y="0" width="595" height="20" uuid="d3085e09-4ab5-495c-aeb3-02d2fd99daa4"/>
+                               <reportElement positionType="Float" x="-17" y="0" width="595" height="20" uuid="d3085e09-4ab5-495c-aeb3-02d2fd99daa4"/>
                                <subreportParameter name="PrefixTable">
                                        <subreportParameterExpression><![CDATA[$P{PrefixTable}]]></subreportParameterExpression>
                                </subreportParameter>
@@ -385,7 +385,7 @@ WHERE i.MTAG=$P{P_MTAG}]]>
                                <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Calibration.jasper"]]></subreportExpression>
                        </subreport>
                        <subreport isUsingCache="false">
-                               <reportElement x="-17" y="20" width="595" height="20" uuid="4cee815a-761d-4693-8893-22f9cf2e1e41"/>
+                               <reportElement positionType="Float" x="-17" y="20" width="595" height="20" uuid="4cee815a-761d-4693-8893-22f9cf2e1e41"/>
                                <subreportParameter name="PrefixTable">
                                        <subreportParameterExpression><![CDATA[$P{PrefixTable}]]></subreportParameterExpression>
                                </subreportParameter>


### PR DESCRIPTION
## Summary
- ensure the calibration and location subreports in the inventory sample use floating positioning
- prevent the two subreports from overlapping so they render one below the other

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83be3d114832bbe02b4b1d9a8c22c