### PR TITLE
Format DAkkS date fields using SimpleDateFormat

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -18,8 +18,8 @@
   COALESCE(i.I4202, "") AS I4202,
   COALESCE(i.I4203, "") AS I4203,
   COALESCE(i.I4204, "") AS I4204,
-  COALESCE(c.C2301, "") AS C2301,
-  COALESCE(c.C2303, "") AS C2303,
+  c.C2301 AS C2301,
+  c.C2303 AS C2303,
   COALESCE(c.C2356, "") AS C2356
 FROM $P!{PrefixTable}standards t
 LEFT JOIN $P!{PrefixTable}inventory i ON (t.`C2430` = i.`MTAG`)
@@ -30,8 +30,8 @@ WHERE t.CTAG = $P{P_CTAG}]]>
 	<field name="I4202" class="java.lang.String"/>
 	<field name="I4203" class="java.lang.String"/>
 	<field name="I4204" class="java.lang.String"/>
-	<field name="C2301" class="java.lang.String"/>
-	<field name="C2303" class="java.lang.String"/>
+        <field name="C2301" class="java.util.Date"/>
+        <field name="C2303" class="java.util.Date"/>
 	<field name="C2356" class="java.lang.String"/>
 	<variable name="Inv_Nr" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Inv.Nr" : "Inventory-Nr"]]></variableExpression>
@@ -284,21 +284,20 @@ WHERE t.CTAG = $P{P_CTAG}]]>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{I4203}]]></textFieldExpression>
 			</textField>
-			<textField>
-				<reportElement x="320" y="0" width="50" height="16" uuid="ee5ba057-36d0-4cad-b62a-cb0e33a157d0"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="SansSerif" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
-				<patternExpression><![CDATA[MONTH($F{C2301}) + ' ' + YEAR( $F{C2301}) ]]></patternExpression>
-			</textField>
-			<textField>
-				<reportElement x="370" y="0" width="50" height="16" uuid="d49d27df-30b6-4274-97c9-0e5fcb80cf34"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="SansSerif" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{C2303}]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="320" y="0" width="50" height="16" uuid="ee5ba057-36d0-4cad-b62a-cb0e33a157d0"/>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                        <font fontName="SansSerif" size="8"/>
+                                </textElement>
+                                <textFieldExpression class="java.lang.String"><![CDATA[$F{C2301} == null ? null : new java.text.SimpleDateFormat("MMMM yyyy", $P{Sprache}.equals("Deutsch") ? java.util.Locale.GERMAN : java.util.Locale.ENGLISH).format($F{C2301})]]></textFieldExpression>
+                        </textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="370" y="0" width="50" height="16" uuid="d49d27df-30b6-4274-97c9-0e5fcb80cf34"/>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                        <font fontName="SansSerif" size="8"/>
+                                </textElement>
+                                <textFieldExpression class="java.lang.String"><![CDATA[$F{C2303} == null ? null : new java.text.SimpleDateFormat("MMMM yyyy", $P{Sprache}.equals("Deutsch") ? java.util.Locale.GERMAN : java.util.Locale.ENGLISH).format($F{C2303})]]></textFieldExpression>
+                        </textField>
 			<textField>
 				<reportElement x="420" y="0" width="115" height="16" uuid="dc4e45e7-01a9-4b84-aa1b-d35209b2d2fc"/>
 				<textElement textAlignment="Center" verticalAlignment="Middle">


### PR DESCRIPTION
## Summary
- keep the DAkkS calibration date fields as dates in the dataset so they can be formatted natively
- render the "Last Cal" and "Next Cal" fields as localized month-year strings with `SimpleDateFormat`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb225e0e44832b8b705f02373aad0a