### PR TITLE
Fix DAkkS sample title layout

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-sample" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" isTitleNewPage="false" isFloatColumnFooter="true" isSummaryNewPage="false" whenResourceMissingType="Error" uuid="e59ec7b0-4a1b-436a-ac42-95f4c3c87ff8">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-sample" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" isTitleNewPage="true" isFloatColumnFooter="true" isSummaryNewPage="false" whenResourceMissingType="Error" uuid="e59ec7b0-4a1b-436a-ac42-95f4c3c87ff8">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="CalHelp Data Adapter "/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
@@ -589,9 +589,10 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 			</band>
 		</groupHeader>
 	</group>
-	<title>
-               <!-- allow more space on the start page so bigger field
-                    contents do not trigger a page break -->
+        <title>
+               <!-- the title prints on its own page (see isTitleNewPage)
+                    so we can keep generous spacing without affecting the
+                    first content page -->
                <band height="707" splitType="Stretch">
                        <property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
                        <textField>


### PR DESCRIPTION
## Summary
- set the DAkkS sample report title to render on a dedicated page so the subsequent group header bands fit within the page height
- document the intention in the title band's inline comment

## Testing
- scripts/check_jasper_version.sh


------
https://chatgpt.com/codex/tasks/task_e_68c876f9b8d0832b9ec4c31fcf95cc80