### PR TITLE
Simplify nominal and measured value fields

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -62,20 +62,16 @@
         <field name="test_status" class="java.lang.String"/>
         <field name="accred" class="java.lang.String"/>
         <field name="row_num" class="java.lang.Number"/>
-	<variable name="NominalValue" class="java.lang.String">
-		<variableExpression><![CDATA[$F{fixq}==null || $F{fixq}.trim().isEmpty()
+        <variable name="NominalValue" class="java.lang.String">
+                <variableExpression><![CDATA[$F{fixq}==null || $F{fixq}.trim().isEmpty()
       ? ""
-      : $F{fixq}.trim()
-        + ($F{fixq_p}==null || $F{fixq_p}.trim().isEmpty() ? "" : " " + $F{fixq_p}.trim())
-        + ($F{fixq_u}==null ? "" : $F{fixq_u})]]></variableExpression>
-	</variable>
-	<variable name="MeasuredValue" class="java.lang.String">
-		<variableExpression><![CDATA[$F{varq}==null || $F{varq}.trim().isEmpty()
+      : $F{fixq}.trim()]]></variableExpression>
+        </variable>
+        <variable name="MeasuredValue" class="java.lang.String">
+                <variableExpression><![CDATA[$F{varq}==null || $F{varq}.trim().isEmpty()
       ? ""
-      : $F{varq}.trim()
-        + ($F{varq_p}==null || $F{varq_p}.trim().isEmpty() ? "" : " " + $F{varq_p}.trim())
-        + ($F{varq_u}==null ? "" : $F{varq_u})]]></variableExpression>
-	</variable>
+      : $F{varq}.trim()]]></variableExpression>
+        </variable>
 	<variable name="PosLimit" class="java.lang.String">
 		<variableExpression><![CDATA[$F{tol_pos}==null || $F{tol_pos}.trim().isEmpty()
       ? ""


### PR DESCRIPTION
## Summary
- update the NominalValue variable to return only the trimmed fixq string
- update the MeasuredValue variable to return only the trimmed varq string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0d700070832b890581c12b5ba947