### PR TITLE
Stop re-encoding cert descriptions

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -863,12 +863,12 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textElement textAlignment="Justified">
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[new String(
+                                <textFieldExpression><![CDATA[(
   (
     ($P{Cert_description} == null || $P{Cert_description}.trim().isEmpty())
     ? "Dieser Kalibrierschein dokumentiert die Rückführung auf nationale Normale zur Darstellung der Einheiten in Übereinstimmung mit dem Internationalen Einheitensystem (SI). Die DAkkS ist Unterzeichner der multilateralen Übereinkommen der European co-operation for Accreditation (EA) und der International Laboratory Accreditation Cooperation (ILAC) zur gegenseitigen Anerkennung der Kalibrierscheine.\nFür die Einhaltung einer angemessenen Frist zur Wiederholung der Kalibrierung ist der Benutzer verantwortlich.\nDie den Messwerten beigeordnete erweiterte Messunsicherheit ergibt sich aus der Standardmessunsicherheit durch Multiplikation mit dem Erweiterungsfaktor k = 2. Sie wurde gemäß DAkkS DKD-3 ermittelt. Der Wert der Messgröße liegt mit einer Wahrscheinlichkeit von 95% im zugeordneten Werteintervall."
     : $P{Cert_description}
-  ).replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8"
+  ).replace("_s_", " ").replace("_n_", "\n")
 ).replace("_00E4_","ä").replace("_00F6_","ö").replace("_00FC_","ü").replace("_00C4_","Ä").replace("_00D6_","Ö").replace("_00DC_","Ü").replace("_00DF_","ß")]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="ScaleFont">
@@ -876,12 +876,12 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 				<textElement textAlignment="Justified">
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[new String(
+                                <textFieldExpression><![CDATA[(
   (
     ($P{Cert_description_1} == null || $P{Cert_description_1}.trim().isEmpty())
     ? "Dieser Kalibrierschein darf nur vollständig und unverändert weiterverbreitet werden. Auszüge oder Änderungen bedürfen der Genehmigung sowohl der Deutschen Akkreditierungsstelle als auch des ausstellenden Kalibrierlaboratoriums. Kalibrierscheine ohne Unterschrift haben keine Gültigkeit."
     : $P{Cert_description_1}
-  ).replace("_s_", " ").replace("_n_", "\n").getBytes("ISO-8859-1"), "UTF-8"
+  ).replace("_s_", " ").replace("_n_", "\n")
 ).replace("_00E4_","ä").replace("_00F6_","ö").replace("_00FC_","ü").replace("_00C4_","Ä").replace("_00D6_","Ö").replace("_00DC_","Ü").replace("_00DF_","ß")]]></textFieldExpression>
 			</textField>
 			<line>


### PR DESCRIPTION
## Summary
- remove the ISO-8859-1 to UTF-8 re-encoding for the certificate description text fields in the DAKKS sample report
- keep the placeholder replacement logic so that umlauts and `_00xx_` markers render as expected

## Testing
- `jshell <<'EOF' ... EOF`


------
https://chatgpt.com/codex/tasks/task_e_68cac0f28bd0832b82e2554ef7b05d49