### PR TITLE
Fix missing fields in inventory report

### DIFF
--- a/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
+++ b/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
@@ -1168,19 +1168,19 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                        <subreportParameterExpression><![CDATA[$P{Sprache}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="C2301">
-                                       <subreportParameterExpression><![CDATA[$F{C2301}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_C2301}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="C2314">
-                                       <subreportParameterExpression><![CDATA[$F{C2314}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_C2314}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="C2341">
-                                       <subreportParameterExpression><![CDATA[$F{C2341}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_C2341}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="C2307">
-                                       <subreportParameterExpression><![CDATA[$F{C2307}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_C2307}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="C2303">
-                                       <subreportParameterExpression><![CDATA[$F{C2303}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_C2303}]]></subreportParameterExpression>
                                </subreportParameter>
                                <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource(1)]]></dataSourceExpression>
                                <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Calibration.jasper"]]></subreportExpression>
@@ -1191,31 +1191,31 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                        <subreportParameterExpression><![CDATA[$P{Sprache}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2801">
-                                       <subreportParameterExpression><![CDATA[$F{L2801}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2801}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2802">
-                                       <subreportParameterExpression><![CDATA[$F{L2802}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2802}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2803">
-                                       <subreportParameterExpression><![CDATA[$F{L2803}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2803}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2804">
-                                       <subreportParameterExpression><![CDATA[$F{L2804}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2804}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2806">
-                                       <subreportParameterExpression><![CDATA[$F{L2806}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2806}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2807">
-                                       <subreportParameterExpression><![CDATA[$F{L2807}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2807}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2809">
-                                       <subreportParameterExpression><![CDATA[$F{L2809}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2809}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2815">
-                                       <subreportParameterExpression><![CDATA[$F{L2815}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2815}]]></subreportParameterExpression>
                                </subreportParameter>
                                <subreportParameter name="L2816">
-                                       <subreportParameterExpression><![CDATA[$F{L2816}]]></subreportParameterExpression>
+                                       <subreportParameterExpression><![CDATA[$F{last_L2816}]]></subreportParameterExpression>
                                </subreportParameter>
                                <dataSourceExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource(1)]]></dataSourceExpression>
                                <subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Location.jasper"]]></subreportExpression>


### PR DESCRIPTION
## Summary
- pass calibration subreport parameters from the corresponding `last_` fields
- update location subreport parameters to use the existing `last_` aliases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c861637fe8832bba404784aec421b1