### PR TITLE
Convert calibration date strings to SQL dates in Standard subreport

### DIFF
--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -18,8 +18,8 @@
   COALESCE(i.I4202, "") AS I4202,
   COALESCE(i.I4203, "") AS I4203,
   COALESCE(i.I4204, "") AS I4204,
-  c.C2301 AS C2301,
-  c.C2303 AS C2303,
+  STR_TO_DATE(c.C2301, '%Y-%m-%d') AS C2301,
+  STR_TO_DATE(c.C2303, '%Y-%m-%d') AS C2303,
   COALESCE(c.C2356, "") AS C2356
 FROM $P!{PrefixTable}standards t
 LEFT JOIN $P!{PrefixTable}inventory i ON (t.`C2430` = i.`MTAG`)


### PR DESCRIPTION
## Summary
- convert the Standard subreport SQL to cast C2301 and C2303 to DATE values with STR_TO_DATE so they arrive as real dates in JasperReports

## Testing
- jshell

------
https://chatgpt.com/codex/tasks/task_e_68cb357861fc832b91c9d97247998cb6