### PR TITLE
Remove last page footer to prevent blank page

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -997,7 +997,4 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 			<printWhenExpression><![CDATA[$V{PAGE_NUMBER} > 1]]></printWhenExpression>
 		</band>
 	</pageFooter>
-        <lastPageFooter>
-                <band height="74"/>
-        </lastPageFooter>
 </jasperReport>


### PR DESCRIPTION
## Summary
- remove the empty `<lastPageFooter>` band from `dakks-sample.jrxml` so that the report no longer emits an additional trailing page
- verified that compiling the report with the sample harness produces only the data pages without an extra blank sheet

## Testing
- `java -cp '/tmp/jasper-libs/*:/tmp/jasper-test/bin' com.example.ReportVerifier /workspace/calServer-reports /tmp/jasper-output`


------
https://chatgpt.com/codex/tasks/task_e_68c85b3dd85c832ba4a78bcade7670e7