### PR TITLE
Remove unused Group_header_1a variable

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -162,9 +162,6 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<variable name="Cert_calibration" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Kalibrierschein Nr." : "Calibration Certificate Nr."]]></variableExpression>
 	</variable>
-	<variable name="Group_header_1a" class="java.lang.String" resetType="None">
-		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "KALIBRIERGEGENSTAND" : "UNIT UNDER TEST"]]></variableExpression>
-	</variable>
 	<variable name="Group_header_1b" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "DATUM DER ANLIEFERUNG" : "INCOMING DATE"]]></variableExpression>
 	</variable>


### PR DESCRIPTION
## Summary
- delete the unused `Group_header_1a` variable from the DAkkS sample report
- confirmed there are no remaining references to the removed variable

## Testing
- java -cp target/classes:/tmp/jasperreports-6.20.6.jar:/tmp/commons-logging-1.2.jar:/tmp/commons-digester-2.1.jar:/tmp/commons-beanutils-1.9.4.jar:/tmp/commons-collections4-4.2.jar:/tmp/commons-collections-3.2.2.jar CompileReport /workspace/calServer-reports/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml /tmp/out/dakks-sample.jasper

------
https://chatgpt.com/codex/tasks/task_e_68c91b1b1fe8832b987ada4901a0f7de