### PR TITLE
Exclude documentation files from report ZIP artifacts

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Create ZIPs of all folders (excluding existing ZIPs)
         run: |
           mkdir -p zip_output
-          (cd DAKKS-SAMPLE && zip -r ../zip_output/dakks-sample.zip main_reports subreports -x "*.zip")
-          (cd ORDER-SAMPLE && zip -r ../zip_output/order-sample.zip main_reports subreports -x "*.zip")
-          (cd INVENTORY-SAMPLE && zip -r ../zip_output/inventory-sample.zip main_reports subreports -x "*.zip")
+          (cd DAKKS-SAMPLE && zip -r ../zip_output/dakks-sample.zip main_reports subreports -x "*.zip" "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
+          (cd ORDER-SAMPLE && zip -r ../zip_output/order-sample.zip main_reports subreports -x "*.zip" "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
+          (cd INVENTORY-SAMPLE && zip -r ../zip_output/inventory-sample.zip main_reports subreports -x "*.zip" "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
 
       - name: Show ZIP contents (Debug)
         run: |

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Create ZIP archives
         run: |
           mkdir -p output
-          (cd DAKKS-SAMPLE && zip -r ../output/dakks-sample.zip main_reports subreports)
-          (cd ORDER-SAMPLE && zip -r ../output/order-sample.zip main_reports subreports)
-          (cd INVENTORY-SAMPLE && zip -r ../output/inventory-sample.zip main_reports subreports)
+          (cd DAKKS-SAMPLE && zip -r ../output/dakks-sample.zip main_reports subreports -x "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
+          (cd ORDER-SAMPLE && zip -r ../output/order-sample.zip main_reports subreports -x "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
+          (cd INVENTORY-SAMPLE && zip -r ../output/inventory-sample.zip main_reports subreports -x "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
 
       - name: Publish release on GitHub
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- adjust the packaging and release workflows to filter out Markdown, text and placeholder files from generated ZIP archives
- ensure the distributed report bundles only contain actual report assets so downstream JasperStarter compilation no longer hits README.md

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68c871ab57f0832bbada533adf310832