### PR TITLE
Adjust status symbol mapping in results subreport

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -464,15 +464,15 @@
 					<textElement textAlignment="Right" verticalAlignment="Bottom">
 						<font fontName="SansSerif" size="6"/>
 					</textElement>
-					<textFieldExpression><![CDATA[(
+                                        <textFieldExpression><![CDATA[(
               ($F{test_status}==null || $F{test_status}.trim().isEmpty())
-              ? "-"
+              ? ""
               : (
-                  $F{test_status}.equalsIgnoreCase("pass indeterminate") ? "?"  :
-                  $F{test_status}.equalsIgnoreCase("fail indeterminate") ? "!?" :
-                  $F{test_status}.equalsIgnoreCase("fail")               ? "!"  :
-                  $F{test_status}.equalsIgnoreCase("pass")               ? "i.T" :
-                  $F{test_status}
+                  $F{test_status}.trim().equalsIgnoreCase("pass")               ? "i.T" :
+                  $F{test_status}.trim().equalsIgnoreCase("fail")               ? "!"  :
+                  $F{test_status}.trim().equalsIgnoreCase("pass indeterminate") ? "?"  :
+                  $F{test_status}.trim().equalsIgnoreCase("fail indeterminate") ? "!?" :
+                  ""
                 )
             )
             + ($V{AccredMark}==null ? "" : $V{AccredMark})]]></textFieldExpression>


### PR DESCRIPTION
## Summary
- update the status column expression in the results subreport so that the "i.T" symbol only appears for the exact status "pass"
- ensure unrecognized or empty statuses no longer render a placeholder but stay blank while keeping the existing mappings for fail variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb051072b8832b8296274f958f4a56