### PR TITLE
Add documentation for DAkkS and order sample reports

### DIFF
--- a/DAKKS-SAMPLE/main_reports/README.md
+++ b/DAKKS-SAMPLE/main_reports/README.md
@@ -1,0 +1,148 @@
+# 📜 DAkkS-Kalibrierschein (`dakks-sample.jrxml`)
+
+Dieser Hauptbericht bildet einen vollständigen **DAkkS-konformen Kalibrierschein**
+ab. Er kombiniert Stammdaten des kalibrierten Messmittels, Kundenangaben,
+Kalibrierergebnisse und die notwendigen normativen Textbausteine. Die Vorlage
+liegt unter `DAKKS-SAMPLE/main_reports/dakks-sample.jrxml` und bindet zwei
+Unterberichte für Normale und Messergebnisse ein.
+
+| Zielgruppe | Nutzen |
+| --- | --- |
+| **Normale Nutzer:innen** | Erzeugt in wenigen Schritten einen druckfertigen Kalibrierschein mit mehrsprachigem Layout. |
+| **Administrator:innen / Entwickler:innen** | Liefert eine dokumentierte SQL-Abfrage, Parametrisierung und Subreport-Struktur für individuelle Erweiterungen. |
+
+---
+
+## 🚀 Schritt-für-Schritt: Kalibrierschein erzeugen
+
+1. **Report öffnen** – im calServer oder lokal via JasperStarter.
+2. **Kalibrierung wählen** – den Pflichtparameter `P_CTAG` mit der gewünschten
+   Kalibrier-ID füllen. Die Abfrage zieht anschließend alle verknüpften Geräte-
+   und Kundendaten.
+3. **Pfad & Sprache setzen** – `Reportpath` auf das gemeinsame Verzeichnis mit
+   den Unterberichten zeigen lassen und bei Bedarf `Sprache` (`Deutsch` /
+   `Englisch`) anpassen.
+4. **Textbausteine prüfen** – optionale Parameter wie
+   `Cert_description`, `Measurements_description` oder
+   `Conformity_description_*` enthalten bereits DAkkS-konforme Standardtexte
+   und lassen sich bei Bedarf überschreiben.
+5. **Report ausgeben** – typischerweise als PDF, alternativ in jedem von
+   JasperReports unterstützten Format.
+
+---
+
+## 1. Für normale Nutzer:innen
+
+### Was zeigt der Bericht?
+
+* **Titel- und Kopfbereich** – dynamischer Titel (`Kalibrierschein` /
+  `Calibration Certificate`) inkl. Zertifikatsnummer aus dem Feld
+  `C2396` (`Cert_field`).
+* **Messmittel-Stammdaten** – Bezeichnung, Typ, Serien- und Inventarnummern
+  (`I4204`, `I4203`, `I4202`, `I4201`) sowie optionaler QR-/Barcode-Wert.
+* **Auftraggeber:in** – Kund:innenname und Adresse (`customer`), Datum der
+  Kalibrierung (`C2301`) sowie interne Referenzen (`C2307`, `C2327`).
+* **Kalibrierstatus** – Informationen zu letzter und nächster Kalibrierung
+  (`C2308`, `C2311`, `C2312`) inklusive Hervorhebung der beteiligten Personen.
+* **Normative Textblöcke** – vordefinierte Absätze zu Rückführbarkeit,
+  Messunsicherheit, Konformität und Zusatzinformationen, um DAkkS-Anforderungen
+  zu erfüllen.
+* **Unterberichte** – Abschnitt „Eingesetzte Normale“ (Subreport
+  `Standard.jasper`) und die mehrseitige Ergebnisdokumentation (Subreport
+  `Results.jasper`).
+
+### Hinweise für den Alltag
+
+* **Sprachwechsel:** Über `Sprache` werden alle Labels und Absätze automatisch
+  auf Deutsch oder Englisch gesetzt.
+* **QR-Code & Bilder:** `QR_Code_Value` sowie `P_Image_Path` erlauben das
+  Einbinden von QR-Codes und Logos (z. B. DAkkS-Logo in der Fußzeile).
+* **Beschreibungstexte:** Parameter wie `Cert_description_1` oder
+  `Measurements_description_1` enthalten bereits abgestimmte Formulierungen und
+  können pro Kunde / Messmittel angepasst werden.
+* **Seitenzahlen im Fließtext:** `Results_description` nutzt `msg(..., Seite)`
+  und passt die Seitenreferenz beim Rendern automatisch an.
+
+---
+
+## 2. Für Administrator:innen & Entwickler:innen
+
+### Datenquellen & Tabellen
+
+Die Hauptabfrage kombiniert drei Kernbereiche der calServer-Datenbank:
+
+* `$P!{PrefixTable}calibration c` – Zertifikatsdaten inkl. Felder
+  `C2301`, `C2307`, `C2327`, `C2308`, `C2311`, `C2312`.
+* `$P!{PrefixTable}inventory i` – Messmittelstammdaten (`I4201`–`I4206`, `I4224`).
+* `$P!{PrefixTable}customers cu` – Auftraggeber:in für Anschrift und Namen.
+
+### SQL-Auszug
+
+```sql
+SELECT COALESCE(c.$P!{Cert_field}, "") AS cert_field,
+       DATE_FORMAT(C2301, '%Y-%m')       AS cal_date,
+       COALESCE(i.I4204, "")            AS I4204,
+       COALESCE(i.I4201, "")            AS I4201,
+       COALESCE(c.C2314, "--")          AS C2314
+FROM   $P!{PrefixTable}calibration c
+LEFT JOIN $P!{PrefixTable}inventory i ON i.MTAG = c.MTAG
+LEFT JOIN $P!{PrefixTable}customers cu ON cu.KTAG = i.KTAG
+WHERE  c.CTAG = $P{P_CTAG};
+```
+
+### Subreports & Ressourcen
+
+* **`subreports/Standard.jasper`** – listet die eingesetzten Normale inklusive
+  Inventarnummer, Hersteller, Typ und Kalibrierstatus.
+* **`subreports/Results.jasper`** – erstellt die tabellarische
+  Messergebnis-Dokumentation mit Toleranzen, Messunsicherheit und Symbolik.
+* Beide Unterberichte benötigen dieselben Parameter (`PrefixTable`, `Sprache`,
+  `P_CTAG`, optional `P_Image_Path`) und denselben Datenbank-Connection-Context.
+
+### Parameterübersicht (Auswahl)
+
+| Parameter | Funktion |
+| --- | --- |
+| `P_CTAG` | **Pflicht** – eindeutige Kalibrierungs-ID. |
+| `Reportpath` | Basisverzeichnis für Unterberichte (`.../DAKKS-SAMPLE`). |
+| `PrefixTable` | Optionales Tabellenpräfix (z. B. `cal_`). |
+| `Sprache` | Setzt Labels/Textbausteine (`Deutsch` / `Englisch`). |
+| `QR_Code_Value` | Inhalt für QR-/Barcode-Elemente. |
+| `Cert_description*`, `Measurements_description*`, `Conformity_description*`, `Additional_information` | Textbausteine für normative Abschnitte. |
+| `Calibration_procedure_*`, `Calibration_document` | Hinweise auf verwendete Verfahren/Dokumente. |
+| `Cert_field` | Datenbankfeld, aus dem die Zertifikatsnummer gelesen wird (Standard: `C2396`). |
+| `P_Image_Path` | Pfad für Logos/Siegel, die im Bericht eingebunden werden. |
+| `ExpUncType` | Freitext für ergänzende Hinweise zur Messunsicherheit. |
+| `ReportVersion` | Ausgabe der Reportversion im Titelbereich. |
+
+### Typische Anpassungen
+
+* **Weitere Sprachen** – zusätzliche Locale-Logik über `Sprache` und
+  `resourceBundles` ergänzen.
+* **Kundenspezifische Logos** – Bildplatzhalter mit `P_Image_Path` befüllen
+  oder eigene Bildkomponenten einfügen.
+* **Erweiterte Datenfelder** – zusätzliche Felder via `LEFT JOIN` in der
+  Hauptabfrage ergänzen und als `<field>` registrieren.
+* **Digital Signatures** – `REPORT_CONNECTION` für Scriptlets nutzen, um
+  qualifizierte Signaturen einzubetten.
+
+---
+
+## 3. Troubleshooting & Tipps
+
+* **Leere Ausgabe?** – prüfen, ob `P_CTAG` auf eine vorhandene Kalibrierung
+  zeigt und ob der angemeldete Benutzer Zugriff auf die Tabellen hat.
+* **Unterberichte fehlen:** sicherstellen, dass `Reportpath` auf den Ordner mit
+  den kompilierten `.jasper`-Dateien zeigt.
+* **Falsche Sprache:** der Parameterwert muss exakt `Deutsch` oder `Englisch`
+  lauten; ansonsten greift der deutsche Default.
+* **Zertifikatsnummer fehlt:** ggf. anderes Feld über `Cert_field` wählen (z. B.
+  `C2307` für externe Referenzen).
+* **Seitenumbrüche anpassen:** der Haupttitel nutzt `isTitleNewPage="true"` –
+  bei Bedarf kann die Startseite über den Report-Parameter `isTitleNewPage`
+  angepasst werden.
+
+---
+
+Mit diesem README erhältst du sowohl eine fachliche Beschreibung als auch eine
+technische Referenz für den DAkkS-Kalibrierschein.

--- a/DAKKS-SAMPLE/subreports/README.md
+++ b/DAKKS-SAMPLE/subreports/README.md
@@ -1,0 +1,65 @@
+# Unterberichte (DAkkS-Kalibrierschein)
+
+Der Hauptbericht `dakks-sample.jrxml` bindet zwei Unterberichte ein. Beide
+verwenden die gleiche Datenbankverbindung wie der Hauptreport und erwarten die
+Parameter `PrefixTable`, `Sprache` und `P_CTAG`. `Results.jasper` erhält
+zusätzlich `P_Image_Path`, um Grafiken oder Symbole anzuzeigen.
+
+---
+
+## `Standard.jrxml`
+
+* **Zweck:** Dokumentiert die eingesetzten Normale (Referenzgeräte) inklusive
+  Inventarnummer, Beschreibung, Hersteller, Typ sowie letztem und nächstem
+  Kalibrierdatum.
+* **SQL-Grundlage:**
+  ```sql
+  SELECT DISTINCT i.I4201, i.I4202, i.I4203, i.I4204,
+                  c.C2301, c.C2303, c.C2364
+  FROM $P!{PrefixTable}standards t
+  LEFT JOIN $P!{PrefixTable}inventory i ON t.C2430 = i.MTAG
+  LEFT JOIN $P!{PrefixTable}calibration c ON c.MTAG = i.MTAG AND c.C2339 = 1
+  WHERE t.CTAG = $P{P_CTAG};
+  ```
+* **Layout:** Querformat-Tabelle mit sieben Spalten (`Inv.Nr`, `Beschreibung`,
+  `Hersteller`, `Typ`, `letzte Kal`, `nächste Kal`, `Kalibrierkennzeichen`).
+  Die Bezeichnungen passen sich über den Parameter `Sprache` automatisch an.
+* **Anpassungstipps:** Zusätzliche Informationen (z. B. Standort oder
+  Seriennummern) können über weitere Felder im SELECT ergänzt und per
+  `<textField>` eingebunden werden.
+
+---
+
+## `Results.jrxml`
+
+* **Zweck:** Listet die Messergebnisse zur ausgewählten Kalibrierung. Je Zeile
+  werden Beschreibung, Sollwert, Messwert, zulässige Abweichungen,
+  Messunsicherheit und Statussymbol ausgegeben.
+* **SQL-Grundlage:** Liest direkt aus `$P!{PrefixTable}results` und reduziert
+  alle Felder per `COALESCE(...)` auf Strings. Gefiltert wird über
+  `WHERE ctag = $P{P_CTAG}`.
+* **Besonderheiten:**
+  * `NominalValue` und `MeasuredValue` kombinieren Wert, Prüfschritt und Einheit
+    zu einer formatierten Anzeige.
+  * `ToleranceRange` entscheidet automatisch, ob ein ±-Wert angezeigt wird oder
+    ob Min-/Max-Spalten untereinander erscheinen.
+  * `RoundedTolErr` rundet numerische Abweichungen auf eine Nachkommastelle und
+    hängt `%` an.
+  * `FormattedUncertainty` formatiert wissenschaftliche Schreibweisen (z. B.
+    `×10<sup>n</sup>`), falls keine HTML-Markups vorhanden sind.
+  * `SymbolStatus` leitet aus dem Feld `test_status` die Symbolik (`iO`, `?`,
+    `!?`, `!`) ab, sofern kein individueller Kommentar (`remark`) hinterlegt ist.
+* **Druckaufbereitung:** Der Spaltenkopf ist fest definiert (`Beschreibung`,
+  `Sollwert`, `Messwert`, `Zul. Abweichung`, `Messunsicherheit`, `Bemerkung`).
+  Für weitere Sprachen können die Labels direkt in den `<staticText>`-Elementen
+  angepasst oder in ein Resource-Bundle ausgelagert werden.
+
+---
+
+## Integration & Pflege
+
+* Unterberichte müssen vor dem Einsatz kompiliert vorliegen (`*.jasper`).
+* Struktur oder Parameteränderungen sollten sowohl im Haupt- als auch im
+  jeweiligen Unterreport gepflegt werden.
+* Durch die konsequente Nutzung von `PrefixTable` lassen sich die Reports in
+  Mandantenumgebungen mit Tabellenpräfixen wiederverwenden.

--- a/ORDER-SAMPLE/main_reports/README.md
+++ b/ORDER-SAMPLE/main_reports/README.md
@@ -1,0 +1,150 @@
+# 📄 Auftrags-/Angebotsdokument (`order-sample.jrxml`)
+
+Dieser Report erzeugt kundenfertige Dokumente für Angebote, Aufträge,
+Rechnungen oder Lieferungen. Er vereint Kopf- und Adressdaten, Positionslisten,
+Rabatte sowie Summenlogik. Die Vorlage liegt unter
+`ORDER-SAMPLE/main_reports/order-sample.jrxml` und bindet den Unterbericht
+`Statistics.jasper` für Summen- und Steuerberechnungen ein.
+
+| Zielgruppe | Nutzen |
+| --- | --- |
+| **Normale Nutzer:innen** | Liefert ein fertig formatiertes Dokument mit allen relevanten Kunden-, Liefer- und Rechnungsinformationen. |
+| **Administrator:innen / Entwickler:innen** | Bietet eine komplexe SQL-Abfrage als Ausgangspunkt für individuelle Dokumenttypen und Automatisierungen. |
+
+---
+
+## 🚀 Schritt-für-Schritt: Dokument erzeugen
+
+1. **Report starten** – in der calServer-Reportverwaltung oder über JasperStarter.
+2. **Auftragskontext setzen** – `Auftragsid` (Pflicht) und optional
+   `Auftragsnummer` mit dem gewünschten Geschäftsvorgang befüllen.
+3. **Dokumenttyp wählen** – `Dokumenttyp` bestimmt Texte/Labels (z. B. Angebot,
+   Auftrag, Rechnung, Lieferung) und steuert logische Verzweigungen im Layout.
+4. **Artikeltypen filtern** – die Parameter `Articletype1` bis `Articletype3`
+   definieren, welche Positionen aus `article` übernommen werden (Standard:
+   Inventar- und Artikelpositionen).
+5. **Kontaktdaten prüfen** – optionale Parameter wie `Return_address`,
+   `Report_mail_address` oder `Report_phone_number` ergänzen Absenderdaten im
+   Dokument.
+6. **Report ausgeben** – PDF empfohlen; XLSX/HTML stehen ebenfalls zur Verfügung.
+
+---
+
+## 1. Für normale Nutzer:innen
+
+### Was zeigt der Bericht?
+
+* **Kopfbereich** – Dokumenttyp, Datum (`CurrentDate`), Referenzen und eigene
+  Kontaktdaten.
+* **Adressblöcke** – automatische Auswahl von Kunden-, Rechnungs- und
+  Lieferadresse inkl. Ansprechpartner:innen. Fehlen spezielle Kontakte, werden
+  Fallbacks aus den Kundenstammdaten genutzt.
+* **Positionsliste** – sortiert nach Positionsnummer und Artikeltyp, inklusive
+  Menge, Einheit, Einzelpreis, Rabatt und Zwischensummen.
+* **Inventarbezug** – wenn Artikel mit Messmitteln verknüpft sind, wird die
+  Inventarbezeichnung (`inventory_name`, `I4204`, `I4202`, `I4206`) angezeigt.
+* **Summenbereich** – netto, Rabatt, Steuer und Gesamtsumme (über den
+  Subreport `Statistics.jasper`) sowie ein freier Textblock aus
+  `Report_description` (z. B. Zahlungsbedingungen).
+
+### Alltagstipps
+
+* **Sprachumschaltung:** Über `Sprache` stehen deutsche und englische Labels zur
+  Verfügung. Weitere Sprachen können über Resource-Bundles ergänzt werden.
+* **Absenderdaten:** `Return_address`, `Report_mail_address` und
+  `Report_phone_number` füllen den Briefkopf ohne Layoutänderungen.
+* **Artikelreihenfolge:** `Articletype*` steuert, welche Positionsarten (z. B.
+  `inventory`, `article`, Dienstleistungen) angezeigt werden.
+* **Freitext:** `Report_description` wird am Ende des Dokuments ausgegeben und
+  eignet sich für Zahlungs- oder Lieferbedingungen.
+
+---
+
+## 2. Für Administrator:innen & Entwickler:innen
+
+### Datenquellen & Tabellen
+
+Die Hauptabfrage verbindet zahlreiche Kernmodule des calServer:
+
+* `$P!{PrefixTable}booking b` – Kopf- und Bewegungsdaten des Vorgangs.
+* `$P!{PrefixTable}article a` – Positionen, Preise, Mengen, Rabatte.
+* `$P!{PrefixTable}collective_invoices ci` – Sammelrechnungs-Bezüge.
+* `$P!{PrefixTable}customers c/bc/dc` – Kunden-, Rechnungs- und Lieferanschriften.
+* `$P!{PrefixTable}contact tc/ti/td` – Ansprechpartner:innen für die jeweiligen
+  Adressarten.
+* `$P!{PrefixTable}standard_article sa`, `$P!{PrefixTable}prices p`,
+  `$P!{PrefixTable}types t` – Artikelstammdaten und Preisgruppen.
+* `$P!{PrefixTable}inventory i` – Messmittelinformationen für inventarbasierte
+  Positionen.
+
+### SQL-Auszug
+
+```sql
+SELECT b.uID,
+       a.article_type,
+       CONCAT_WS(" ", c.K4613, c.K4602) AS customer_name,
+       CONCAT_WS("\n", ti.label, ti.name, ti.street) AS billing_contact,
+       IF(a.discount IS NULL, 0, ROUND(a.discount, 2)) AS discount
+FROM   $P!{PrefixTable}booking b
+LEFT JOIN $P!{PrefixTable}article a
+       ON (b.uID = a.booking_uID OR ci.other_booking_uID = a.booking_uID)
+LEFT JOIN $P!{PrefixTable}collective_invoices ci ON ci.invoice_uID = b.uID
+LEFT JOIN $P!{PrefixTable}customers c ON b.customer_KTAG = c.KTAG
+LEFT JOIN $P!{PrefixTable}contact ti ON ti.uID = b.invoice_contact_id
+WHERE  b.uID = $P{Auftragsid};
+```
+
+### Subreport & Summenlogik
+
+* **`subreports/Statistics.jasper`** ermittelt Zwischensummen, Rabatt,
+  Steuerbeträge pro Steuersatz sowie die Gesamtsumme. Über den Parameter
+  `Report_description` wird außerdem ein freier Textblock ausgegeben.
+* Der Unterbericht erhält sämtliche Artikeltyp-Parameter (`Articletype1-3`) und
+  `Dokumenttyp`, um gleiche Filterlogik wie der Hauptreport zu gewährleisten.
+
+### Parameterübersicht (Auswahl)
+
+| Parameter | Funktion |
+| --- | --- |
+| `Auftragsid` | **Pflicht** – eindeutige ID des Vorgangs (`booking.uID`). |
+| `Auftragsnummer` | Optionale Anzeige der Buchungsnummer (`b.number`). |
+| `Dokumenttyp` | Steuert Labels/Logik (z. B. Angebot, Auftrag, Rechnung). |
+| `Articletype1-3` | Filtert erlaubte Positionsarten im SELECT. |
+| `Reportpath` | Pfad zum Unterbericht `Statistics.jasper`. |
+| `PrefixTable` | Tabellenpräfix für mandantenfähige Installationen. |
+| `Return_address`, `Report_mail_address`, `Report_phone_number` | Ergänzen Absenderdaten im Kopf. |
+| `Report_description` | Freitext für Geschäftsbedingungen. |
+| `Sprache` | Setzt Labels (Deutsch/Englisch). |
+| `ReportVersion` | Kennzeichnet die Version im Dokumentkopf. |
+
+### Erweiterungsideen
+
+* **Zusätzliche Artikelgruppen** – weitere Parameter (`Articletype4` …) oder
+  SQL-Bedingungen ergänzen.
+* **Mehrsprachige Inhalte** – statische Texte in Resource-Bundles auslagern oder
+  über `Sprache` erweitern.
+* **Logo & Briefpapier** – Hintergrundbilder oder `P_Image_Path`-Konzepte aus
+  anderen Reports übernehmen.
+* **Automatisierte Serienläufe** – JasperStarter oder GitHub Actions nutzen, um
+  Dokumente stapelweise zu erzeugen.
+
+---
+
+## 3. Troubleshooting & Tipps
+
+* **Keine Positionen?** – prüfen, ob die Artikeltypen mit den realen Werten in
+  `article.article_type` übereinstimmen und ob `a.uID` nicht `NULL` ist.
+* **Falsche Adresse:** falls spezielle Kontakte fehlen, werden Fallbacks genutzt –
+  ggf. `customer_contact_id`, `invoice_contact_id` oder `delivery_contact_id`
+  im calServer pflegen.
+* **Rabatte wirken nicht:** der Unterbericht berechnet Rabatte über `W4114`; ist
+  der Wert `0` oder `NULL`, wird kein Abzug ausgewiesen.
+* **Mehrsprachigkeit:** nicht erkannte Sprachwerte fallen auf Deutsch zurück –
+  den Parameter exakt schreiben (`Deutsch`, `Englisch`).
+* **Leere Summen:** sicherstellen, dass `Reportpath` korrekt auf das kompilierte
+  Unterreport-Verzeichnis zeigt.
+
+---
+
+Dieser README liefert eine inhaltliche und technische Orientierung für das
+Auftrags-/Angebotsdokument.

--- a/ORDER-SAMPLE/subreports/README.md
+++ b/ORDER-SAMPLE/subreports/README.md
@@ -1,0 +1,94 @@
+# Unterbericht `Statistics.jrxml`
+
+Der Unterbericht `Statistics.jrxml` liefert sämtliche Summen-, Rabatt- und
+Steuerberechnungen für das Hauptdokument `order-sample.jrxml`. Er wird im
+Gruppenfuß des Hauptberichts eingebunden und nutzt dieselben Parameter für
+Tabellenpräfix, Dokumenttyp und Artikeltypen.
+
+---
+
+## Funktionsumfang
+
+* **Positionensummen:** Gruppiert alle Positionen eines Auftrags (`booking.uID`)
+  und berechnet Netto-Zwischensummen je Steuersatz.
+* **Rabattlogik:** Nutzt das Feld `W4114` aus `booking` als prozentuale Angabe
+  und zieht den Wert (`discount`) automatisch von den Zwischensummen ab.
+* **Steuerberechnung:** Multipliziert die Nettoanteile je Steuersatz (`tax`) und
+  bildet Gesamtsteuer (`Order_Total_Tax`).
+* **Endsumme:** Aggregiert Netto-, Steuer- und Rabattanteile zu `Order_Total`
+  und gibt sie mit fett gedruckter Beschriftung aus.
+* **Freitext:** Gibt den Inhalt des Parameters `Report_description` als
+  abschließenden Hinweis- oder AGB-Block aus.
+
+---
+
+## SQL-Basis
+
+```sql
+SELECT tax,
+       ROUND((SUM(old_total)) * tax / 100, 2) AS total_tax,
+       SUM(old_total) AS total,
+       total_new,
+       IF(W4114 > 0, W4114, 0) AS W4114,
+       IF(W4114 > 0, SUM(old_total) * W4114 / 100, 0) AS discount
+FROM (
+    SELECT b.uID,
+           b.W4114,
+           ROUND(a.tax) AS tax,
+           ROUND(a.quantity * a.price - a.quantity * a.price *
+                 (IF(a.discount IS NULL, 0, a.discount)) / 100, 2) AS old_total
+    FROM $P!{PrefixTable}booking b
+    LEFT JOIN $P!{PrefixTable}collective_invoices ci ON ci.invoice_uID = b.uID
+    LEFT JOIN $P!{PrefixTable}article a ON (b.uID = a.booking_uID OR
+         ci.other_booking_uID = a.booking_uID)
+        AND a.article_type IN ('$P!{Articletype1}', '$P!{Articletype2}', '$P!{Articletype3}')
+    WHERE b.uID = $P{Auftragsid} AND a.uID IS NOT NULL
+) AS t
+LEFT JOIN (
+    SELECT b.uID,
+           SUM(ROUND(a.quantity * a.price - a.quantity * a.price *
+               (IF(a.discount IS NULL, 0, a.discount)) / 100, 2)) AS total_new
+    FROM $P!{PrefixTable}booking b
+    LEFT JOIN $P!{PrefixTable}collective_invoices ci ON ci.invoice_uID = b.uID
+    LEFT JOIN $P!{PrefixTable}article a ON (b.uID = a.booking_uID OR
+         ci.other_booking_uID = a.booking_uID)
+        AND a.article_type IN ('$P!{Articletype1}', '$P!{Articletype2}', '$P!{Articletype3}')
+    WHERE b.uID = $P{Auftragsid} AND a.uID IS NOT NULL
+) AS t1 ON t.uID = t1.uID
+GROUP BY tax;
+```
+
+---
+
+## Wichtige Parameter & Variablen
+
+| Name | Beschreibung |
+| --- | --- |
+| `PrefixTable` | Tabellenpräfix; muss mit dem Hauptreport übereinstimmen. |
+| `Sprache` | Steuert alle Labels (Deutsch/Englisch). |
+| `Dokumenttyp` | Passt Summenbeschriftungen an (`Angebot`, `Auftrag`, `Rechnung`, `Lieferung`). |
+| `Articletype1-3` | Legen fest, welche Positionen in die Berechnung eingehen. |
+| `Auftragsid` | Referenziert den aktuellen `booking`-Datensatz. |
+| `Report_description` | Übergibt Freitext an den Schlussbereich. |
+| `DETAIL_*` Variablen | Liefern lokalisierte Beschriftungen für Netto-, Rabatt- und Gesamtsummen. |
+| `Sum_Netto`, `Sum_Discount`, `Order_Total`, `Order_Total_Tax` | Aggregierte Beträge zur Anzeige im Fuß. |
+
+---
+
+## Anpassungshinweise
+
+* **Weitere Steuersätze:** Zusätzliche Gruppen oder Variablen können angelegt
+  werden, falls landesspezifische Steuermodelle (z. B. 0 %, 7 %, 19 %) separat
+  dargestellt werden sollen.
+* **Währungsausgabe:** Standardmäßig werden Werte als Dezimalzahl mit "€"
+  dargestellt. Über Formatmasken (`pattern="#,##0.00 ¤"`) lassen sich weitere
+  Währungen einbinden.
+* **Rabattlogik erweitern:** Bei Mischrabatten (Fixbetrag + Prozent) können
+  zusätzliche Variablen angelegt und in `Order_Total` berücksichtigt werden.
+* **Mehrsprachige Hinweise:** Freitext (`Report_description`) kann für andere
+  Sprachen per Parameter oder Resource-Bundle angepasst werden.
+
+---
+
+Der Unterbericht bildet das finanzielle Rückgrat des Auftragsdokuments und kann
+bei Bedarf leicht auf weitere Geschäftsprozesse angepasst werden.


### PR DESCRIPTION
## Summary
- add a README for the DAkkS sample main report with usage guidance and parameter overview
- document the DAkkS subreports Standard and Results
- add READMEs for the order sample main report and its statistics subreport

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c8aaf73cd0832b9d89aa1c45334843