### PR TITLE
Use compiled subreports in DAkkS sample report

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -429,7 +429,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 						<subreportParameterExpression><![CDATA[$P{P_CTAG}]]></subreportParameterExpression>
 					</subreportParameter>
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-                                    <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Standard.jrxml"]]></subreportExpression>
+                                    <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Standard.jasper"]]></subreportExpression>
 				</subreport>
 			</band>
 			<band height="160">
@@ -584,7 +584,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 						<subreportParameterExpression><![CDATA[$P{P_Image_Path}]]></subreportParameterExpression>
 					</subreportParameter>
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-                                    <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Results.jrxml"]]></subreportExpression>
+                                    <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Results.jasper"]]></subreportExpression>
 				</subreport>
 			</band>
 		</groupHeader>


### PR DESCRIPTION
## Summary
- update the DAkkS sample main report to reference the compiled .jasper subreports required for runtime execution

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c846f6f41c832ba54ac0a1b9e50cb1