### PR TITLE
Limit measurement data check to fixq and varq

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -145,14 +145,8 @@
         <variable name="HasMeasurementData" class="java.lang.Boolean">
                 <variableExpression><![CDATA[
         Boolean.valueOf(
-            ($V{NominalValue} != null && !$V{NominalValue}.trim().isEmpty())
-         || ($V{MeasuredValue} != null && !$V{MeasuredValue}.trim().isEmpty())
-         || ($V{NegLimit} != null && !$V{NegLimit}.trim().isEmpty())
-         || ($V{PosLimit} != null && !$V{PosLimit}.trim().isEmpty())
-         || ($V{ToleranceRange} != null && !$V{ToleranceRange}.trim().isEmpty())
-         || ($V{RoundedRelError} != null && !$V{RoundedRelError}.trim().isEmpty())
-         || ($V{RoundedTolErr} != null && !$V{RoundedTolErr}.trim().isEmpty())
-         || ($V{FormattedUncertainty} != null && !$V{FormattedUncertainty}.trim().isEmpty())
+            ($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+         || ($F{varq} != null && !$F{varq}.trim().isEmpty())
         )
         ]]></variableExpression>
         </variable>


### PR DESCRIPTION
## Summary
- restrict the `HasMeasurementData` variable in the DAkkS Results subreport to only look at `fixq` and `varq`
- ensure remarks continue to display whenever no true measurement values are provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0e086648832b99ebacad508151e3