### PR TITLE
Adjust calibration header styling

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -228,7 +228,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
                                                 <property name="com.jaspersoft.studio.unit.height" value="pixel"/>
                                         </reportElement>
                                         <textElement verticalAlignment="Middle" markup="html"/>
-                                        <textFieldExpression><![CDATA["<font size='14'><b>KALIBRIERGEGENSTAND </b></font><font size='10'><i>UNIT UNDER TEST</i></font>"]]></textFieldExpression>
+                                        <textFieldExpression><![CDATA["<font size='12'><b>KALIBRIERGEGENSTAND </b></font><font size='10'><i>UNIT UNDER TEST</i></font>"]]></textFieldExpression>
                                 </textField>
 				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="ContainerHeight" x="16" y="26" width="535" height="34" uuid="f64af78b-568f-4c33-8607-48ef6c19c765">


### PR DESCRIPTION
## Summary
- update the "Kalibriergegenstand" header text field to keep HTML markup while using a 12pt font size for the German label
- compiled the main report with its subreports to confirm the text field renders and exported a PDF preview

## Testing
- java -cp classes:/tmp/jasper-libs/barcode4j-2.1.jar:/tmp/jasper-libs/batik-anim-1.17.jar:/tmp/jasper-libs/batik-awt-util-1.17.jar:/tmp/jasper-libs/batik-bridge-1.17.jar:/tmp/jasper-libs/batik-constants-1.17.jar:/tmp/jasper-libs/batik-css-1.17.jar:/tmp/jasper-libs/batik-dom-1.17.jar:/tmp/jasper-libs/batik-ext-1.17.jar:/tmp/jasper-libs/batik-gvt-1.17.jar:/tmp/jasper-libs/batik-i18n-1.17.jar:/tmp/jasper-libs/batik-parser-1.17.jar:/tmp/jasper-libs/batik-script-1.17.jar:/tmp/jasper-libs/batik-svg-dom-1.17.jar:/tmp/jasper-libs/batik-svggen-1.17.jar:/tmp/jasper-libs/batik-transcoder-1.17.jar:/tmp/jasper-libs/batik-util-1.17.jar:/tmp/jasper-libs/batik-xml-1.17.jar:/tmp/jasper-libs/commons-beanutils-1.9.4.jar:/tmp/jasper-libs/commons-collections-3.2.2.jar:/tmp/jasper-libs/commons-collections4-4.2.jar:/tmp/jasper-libs/commons-digester-2.1.jar:/tmp/jasper-libs/commons-io-2.11.0.jar:/tmp/jasper-libs/commons-logging-1.1.1.jar:/tmp/jasper-libs/ecj-3.21.0.jar:/tmp/jasper-libs/jasperreports-6.20.6.jar:/tmp/jasper-libs/openpdf-1.3.30.jar:/tmp/jasper-libs/xml-apis-ext-1.3.04.jar:/tmp/jasper-libs/xmlgraphics-commons-2.9.jar:/tmp/jasper-libs/zxing-core-3.5.2.jar com.example.CompileReport /workspace/calServer-reports/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml /tmp/dakks-sample.pdf

------
https://chatgpt.com/codex/tasks/task_e_68c92c7c5288832b8936a5c95640ddc0