### PR TITLE
Stage JRXML-only artifacts in CI workflows

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -47,12 +47,53 @@ jobs:
           echo "📂 Inhalt von INVENTORY-SAMPLE:"
           find INVENTORY-SAMPLE
 
-      - name: Create ZIPs of all folders (excluding existing ZIPs)
+      - name: Create ZIPs of all folders (JRXML only)
         run: |
-          mkdir -p zip_output
-          (cd DAKKS-SAMPLE && zip -r ../zip_output/dakks-sample.zip main_reports subreports -x "*.zip" "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
-          (cd ORDER-SAMPLE && zip -r ../zip_output/order-sample.zip main_reports subreports -x "*.zip" "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
-          (cd INVENTORY-SAMPLE && zip -r ../zip_output/inventory-sample.zip main_reports subreports -x "*.zip" "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
+          set -euo pipefail
+
+          mkdir -p zip_output staging
+
+          create_zip() {
+            local sample="$1"
+            local zip_name="$2"
+            local stage_dir="staging/${zip_name}"
+
+            rm -rf "${stage_dir}"
+            mkdir -p "${stage_dir}"
+
+            for folder in main_reports subreports; do
+              if [ -d "${sample}/${folder}" ]; then
+                rsync -avm \
+                  --include='*/' \
+                  --include='*.jrxml' \
+                  --exclude='*' \
+                  "${sample}/${folder}/" "${stage_dir}/${folder}/"
+              fi
+            done
+
+            if [ -z "$(find "${stage_dir}" -type f -name '*.jrxml' -print -quit)" ]; then
+              echo "❌ No JRXML files found in ${sample}" >&2
+              exit 1
+            fi
+
+            pushd "${stage_dir}" >/dev/null
+            if [ -d main_reports ] && [ -d subreports ]; then
+              zip -r "../../zip_output/${zip_name}.zip" main_reports subreports
+            elif [ -d main_reports ]; then
+              zip -r "../../zip_output/${zip_name}.zip" main_reports
+            elif [ -d subreports ]; then
+              zip -r "../../zip_output/${zip_name}.zip" subreports
+            else
+              echo "❌ No report folders found for ${sample}" >&2
+              popd >/dev/null
+              exit 1
+            fi
+            popd >/dev/null
+          }
+
+          create_zip "DAKKS-SAMPLE" "dakks-sample"
+          create_zip "ORDER-SAMPLE" "order-sample"
+          create_zip "INVENTORY-SAMPLE" "inventory-sample"
 
       - name: Show ZIP contents (Debug)
         run: |

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -18,15 +18,53 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Create ZIP archives
+      - name: Create ZIP archives (JRXML only)
         run: |
-          mkdir -p output
-          (cd DAKKS-SAMPLE && zip -r ../output/dakks-sample.zip main_reports subreports \
-            -x "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
-          (cd ORDER-SAMPLE && zip -r ../output/order-sample.zip main_reports subreports \
-            -x "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
-          (cd INVENTORY-SAMPLE && zip -r ../output/inventory-sample.zip main_reports subreports \
-            -x "*.md" "*.MD" "*.txt" "*.TXT" "*.gitkeep")
+          set -euo pipefail
+
+          mkdir -p output staging
+
+          create_zip() {
+            local sample="$1"
+            local zip_name="$2"
+            local stage_dir="staging/${zip_name}"
+
+            rm -rf "${stage_dir}"
+            mkdir -p "${stage_dir}"
+
+            for folder in main_reports subreports; do
+              if [ -d "${sample}/${folder}" ]; then
+                rsync -avm \
+                  --include='*/' \
+                  --include='*.jrxml' \
+                  --exclude='*' \
+                  "${sample}/${folder}/" "${stage_dir}/${folder}/"
+              fi
+            done
+
+            if [ -z "$(find "${stage_dir}" -type f -name '*.jrxml' -print -quit)" ]; then
+              echo "❌ No JRXML files found in ${sample}" >&2
+              exit 1
+            fi
+
+            pushd "${stage_dir}" >/dev/null
+            if [ -d main_reports ] && [ -d subreports ]; then
+              zip -r "../../output/${zip_name}.zip" main_reports subreports
+            elif [ -d main_reports ]; then
+              zip -r "../../output/${zip_name}.zip" main_reports
+            elif [ -d subreports ]; then
+              zip -r "../../output/${zip_name}.zip" subreports
+            else
+              echo "❌ No report folders found for ${sample}" >&2
+              popd >/dev/null
+              exit 1
+            fi
+            popd >/dev/null
+          }
+
+          create_zip "DAKKS-SAMPLE" "dakks-sample"
+          create_zip "ORDER-SAMPLE" "order-sample"
+          create_zip "INVENTORY-SAMPLE" "inventory-sample"
 
       - name: Determine release metadata
         id: release_meta

--- a/scripts/dakks_upload_sample.bat
+++ b/scripts/dakks_upload_sample.bat
@@ -21,7 +21,9 @@ set ZIP_NAME=dakks-sample.zip
 
 :: Pfade der zu packenden Ordner relativ zum Skript
 set SOURCE_FOLDER=DAKKS-SAMPLE
-set SUBFOLDERS=main_reports, subreports
+:: Mehrere Ordner mit Leerzeichen trennen (z. B. "main_reports subreports")
+set SUBFOLDERS=main_reports subreports
+set TEMP_STAGE=_jrxml_only_stage
 
 :: ==============================================
 :: === Verarbeitung ==============================
@@ -30,13 +32,45 @@ set SUBFOLDERS=main_reports, subreports
 :: ZIP-Ausgabeordner vorbereiten
 mkdir zip_output 2>nul
 
-:: ZIP erstellen (ohne Oberordner)
-cd %SOURCE_FOLDER%
-powershell -Command "Compress-Archive -Path %SUBFOLDERS% -DestinationPath ../zip_output/%ZIP_NAME%"
-cd ..
+:: ZIP erstellen (nur JRXML-Dateien, ohne README, .jasper etc.)
+pushd %SOURCE_FOLDER% >nul
+
+if exist "%TEMP_STAGE%" rd /s /q "%TEMP_STAGE%"
+mkdir "%TEMP_STAGE%" >nul
+
+for %%F in (%SUBFOLDERS%) do (
+  if exist "%%F" (
+    robocopy "%%F" "%TEMP_STAGE%\%%F" *.jrxml /S >nul
+    if ERRORLEVEL 8 (
+      echo ❌ Fehler beim Kopieren der JRXML-Dateien aus %%F.
+      if exist "%TEMP_STAGE%" rd /s /q "%TEMP_STAGE%"
+      popd >nul
+      exit /b 1
+    )
+  ) else (
+    echo ⚠️ Ordner %%F wurde nicht gefunden und wird uebersprungen.
+  )
+)
+
+set COPIED_FILES=0
+for /f %%# in ('powershell -NoProfile -Command "(Get-ChildItem ''%TEMP_STAGE%'' -Recurse -Filter *.jrxml).Count"') do set COPIED_FILES=%%#
+
+if "%COPIED_FILES%"=="0" (
+  echo ❌ Es wurden keine JRXML-Dateien gefunden. ZIP wird nicht erstellt.
+  rd /s /q "%TEMP_STAGE%"
+  popd >nul
+  exit /b 1
+)
+
+del /q "..\zip_output\%ZIP_NAME%" 2>nul
+powershell -Command "Compress-Archive -Path %TEMP_STAGE%\* -DestinationPath ..\zip_output\%ZIP_NAME% -Force"
+
+rd /s /q "%TEMP_STAGE%"
+popd >nul
 
 :: Optional: ZIP-Inhalte anzeigen
 echo === Inhalt von %ZIP_NAME% ===
+rmdir /s /q tmp_dakks 2>nul
 powershell -Command "Expand-Archive -Path zip_output/%ZIP_NAME% -DestinationPath tmp_dakks -Force; Get-ChildItem -Recurse tmp_dakks"
 echo.
 


### PR DESCRIPTION
## Summary
- stage each sample directory into a temporary tree containing only JRXML files before zipping in the package workflow
- apply the same staging logic to the release workflow so generated archives exclude README and compiled artifacts

## Testing
- yamllint .github/workflows

------
https://chatgpt.com/codex/tasks/task_e_68cacbfc3660832b828bd5d8b2baba3d