### PR TITLE
Increase Standard subreport row heights

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -58,52 +58,52 @@ GROUP BY t.C2430]]>
 	<variable name="Calibration_mark" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Kalibrierkennzeichnung" : "Calibration-Mark"]]></variableExpression>
 	</variable>
-	<columnHeader>
-		<band height="8" splitType="Stretch">
+        <columnHeader>
+                <band height="18" splitType="Stretch">
 			<textField>
-				<reportElement x="0" y="0" width="75" height="8" backcolor="#F2F2F2" uuid="fc29e98b-b159-4cc3-a555-602e348eb0c6"/>
+                                <reportElement x="0" y="0" width="75" height="18" backcolor="#F2F2F2" uuid="fc29e98b-b159-4cc3-a555-602e348eb0c6"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{Inv_Nr}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="75" y="0" width="125" height="8" backcolor="#F2F2F2" uuid="b3d9104d-98d3-4c37-91df-245f86aa107b"/>
+                                <reportElement x="75" y="0" width="125" height="18" backcolor="#F2F2F2" uuid="b3d9104d-98d3-4c37-91df-245f86aa107b"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{Description}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="200" y="0" width="75" height="8" backcolor="#F2F2F2" uuid="61d70333-b95a-40cf-8c3b-ec30de752c67"/>
+                                <reportElement x="200" y="0" width="75" height="18" backcolor="#F2F2F2" uuid="61d70333-b95a-40cf-8c3b-ec30de752c67"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{Manufacturer}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="275" y="0" width="85" height="8" backcolor="#F2F2F2" uuid="d814a74a-4a49-44c8-a349-aaa613d2543b"/>
+                                <reportElement x="275" y="0" width="85" height="18" backcolor="#F2F2F2" uuid="d814a74a-4a49-44c8-a349-aaa613d2543b"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{Type}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="360" y="0" width="65" height="8" backcolor="#F2F2F2" uuid="d475d00e-fe39-410c-a223-7991737bab30"/>
+                                <reportElement x="360" y="0" width="65" height="18" backcolor="#F2F2F2" uuid="d475d00e-fe39-410c-a223-7991737bab30"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{Lastcal}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="425" y="0" width="65" height="8" backcolor="#F2F2F2" uuid="d8d5996d-7ecd-479d-a35a-ac4c50229a59"/>
+                                <reportElement x="425" y="0" width="65" height="18" backcolor="#F2F2F2" uuid="d8d5996d-7ecd-479d-a35a-ac4c50229a59"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{Duedate}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="490" y="0" width="45" height="8" backcolor="#F2F2F2" uuid="bba1fa61-8bea-4d3c-a7e7-1a1483c1458d"/>
+                                <reportElement x="490" y="0" width="45" height="18" backcolor="#F2F2F2" uuid="bba1fa61-8bea-4d3c-a7e7-1a1483c1458d"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8" isBold="true"/>
 				</textElement>
@@ -111,52 +111,52 @@ GROUP BY t.C2430]]>
 			</textField>
 		</band>
 	</columnHeader>
-	<detail>
-                <band height="8">
+        <detail>
+                <band height="18">
 			<textField>
-				<reportElement x="0" y="0" width="75" height="8" uuid="c7ae95e5-d1c2-4ebb-b86c-c57c342e41d0"/>
+                                <reportElement x="0" y="0" width="75" height="18" uuid="c7ae95e5-d1c2-4ebb-b86c-c57c342e41d0"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{I4201}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="75" y="0" width="125" height="8" uuid="38cff896-60bc-4170-b821-4b18da5a4427"/>
+                                <reportElement x="75" y="0" width="125" height="18" uuid="38cff896-60bc-4170-b821-4b18da5a4427"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{I4204}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="200" y="0" width="75" height="8" uuid="9903b87d-6099-40b1-bba0-6ee5574d96df"/>
+                                <reportElement x="200" y="0" width="75" height="18" uuid="9903b87d-6099-40b1-bba0-6ee5574d96df"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{I4202}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="275" y="0" width="85" height="8" uuid="79080a7e-1b0a-424f-8478-8543e0b81ba0"/>
+                                <reportElement x="275" y="0" width="85" height="18" uuid="79080a7e-1b0a-424f-8478-8543e0b81ba0"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{I4203}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="360" y="0" width="65" height="8" uuid="34913dcf-b72a-4141-9aa7-c6ce9a3ddee4"/>
+                                <reportElement x="360" y="0" width="65" height="18" uuid="34913dcf-b72a-4141-9aa7-c6ce9a3ddee4"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="425" y="0" width="65" height="8" uuid="0a316a53-bd2b-4942-af33-6d6065c7bffe"/>
+                                <reportElement x="425" y="0" width="65" height="18" uuid="0a316a53-bd2b-4942-af33-6d6065c7bffe"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{C2303}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="490" y="0" width="45" height="8" uuid="9075fa2a-aa64-472c-b973-3d44a95d0c0b"/>
+                                <reportElement x="490" y="0" width="45" height="18" uuid="9075fa2a-aa64-472c-b973-3d44a95d0c0b"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="8"/>
 				</textElement>


### PR DESCRIPTION
## Summary
- raise the Standard subreport column header and detail band heights to 18px so table rows have more breathing room

## Testing
- scripts/check_jasper_version.sh
- attempted to compile Standard.jrxml and run the DAkkS main report locally (blocked: Maven plugin download failed without network access)


------
https://chatgpt.com/codex/tasks/task_e_68c85d18f588832b94f81e40e985f081