### PR TITLE
Replace deprecated Jasper text overflow attribute usage

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -130,7 +130,7 @@ WHERE t.CTAG = $P{P_CTAG}]]>
                                 </textElement>
                                 <textFieldExpression><![CDATA[$F{I4201}]]></textFieldExpression>
                         </textField>
-                        <textField isStretchWithOverflow="true">
+                        <textField textAdjust="StretchHeight">
                                 <reportElement x="75" y="0" width="110" height="16" uuid="38cff896-60bc-4170-b821-4b18da5a4427"/>
                                 <textElement verticalAlignment="Top">
                                         <font fontName="Arial" size="8"/>

--- a/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
+++ b/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
@@ -1306,7 +1306,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$V{Calibration_title}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement stretchType="RelativeToBandHeight" x="17" y="76" width="75" height="25" uuid="ffee13c8-d540-46c0-8a33-692d8fa613ae">
                                                 <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         </reportElement>
@@ -1315,7 +1315,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_C2301}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement stretchType="RelativeToBandHeight" x="100" y="76" width="89" height="25" uuid="10c6d2e7-3e34-4eff-a70a-147355a4422d">
                                                 <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         </reportElement>
@@ -1324,7 +1324,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_C2314}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement stretchType="RelativeToBandHeight" x="200" y="77" width="165" height="25" uuid="bb4da48e-b59e-4fd7-a0dd-412a7fbac8fb">
                                                 <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                                 <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -1334,7 +1334,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_C2341}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement stretchType="RelativeToBandHeight" x="374" y="76" width="91" height="25" uuid="3d7bc564-ee06-4788-880d-7cea206d1593">
                                                 <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         </reportElement>
@@ -1343,7 +1343,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_C2307}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement stretchType="RelativeToBandHeight" x="475" y="76" width="74" height="25" uuid="2ed56792-da39-4fda-99cb-434fa9400673">
                                                 <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         </reportElement>
@@ -1475,63 +1475,63 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$V{Loc16}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="12" y="34" width="60" height="25" uuid="aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2801}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="72" y="34" width="60" height="25" uuid="aaaaaaa2-aaaa-aaaa-aaaa-aaaaaaaaaaa2"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2802}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="132" y="34" width="60" height="25" uuid="aaaaaaa3-aaaa-aaaa-aaaa-aaaaaaaaaaa3"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2803}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="192" y="34" width="60" height="25" uuid="aaaaaaa4-aaaa-aaaa-aaaa-aaaaaaaaaaa4"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2804}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="252" y="34" width="60" height="25" uuid="aaaaaaa5-aaaa-aaaa-aaaa-aaaaaaaaaaa5"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2806}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="312" y="34" width="60" height="25" uuid="aaaaaaa6-aaaa-aaaa-aaaa-aaaaaaaaaaa6"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2807}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="372" y="34" width="60" height="25" uuid="aaaaaaa7-aaaa-aaaa-aaaa-aaaaaaaaaaa7"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2809}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="432" y="34" width="60" height="25" uuid="aaaaaaa8-aaaa-aaaa-aaaa-aaaaaaaaaaa8"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$F{last_L2815}]]></textFieldExpression>
                                 </textField>
-                                <textField isStretchWithOverflow="true">
+                                <textField textAdjust="StretchHeight">
                                         <reportElement x="492" y="34" width="63" height="25" uuid="aaaaaaa9-aaaa-aaaa-aaaa-aaaaaaaaaaa9"/>
                                         <textElement verticalAlignment="Middle">
                                                 <font size="12"/>

--- a/ORDER-SAMPLE/subreports/Statistics.jrxml
+++ b/ORDER-SAMPLE/subreports/Statistics.jrxml
@@ -126,7 +126,7 @@ GROUP BY tax]]>
 						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					</reportElement>
 				</line>
-				<textField isStretchWithOverflow="true">
+				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="RelativeToBandHeight" x="35" y="0" width="160" height="15" uuid="20074f80-45d6-4b04-9f19-3c54d94e394e">
 						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 						<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -135,7 +135,7 @@ GROUP BY tax]]>
 					<textElement verticalAlignment="Middle"/>
 					<textFieldExpression><![CDATA[$V{DETAIL_Discount}]]></textFieldExpression>
 				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="bookingID" isBlankWhenNull="true">
+				<textField textAdjust="StretchHeight" evaluationTime="Group" evaluationGroup="bookingID" isBlankWhenNull="true">
 					<reportElement stretchType="RelativeToBandHeight" x="451" y="0" width="100" height="15" uuid="a01b5b3e-22fd-4990-a127-610739f6d855">
 						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					</reportElement>
@@ -196,7 +196,7 @@ GROUP BY tax]]>
 					</textElement>
 					<textFieldExpression><![CDATA[($V{Order_Total} == null ? 0 : $V{Order_Total}) + "  €"]]></textFieldExpression>
 				</textField>
-				<textField isStretchWithOverflow="true">
+				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="RelativeToBandHeight" x="35" y="42" width="516" height="26" uuid="486dc54f-7909-422e-bf3d-c0b3d4e859db">
 						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 						<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -234,7 +234,7 @@ GROUP BY tax]]>
 						<printWhenExpression><![CDATA[!$F{W4114}.toPlainString().equals("0")]]></printWhenExpression>
 					</reportElement>
 				</line>
-				<textField isStretchWithOverflow="true">
+				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="RelativeToBandHeight" x="35" y="-12" width="100" height="15" uuid="6febf5fb-29b7-489c-b666-f0903c0f8d8c">
 						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 						<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -246,7 +246,7 @@ GROUP BY tax]]>
 					</textElement>
 					<textFieldExpression><![CDATA[$V{DETAIL_Discount_Max_Tax}]]></textFieldExpression>
 				</textField>
-				<textField isStretchWithOverflow="true">
+				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="RelativeToBandHeight" x="135" y="-12" width="60" height="15" uuid="7aa02ae4-c2e5-4787-99db-fabfcc494d34">
 						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
@@ -257,7 +257,7 @@ GROUP BY tax]]>
 					</textElement>
 					<textFieldExpression><![CDATA[$V{DETAIL_Percent}]]></textFieldExpression>
 				</textField>
-				<textField isStretchWithOverflow="true">
+				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="RelativeToBandHeight" x="451" y="-12" width="100" height="15" uuid="916f53c2-f4d9-4c52-8cb1-982ee8351bf4">
 						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 						<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
@@ -324,7 +324,7 @@ GROUP BY tax]]>
 	<detail>
 		<band height="15" splitType="Prevent">
 			<printWhenExpression><![CDATA[!$F{tax}.toPlainString().equals("0")]]></printWhenExpression>
-			<textField isStretchWithOverflow="true">
+			<textField textAdjust="StretchHeight">
 				<reportElement stretchType="RelativeToBandHeight" x="35" y="0" width="100" height="15" uuid="60e6fc68-95e2-4d45-8365-fbe75a203b7b">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -336,7 +336,7 @@ GROUP BY tax]]>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{DETAIL_Steuerbasisbeitrag}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true">
+			<textField textAdjust="StretchHeight">
 				<reportElement stretchType="RelativeToBandHeight" x="135" y="0" width="60" height="15" uuid="ae18fc17-edc5-4a4f-8514-e59b41486467">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
@@ -348,7 +348,7 @@ GROUP BY tax]]>
 				</textElement>
 				<textFieldExpression><![CDATA[$V{DETAIL_Percent}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true">
+			<textField textAdjust="StretchHeight">
 				<reportElement stretchType="RelativeToBandHeight" x="451" y="0" width="100" height="15" uuid="bf7a1a73-6db3-4ba6-b957-7b11977a811a">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>


### PR DESCRIPTION
## Summary
- replace the deprecated `isStretchWithOverflow` setting on text fields with the recommended `textAdjust="StretchHeight"` value across the sample reports to eliminate Jasper warnings

## Testing
- scripts/check_jasper_version.sh

------
https://chatgpt.com/codex/tasks/task_e_68c875576ef0832b929bddbab885d5c8