### PR TITLE
Remove redundant test_step2 suffix from DAkkS results subreport

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -391,8 +391,8 @@
 					<textElement verticalAlignment="Bottom">
 						<font fontName="SansSerif" size="6"/>
 					</textElement>
-					<textFieldExpression><![CDATA[!$F{test_desc}.trim().isEmpty()
-              ? $F{test_desc} + ( !$F{test_step2}.trim().isEmpty() ? " " + $F{test_step2} : "" )
+                                        <textFieldExpression><![CDATA[!$F{test_desc}.trim().isEmpty()
+              ? $F{test_desc}
               : $F{test_step2}]]></textFieldExpression>
                                 </textField>
                                 <textField>


### PR DESCRIPTION
## Summary
- stop appending the test_step2 field to the first column in the DAkkS Results subreport
- keep test_step2 only as a fallback when no description is provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb1289c17c832ba736277c23f67c50