### PR TITLE
Ensure workflow keeps empty report folders in ZIPs

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -71,10 +71,11 @@ jobs:
 
             rm -rf "${stage_dir}"
             mkdir -p "${stage_dir}"
+            mkdir -p "${stage_dir}/main_reports" "${stage_dir}/subreports"
 
             for folder in main_reports subreports; do
               if [ -d "${sample}/${folder}" ]; then
-                rsync -avm \
+                rsync -av \
                   --include='*/' \
                   --include='*.jrxml' \
                   --exclude='*' \
@@ -86,7 +87,6 @@ jobs:
             # werden sie vorsorglich entfernt, damit die ZIP-Archive ausschliesslich
             # JRXML-Dateien enthalten.
             find "${stage_dir}" -type f ! -name '*.jrxml' -delete
-            find "${stage_dir}" -type d -empty -delete
 
             if [ -z "$(find "${stage_dir}" -type f -name '*.jrxml' -print -quit)" ]; then
               echo "❌ No JRXML files found in ${sample}" >&2


### PR DESCRIPTION
## Summary
- pre-create main_reports and subreports staging directories before zipping
- stop pruning empty folders so the API receives both directories per package
- retain only JRXML files in the staged directories while keeping folder structure intact

## Testing
- `yamllint .github/workflows/package-reports.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bff1160c832b8b02d9beb68227ee