### PR TITLE
Ensure workflow zips only contain JRXML files

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -71,6 +71,12 @@ jobs:
               fi
             done
 
+            # Falls trotz Filter noch andere Dateien vorhanden sind (z. B. README.md),
+            # werden sie vorsorglich entfernt, damit die ZIP-Archive ausschliesslich
+            # JRXML-Dateien enthalten.
+            find "${stage_dir}" -type f ! -name '*.jrxml' -delete
+            find "${stage_dir}" -type d -empty -delete
+
             if [ -z "$(find "${stage_dir}" -type f -name '*.jrxml' -print -quit)" ]; then
               echo "❌ No JRXML files found in ${sample}" >&2
               exit 1

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -42,6 +42,10 @@ jobs:
               fi
             done
 
+            # Sicherstellen, dass nur JRXML-Dateien in den ZIPs landen
+            find "${stage_dir}" -type f ! -name '*.jrxml' -delete
+            find "${stage_dir}" -type d -empty -delete
+
             if [ -z "$(find "${stage_dir}" -type f -name '*.jrxml' -print -quit)" ]; then
               echo "❌ No JRXML files found in ${sample}" >&2
               exit 1


### PR DESCRIPTION
## Summary
- harden both packaging workflows so staging folders remove any non-JRXML files before zipping
- prune empty directories after cleanup to keep archives limited to the report templates

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68caf8936568832b8fb379447aaa4e28