### PR TITLE
Use HTML font tags in calibration group header

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -226,13 +226,13 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 		<groupHeader>
 			<band height="60">
 				<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-				<textField>
-					<reportElement x="16" y="0" width="275" height="25" uuid="9e9fe0b8-4e8c-42e4-b231-7b7f2d6d2e08">
-						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-					</reportElement>
-					<textElement verticalAlignment="Middle" markup="styled"/>
-					<textFieldExpression><![CDATA["<style isBold=\"true\" fontSize=\"14\">KALIBRIERGEGENSTAND </style><style isItalic=\"true\" fontSize=\"10\">UNIT UNDER TEST</style>"]]></textFieldExpression>
-				</textField>
+                                <textField>
+                                        <reportElement x="16" y="0" width="275" height="25" uuid="9e9fe0b8-4e8c-42e4-b231-7b7f2d6d2e08">
+                                                <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+                                        </reportElement>
+                                        <textElement verticalAlignment="Middle" markup="html"/>
+                                        <textFieldExpression><![CDATA["<font size='14'><b>KALIBRIERGEGENSTAND </b></font><font size='10'><i>UNIT UNDER TEST</i></font>"]]></textFieldExpression>
+                                </textField>
 				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="ContainerHeight" x="16" y="26" width="535" height="34" uuid="f64af78b-568f-4c33-8607-48ef6c19c765">
 						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>


### PR DESCRIPTION
## Summary
- adjust the first group header label to use HTML font markup so bold and italic fonts render at separate sizes

## Testing
- not run (JasperReports tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c91b2280a4832ba211c55af3467bcc