### PR TITLE
Fix Jasper compatibility in field names report

### DIFF
--- a/FIELD-NAMES/main_reports/field-names-language-overview.jrxml
+++ b/FIELD-NAMES/main_reports/field-names-language-overview.jrxml
@@ -62,7 +62,7 @@ ORDER BY fn.table_name, fn.field_name
         <groupExpression><![CDATA[$F{table_name}]]></groupExpression>
         <groupHeader>
             <band height="32">
-                <textField isStretchWithOverflow="true">
+                <textField textAdjust="StretchHeight">
                     <reportElement x="0" y="6" width="515" height="24" uuid="69a703ae-a3af-4f48-8a3f-5c7c598cecf5"/>
                     <textElement>
                         <font size="14" isBold="true"/>
@@ -165,26 +165,26 @@ ORDER BY fn.table_name, fn.field_name
     </pageHeader>
     <detail>
         <band height="48" splitType="Stretch">
-            <frame isStretchWithOverflow="true">
+            <frame stretchType="RelativeToTallestObject">
                 <reportElement x="0" y="0" width="555" height="48" uuid="69ff56d8-b64a-4552-9e72-83a8749d41f8"/>
                 <box>
                     <bottomPen lineWidth="0.2" lineStyle="Dotted"/>
                 </box>
-                <textField isStretchWithOverflow="true">
+                <textField textAdjust="StretchHeight">
                     <reportElement x="0" y="4" width="110" height="16" uuid="d0a6a546-d2d0-47dd-a798-59492607db8f"/>
                     <textElement>
                         <font size="9"/>
                     </textElement>
                     <textFieldExpression><![CDATA[$F{field_name}]]></textFieldExpression>
                 </textField>
-                <textField isStretchWithOverflow="true">
+                <textField textAdjust="StretchHeight">
                     <reportElement x="110" y="4" width="120" height="16" uuid="6debb1a0-2b0d-4dbd-8ad7-11541834cf55"/>
                     <textElement>
                         <font size="9"/>
                     </textElement>
                     <textFieldExpression><![CDATA[$F{default_label} == null ? "" : $F{default_label}]]></textFieldExpression>
                 </textField>
-                <textField isStretchWithOverflow="true">
+                <textField textAdjust="StretchHeight">
                     <reportElement x="230" y="4" width="120" height="16" uuid="c1a523af-38d0-46c0-934e-0a1e68832f31"/>
                     <textElement>
                         <font size="9"/>
@@ -205,14 +205,14 @@ ORDER BY fn.table_name, fn.field_name
                     </textElement>
                     <textFieldExpression><![CDATA[$F{required_flag} == null ? "" : ($F{required_flag}.equalsIgnoreCase("Y") || $F{required_flag}.equalsIgnoreCase("1") ? "Ja" : "Nein")]]></textFieldExpression>
                 </textField>
-                <textField isStretchWithOverflow="true">
+                <textField textAdjust="StretchHeight">
                     <reportElement x="470" y="4" width="85" height="16" uuid="1991fde8-ff16-4f28-b3fe-0b5ff8b17aea"/>
                     <textElement>
                         <font size="9"/>
                     </textElement>
                     <textFieldExpression><![CDATA[$F{translation_hint} != null && !$F{translation_hint}.isEmpty() ? $F{translation_hint} : $F{default_hint}]]></textFieldExpression>
                 </textField>
-                <textField isStretchWithOverflow="true">
+                <textField textAdjust="StretchHeight">
                     <reportElement x="0" y="24" width="555" height="18" uuid="7b9434ab-5463-4850-9d37-992bfb45d51c"/>
                     <textElement>
                         <font size="8" isItalic="true"/>


### PR DESCRIPTION
## Summary
- replace deprecated `isStretchWithOverflow` usages in the field names overview report with the supported `textAdjust` attribute
- configure the detail frame to stretch relative to its tallest child so overflowing text still expands correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2b9d399e4832ba38e9625b6b0f383