### PR TITLE
Adjust DAkkS sample title layout to fit page height

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -592,7 +592,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<title>
                <!-- allow more space on the start page so bigger field
                     contents do not trigger a page break -->
-               <band height="818" splitType="Stretch">
+               <band height="707" splitType="Stretch">
                        <property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
                        <textField>
                                <reportElement x="0" y="0" width="100" height="10" forecolor="#808080" uuid="09fbdd07-84e0-421a-8062-48071b34af67">
@@ -605,7 +605,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                <textFieldExpression><![CDATA[$P{ReportVersion}]]></textFieldExpression>
                        </textField>
                        <textField textAdjust="StretchHeight">
-				<reportElement x="17" y="370" width="134" height="30" uuid="6e73786e-fde1-4967-9ccb-5258187d7a90">
+				<reportElement x="17" y="303" width="134" height="30" uuid="6e73786e-fde1-4967-9ccb-5258187d7a90">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
@@ -615,14 +615,14 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{title}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="154" y="380" width="162" height="20" uuid="07efb9da-d825-467b-aa7f-024beca396d4">
+				<reportElement x="154" y="313" width="162" height="20" uuid="07efb9da-d825-467b-aa7f-024beca396d4">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Bottom"/>
 				<textFieldExpression><![CDATA[$F{cert_field}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="370" y="377" width="115" height="20" uuid="dc0bbf1c-965c-4463-946b-4175962c6f4c">
+				<reportElement x="370" y="310" width="115" height="20" uuid="dc0bbf1c-965c-4463-946b-4175962c6f4c">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
@@ -631,44 +631,44 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{mark}]]></textFieldExpression>
 			</textField>
 			<line>
-				<reportElement x="495" y="324" width="57" height="1" uuid="c9b00435-45f5-4242-bbe3-ef49a417fc2b">
+				<reportElement x="495" y="257" width="57" height="1" uuid="c9b00435-45f5-4242-bbe3-ef49a417fc2b">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 			</line>
 			<line>
-				<reportElement x="495" y="397" width="57" height="1" uuid="22199f42-b7dd-49e1-ab99-d2e8b3ecd6b4">
+				<reportElement x="495" y="330" width="57" height="1" uuid="22199f42-b7dd-49e1-ab99-d2e8b3ecd6b4">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 			</line>
 			<line>
-				<reportElement x="495" y="324" width="1" height="74" uuid="995a0596-e29a-4ba1-96fb-13dfd6d832b2">
+				<reportElement x="495" y="257" width="1" height="74" uuid="995a0596-e29a-4ba1-96fb-13dfd6d832b2">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 			</line>
 			<line>
-				<reportElement x="551" y="324" width="1" height="74" uuid="9b3f36d2-eefe-40f3-9738-295beaca3781">
+				<reportElement x="551" y="257" width="1" height="74" uuid="9b3f36d2-eefe-40f3-9738-295beaca3781">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 			</line>
 			<line>
-				<reportElement x="495" y="344" width="57" height="1" uuid="e4d0501b-c98d-4bd1-9210-a3a4dfbcdec1">
+				<reportElement x="495" y="277" width="57" height="1" uuid="e4d0501b-c98d-4bd1-9210-a3a4dfbcdec1">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
 			</line>
 			<line>
-				<reportElement x="495" y="377" width="57" height="1" uuid="1b754e39-dfac-4b1b-ac39-8016e23b0e41">
+				<reportElement x="495" y="310" width="57" height="1" uuid="1b754e39-dfac-4b1b-ac39-8016e23b0e41">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 			</line>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="498" y="327" width="51" height="15" uuid="0bf13ba4-dc4a-431f-9374-24fc8b4d40a4">
+				<reportElement x="498" y="260" width="51" height="15" uuid="0bf13ba4-dc4a-431f-9374-24fc8b4d40a4">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
@@ -678,7 +678,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{cert_field}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="498" y="380" width="51" height="15" uuid="90c88fcb-27d6-499a-b959-f2acc28ae051">
+				<reportElement x="498" y="313" width="51" height="15" uuid="90c88fcb-27d6-499a-b959-f2acc28ae051">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -688,12 +688,12 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression>
 			</textField>
 			<line>
-				<reportElement x="16" y="413" width="535" height="1" uuid="92109169-f0d7-470b-9d8a-3261a3feae25">
+				<reportElement x="16" y="346" width="535" height="1" uuid="92109169-f0d7-470b-9d8a-3261a3feae25">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
 			</line>
 			<textField>
-				<reportElement x="16" y="423" width="105" height="20" uuid="866190bf-dc6f-4db7-98db-a2ee2ebf7732">
+				<reportElement x="16" y="356" width="105" height="20" uuid="866190bf-dc6f-4db7-98db-a2ee2ebf7732">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -703,7 +703,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{object}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="446" width="105" height="20" uuid="7c563f27-c417-4bc6-b531-10eda0df8923">
+				<reportElement x="16" y="379" width="105" height="20" uuid="7c563f27-c417-4bc6-b531-10eda0df8923">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -713,7 +713,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{manufacturer}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="470" width="105" height="20" uuid="25a0b54c-9d69-477f-8b35-bd517a5d7c63">
+				<reportElement x="16" y="403" width="105" height="20" uuid="25a0b54c-9d69-477f-8b35-bd517a5d7c63">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -723,7 +723,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{type}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="494" width="105" height="20" uuid="1d6cc280-0428-4c46-a0db-346731a3b71d">
+				<reportElement x="16" y="427" width="105" height="20" uuid="1d6cc280-0428-4c46-a0db-346731a3b71d">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -734,7 +734,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{serial_number}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="540" width="105" height="20" uuid="bd2bf486-1f0d-411c-8cd2-feec28ba9502">
+				<reportElement x="16" y="473" width="105" height="20" uuid="bd2bf486-1f0d-411c-8cd2-feec28ba9502">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -744,7 +744,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{customer}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="607" width="105" height="20" uuid="f4566753-3247-49e4-9e44-2a7611a70089">
+				<reportElement x="16" y="540" width="105" height="20" uuid="f4566753-3247-49e4-9e44-2a7611a70089">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -754,7 +754,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{order_no}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="630" width="105" height="20" uuid="1e4ed23a-eeee-4351-a085-36f6f6771581">
+				<reportElement x="16" y="563" width="105" height="20" uuid="1e4ed23a-eeee-4351-a085-36f6f6771581">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Middle">
@@ -763,7 +763,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{page_number}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="16" y="585" width="105" height="20" uuid="2a0c2b8d-d097-44c8-ba01-452399e43012">
+				<reportElement x="16" y="518" width="105" height="20" uuid="2a0c2b8d-d097-44c8-ba01-452399e43012">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
@@ -773,7 +773,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{date_of_cal}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="124" y="423" width="188" height="20" uuid="24ac6a93-e909-4a3f-a450-2125e86b04fb">
+				<reportElement x="124" y="356" width="188" height="20" uuid="24ac6a93-e909-4a3f-a450-2125e86b04fb">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Middle">
@@ -782,7 +782,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{I4204}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="125" y="446" width="187" height="20" uuid="6e87d9dc-6ac9-47f2-b8c4-5a85c1b438a6">
+				<reportElement x="125" y="379" width="187" height="20" uuid="6e87d9dc-6ac9-47f2-b8c4-5a85c1b438a6">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Middle">
@@ -791,7 +791,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{I4202}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="125" y="470" width="187" height="20" uuid="5eef8ce2-2f4a-42f4-a111-c27072d8fa02">
+				<reportElement x="125" y="403" width="187" height="20" uuid="5eef8ce2-2f4a-42f4-a111-c27072d8fa02">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
@@ -801,7 +801,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{I4203}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="125" y="494" width="187" height="20" uuid="9622b7b4-2dba-4e72-a25d-ce9fe032c62f">
+				<reportElement x="125" y="427" width="187" height="20" uuid="9622b7b4-2dba-4e72-a25d-ce9fe032c62f">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
@@ -811,7 +811,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{I4206}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="125" y="516" width="187" height="20" uuid="3740e497-e70d-4168-a6b1-564ecd08f69b">
+				<reportElement x="125" y="449" width="187" height="20" uuid="3740e497-e70d-4168-a6b1-564ecd08f69b">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -822,14 +822,14 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{inv_number}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="125" y="540" width="187" height="40" uuid="76e9de4b-1338-486a-bd7d-4676a43f0586"/>
+				<reportElement x="125" y="473" width="187" height="40" uuid="76e9de4b-1338-486a-bd7d-4676a43f0586"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Arial" size="9"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{customer} != null ? $F{customer} : "--"]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="125" y="607" width="187" height="20" uuid="2b975fb0-c2e5-4b02-ba3f-c4d916a386f2">
+				<reportElement x="125" y="540" width="187" height="20" uuid="2b975fb0-c2e5-4b02-ba3f-c4d916a386f2">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Middle">
@@ -838,14 +838,14 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{C2314}]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
-				<reportElement x="125" y="630" width="187" height="20" uuid="95a6d653-8c2e-44b3-b97d-d5db00e03271"/>
+				<reportElement x="125" y="563" width="187" height="20" uuid="95a6d653-8c2e-44b3-b97d-d5db00e03271"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Arial" size="9"/>
 				</textElement>
 				<textFieldExpression><![CDATA["- " + $V{PAGE_NUMBER} + " -"]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" pattern="dd.MM.yyyy" isBlankWhenNull="true">
-				<reportElement x="125" y="585" width="187" height="20" uuid="e6f25338-d02f-4760-be6a-03e6592cf71c">
+				<reportElement x="125" y="518" width="187" height="20" uuid="e6f25338-d02f-4760-be6a-03e6592cf71c">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Middle">
@@ -854,14 +854,14 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
 			</textField>
                         <textField textAdjust="ScaleFont">
-                                <reportElement x="329" y="423" width="222" height="237" uuid="63ba20c4-fdad-4cef-8538-a07589d41d75"/>
+                                <reportElement x="329" y="356" width="222" height="237" uuid="63ba20c4-fdad-4cef-8538-a07589d41d75"/>
                                 <textElement textAlignment="Justified">
                                         <font size="9"/>
                                 </textElement>
                                 <textFieldExpression><![CDATA[new String($P{Cert_description}.replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8").replace("_00E4_", "ä").replace("_00F6_", "ö").replace("_00FC_", "ü").replace("_00C4_", "Ä").replace("_00D6_", "Ö").replace("_00DC_", "Ü").replace("_00DF_", "ß")]]></textFieldExpression>
                         </textField>
                         <textField textAdjust="ScaleFont">
-                                <reportElement x="16" y="677" width="535" height="21" uuid="470997ee-2360-4f40-8dc0-1cd01e68aa01">
+                                <reportElement x="16" y="610" width="535" height="21" uuid="470997ee-2360-4f40-8dc0-1cd01e68aa01">
                                         <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
                                 </reportElement>
                                 <textElement textAlignment="Justified">
@@ -870,12 +870,12 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[new String($P{Cert_description_1}.replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8").replace("_00E4_", "ä").replace("_00F6_", "ö").replace("_00FC_", "ü").replace("_00C4_", "Ä").replace("_00D6_", "Ö").replace("_00DC_", "Ü").replace("_00DF_", "ß")]]></textFieldExpression>
                         </textField>
 			<line>
-				<reportElement positionType="Float" x="16" y="700" width="535" height="1" uuid="7180f2cc-b318-42fe-8297-222a27072378">
+				<reportElement positionType="Float" x="16" y="633" width="535" height="1" uuid="7180f2cc-b318-42fe-8297-222a27072378">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
 			</line>
                         <textField>
-                                <reportElement positionType="Float" stretchType="ContainerHeight" x="16" y="703" width="134" height="20" uuid="46c04130-b64c-43e6-9a51-d831732c69dc">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="16" y="636" width="134" height="20" uuid="46c04130-b64c-43e6-9a51-d831732c69dc">
                                         <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
                                 </reportElement>
@@ -885,7 +885,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[$V{Datum}]]></textFieldExpression>
                         </textField>
                         <textField textAdjust="StretchHeight" pattern="dd.MM.yyyy" isBlankWhenNull="true">
-                                <reportElement positionType="Float" stretchType="ContainerHeight" x="16" y="726" width="134" height="20" uuid="e0db9184-37b0-441a-9c29-bf6775d558f7">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="16" y="659" width="134" height="20" uuid="e0db9184-37b0-441a-9c29-bf6775d558f7">
                                         <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
                                 </reportElement>
@@ -895,14 +895,14 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
                         </textField>
                         <line>
-                                <reportElement positionType="Float" x="16" y="773" width="535" height="1" uuid="d14783c6-e3cc-4217-a64f-df17f8f3e82a">
+                                <reportElement positionType="Float" x="16" y="706" width="535" height="1" uuid="d14783c6-e3cc-4217-a64f-df17f8f3e82a">
                                         <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
                                 </reportElement>
                         </line>
                         <textField>
-                                <reportElement positionType="Float" stretchType="ContainerHeight" x="204" y="703" width="149" height="20" uuid="6142ebc6-b46e-4e8e-a702-9b9d810d885f">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="204" y="636" width="149" height="20" uuid="6142ebc6-b46e-4e8e-a702-9b9d810d885f">
                                         <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -913,7 +913,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[$V{Kalibrierlabor}]]></textFieldExpression>
                         </textField>
                         <textField textAdjust="StretchHeight">
-                                <reportElement positionType="Float" stretchType="ContainerHeight" x="204" y="726" width="149" height="20" uuid="374d1e1f-60cd-4376-8b3d-006adc0bc73f">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="204" y="659" width="149" height="20" uuid="374d1e1f-60cd-4376-8b3d-006adc0bc73f">
                                         <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                 </reportElement>
                                 <textElement verticalAlignment="Middle">
@@ -922,7 +922,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[$F{C2327}]]></textFieldExpression>
                         </textField>
                         <textField>
-                                <reportElement positionType="Float" stretchType="ContainerHeight" x="408" y="703" width="143" height="20" uuid="f0491c98-4de4-4515-9038-a2a20eae9865">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="408" y="636" width="143" height="20" uuid="f0491c98-4de4-4515-9038-a2a20eae9865">
                                         <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
                                         <property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -933,7 +933,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[$V{Person_in_charge}]]></textFieldExpression>
                         </textField>
                         <textField textAdjust="StretchHeight">
-                                <reportElement positionType="Float" stretchType="ContainerHeight" x="408" y="726" width="143" height="20" uuid="ec31e771-b9cd-4088-8317-5f5f22b50907">
+                                <reportElement positionType="Float" stretchType="ContainerHeight" x="408" y="659" width="143" height="20" uuid="ec31e771-b9cd-4088-8317-5f5f22b50907">
                                         <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                 </reportElement>
                                 <textElement verticalAlignment="Middle">
@@ -942,7 +942,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                 <textFieldExpression><![CDATA[$F{C2307}]]></textFieldExpression>
                         </textField>
 			<textField>
-				<reportElement x="498" y="349" width="51" height="24" uuid="de2ec427-896e-4411-86b3-d78b5eb6e1dc">
+				<reportElement x="498" y="282" width="51" height="24" uuid="de2ec427-896e-4411-86b3-d78b5eb6e1dc">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -952,7 +952,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textFieldExpression><![CDATA[$V{type_mark}]]></textFieldExpression>
 			</textField>
 			<componentElement>
-				<reportElement x="437" y="324" width="48" height="48" uuid="458d3628-6bfd-46c0-89be-0bc6a5f1eae9"/>
+				<reportElement x="437" y="257" width="48" height="48" uuid="458d3628-6bfd-46c0-89be-0bc6a5f1eae9"/>
 				<jr:QRCode xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
 					<jr:codeExpression><![CDATA[$P{QR_Code_Value}]]></jr:codeExpression>
 				</jr:QRCode>


### PR DESCRIPTION
## Summary
- reduce the title band height to 707 so it fits alongside the page header and footer
- shift the title elements upward to keep the original layout within the smaller band

## Testing
- scripts/check_jasper_version.sh

------
https://chatgpt.com/codex/tasks/task_e_68c870c88e10832b894963e471e14de0