### PR TITLE
Remove percent suffix from DAkkS error outputs

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -101,26 +101,26 @@
           ($V{PosLimit}==null ? "" : $V{PosLimit}.trim())
         )]]></variableExpression>
 	</variable>
-	<variable name="RoundedRelError" class="java.lang.String">
-		<variableExpression><![CDATA[$F{error}==null || $F{error}.trim().isEmpty()
+        <variable name="RoundedRelError" class="java.lang.String">
+                <variableExpression><![CDATA[$F{error}==null || $F{error}.trim().isEmpty()
       ? ""
       : (
           $F{error}.replaceAll("[^0-9\\.,\\-+]", "").replace(",", ".").matches("-?\\d+(\\.\\d+)?")
           ? new java.text.DecimalFormat("0.0")
-              .format(Double.parseDouble($F{error}.replaceAll("[^0-9\\.,\\-+]", "").replace(",", "."))) + "%"
+              .format(Double.parseDouble($F{error}.replaceAll("[^0-9\\.,\\-+]", "").replace(",", ".")))
           : $F{error}
         )]]></variableExpression>
-	</variable>
-	<variable name="RoundedTolErr" class="java.lang.String">
-		<variableExpression><![CDATA[$F{tol_err}==null || $F{tol_err}.trim().isEmpty()
+        </variable>
+        <variable name="RoundedTolErr" class="java.lang.String">
+                <variableExpression><![CDATA[$F{tol_err}==null || $F{tol_err}.trim().isEmpty()
       ? ""
       : (
           $F{tol_err}.replaceAll("[^0-9\\.,\\-+]", "").replace(",", ".").matches("-?\\d+(\\.\\d+)?")
           ? new java.text.DecimalFormat("0.0")
-              .format(Double.parseDouble($F{tol_err}.replaceAll("[^0-9\\.,\\-+]", "").replace(",", "."))) + "%"
+              .format(Double.parseDouble($F{tol_err}.replaceAll("[^0-9\\.,\\-+]", "").replace(",", ".")))
           : $F{tol_err}
         )]]></variableExpression>
-	</variable>
+        </variable>
         <variable name="FormattedUncertainty" class="java.lang.String">
                 <variableExpression><![CDATA[($F{exp_uncert_iso_e}==null || $F{exp_uncert_iso_e}.trim().isEmpty())
       ? ""


### PR DESCRIPTION
## Summary
- stop appending a percent symbol to the rounded relative deviation value in the DAkkS results subreport
- stop appending a percent symbol to the rounded tolerance error value in the DAkkS results subreport

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb1308eb90832bbec7a157bccb189f