### PR TITLE
Replace sticker reports with Zebra ZD621 layouts

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6 -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+    name="CAL_STICKER_Zebra_ZD621_30x15_203dpi" pageWidth="240" pageHeight="120" columnWidth="240" leftMargin="0" rightMargin="0"
+    topMargin="0" bottomMargin="0" uuid="92a76325-9f24-4ca8-9f50-2d46ed416312">
+    <property name="com.jaspersoft.studio.data.defaultdataadapter" value="calServer"/>
+    <property name="com.jaspersoft.studio.unit." value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+    <parameter name="PrefixTable" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="P_MTAG" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <queryString language="SQL">
+        <![CDATA[SELECT
+  i.I4201 AS I4201,
+  cal.C2307 AS CAL_C2307,
+  cal.C2301 AS CAL_C2301,
+  cal.C2303 AS CAL_C2303
+FROM $P!{PrefixTable}inventory i
+LEFT JOIN $P!{PrefixTable}calibration cal ON cal.MTAG = i.MTAG AND cal.C2339 = 1
+WHERE i.MTAG = $P{P_MTAG}]]>
+    </queryString>
+    <field name="I4201" class="java.lang.String"/>
+    <field name="CAL_C2307" class="java.lang.String"/>
+    <field name="CAL_C2301" class="java.lang.Object"/>
+    <field name="CAL_C2303" class="java.lang.Object"/>
+    <variable name="FormattedLastCalibration" class="java.lang.String">
+        <variableExpression><![CDATA[$F{CAL_C2301} == null
+    ? "-"
+    : ($F{CAL_C2301} instanceof java.util.Date
+        ? new java.text.SimpleDateFormat("dd.MM.yyyy").format((java.util.Date) $F{CAL_C2301})
+        : $F{CAL_C2301}.toString())]]></variableExpression>
+    </variable>
+    <variable name="FormattedNextCalibration" class="java.lang.String">
+        <variableExpression><![CDATA[$F{CAL_C2303} == null
+    ? "-"
+    : ($F{CAL_C2303} instanceof java.util.Date
+        ? new java.text.SimpleDateFormat("dd.MM.yyyy").format((java.util.Date) $F{CAL_C2303})
+        : $F{CAL_C2303}.toString())]]></variableExpression>
+    </variable>
+    <background>
+        <band splitType="Stretch">
+            <rectangle>
+                <reportElement x="0" y="0" width="240" height="120" backcolor="#FFFFFF" uuid="a53d301f-3c72-4dea-bac7-3bcd708dd05b"/>
+            </rectangle>
+        </band>
+    </background>
+    <detail>
+        <band height="120" splitType="Prevent">
+            <staticText>
+                <reportElement x="10" y="6" width="120" height="16" uuid="4545f2f6-7fc4-40ea-892a-b523f2f8977f"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="10" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Inventar-Nr.]]></text>
+            </staticText>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="10" y="22" width="220" height="20" uuid="06673d21-a482-4f75-9f77-e8cfba39fb9d"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="14" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{I4201} == null || $F{I4201}.trim().isEmpty() ? "-" : $F{I4201}.trim()]]></textFieldExpression>
+            </textField>
+            <line>
+                <reportElement x="10" y="46" width="220" height="1" forecolor="#999999" uuid="8fd1a020-d369-429f-a9bc-1b5d3d7e6d14"/>
+            </line>
+            <staticText>
+                <reportElement x="10" y="54" width="100" height="14" uuid="eaa02de8-2860-4014-b648-11fd57878cf8"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Kalibriert durch]]></text>
+            </staticText>
+            <textField isStretchWithOverflow="true">
+                <reportElement x="10" y="68" width="220" height="16" uuid="ad8d8d46-086b-47c7-a768-453ad62c611f"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{CAL_C2307} == null || $F{CAL_C2307}.trim().isEmpty() ? "-" : $F{CAL_C2307}.trim()]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement x="10" y="86" width="100" height="14" uuid="4a545430-9e64-4553-bf43-c531529041a9"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Letzte Kalibrierung]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="130" y="86" width="100" height="14" uuid="ae815cd6-0426-4dca-87a5-22ba3c87bdf3"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Nächste Kalibrierung]]></text>
+            </staticText>
+            <textField>
+                <reportElement x="10" y="100" width="100" height="16" uuid="15c4ec13-28de-40aa-a25c-1d8cc0deac1f"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{FormattedLastCalibration}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="130" y="100" width="100" height="16" uuid="8a407c4f-b7e9-4049-95bb-6fd82e1f2b1a"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{FormattedNextCalibration}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+</jasperReport>

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6 -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components"
+    xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd
+        http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd"
+    name="INV_STICKER_Zebra_ZD621_30x15_203dpi" pageWidth="240" pageHeight="120" columnWidth="240" leftMargin="0" rightMargin="0"
+    topMargin="0" bottomMargin="0" uuid="7319ca2b-fb83-4536-82c6-43bf6403a8ef">
+    <property name="com.jaspersoft.studio.data.defaultdataadapter" value="calServer"/>
+    <property name="com.jaspersoft.studio.unit." value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+    <property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+    <parameter name="PrefixTable" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="P_MTAG" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <queryString language="SQL">
+        <![CDATA[SELECT
+  i.I4201 AS I4201,
+  c.K4601 AS CUST_K4601,
+  c.K4602 AS CUST_K4602,
+  l.L2801 AS LOC_L2801,
+  l.L2802 AS LOC_L2802
+FROM $P!{PrefixTable}inventory i
+LEFT JOIN $P!{PrefixTable}customers c ON i.KTAG = c.KTAG
+LEFT JOIN $P!{PrefixTable}location l ON l.MTAG = i.MTAG AND l.L2815 = 1
+WHERE i.MTAG = $P{P_MTAG}]]>
+    </queryString>
+    <field name="I4201" class="java.lang.String"/>
+    <field name="CUST_K4601" class="java.lang.String"/>
+    <field name="CUST_K4602" class="java.lang.String"/>
+    <field name="LOC_L2801" class="java.lang.String"/>
+    <field name="LOC_L2802" class="java.lang.String"/>
+    <background>
+        <band splitType="Stretch">
+            <rectangle>
+                <reportElement x="0" y="0" width="240" height="120" backcolor="#FFFFFF" uuid="f06892b2-713d-41ab-b880-d1201d3e0a83"/>
+            </rectangle>
+        </band>
+    </background>
+    <detail>
+        <band height="120" splitType="Prevent">
+            <componentElement>
+                <reportElement x="8" y="12" width="96" height="96" uuid="b9276c7f-112e-4ae0-b6bc-0fb8d7257dc1"/>
+                <jr:QRCode>
+                    <jr:codeExpression><![CDATA[$F{I4201} == null || $F{I4201}.trim().isEmpty() ? "" : $F{I4201}.trim()]]></jr:codeExpression>
+                </jr:QRCode>
+            </componentElement>
+            <textField textAdjust="StretchHeight">
+                <reportElement x="8" y="103" width="96" height="15" uuid="27c363dc-57eb-4ee7-9a7e-69b32e5174a5"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{I4201} == null ? "" : $F{I4201}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement x="112" y="6" width="120" height="14" uuid="3c008baa-d7f5-4819-bf3f-6bf0d9090f6d"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[OE-Bezeichnung]]></text>
+            </staticText>
+            <textField textAdjust="StretchHeight">
+                <reportElement x="112" y="20" width="120" height="28" uuid="85dd7099-8882-4fc8-9ce0-d3c61f91a4af"/>
+                <textElement verticalAlignment="Top">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{CUST_K4602} == null || $F{CUST_K4602}.trim().isEmpty() ? "-" : $F{CUST_K4602}.trim()]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement x="112" y="50" width="120" height="14" uuid="fbe5c3a4-3955-4ed4-b79a-422655c8d5cd"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Kostenstelle]]></text>
+            </staticText>
+            <textField textAdjust="StretchHeight">
+                <reportElement x="112" y="64" width="120" height="18" uuid="31b4a303-6cd2-4e74-bf63-8e4244dcb70c"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="10"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{CUST_K4601} == null || $F{CUST_K4601}.trim().isEmpty() ? "-" : $F{CUST_K4601}.trim()]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement x="112" y="84" width="120" height="14" uuid="44c9064b-2f5d-4d75-966f-b9914949a8b3"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Gebäude / Raum]]></text>
+            </staticText>
+            <textField textAdjust="StretchHeight">
+                <reportElement x="112" y="98" width="120" height="20" uuid="a1b3a44d-4c9b-4e4e-88e6-04675c9d260d"/>
+                <textElement verticalAlignment="Top">
+                    <font size="9"/>
+                </textElement>
+                <textFieldExpression><![CDATA[
+                    $F{LOC_L2801} == null && ($F{LOC_L2802} == null || $F{LOC_L2802}.trim().isEmpty())
+                        ? "-"
+                        : ($F{LOC_L2801} == null || $F{LOC_L2801}.trim().isEmpty()
+                            ? ""
+                            : $F{LOC_L2801}.trim())
+                            + (($F{LOC_L2802} == null || $F{LOC_L2802}.trim().isEmpty())
+                                ? ""
+                                : ($F{LOC_L2801} == null || $F{LOC_L2801}.trim().isEmpty() ? "" : " / ") + $F{LOC_L2802}.trim())
+                ]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+</jasperReport>


### PR DESCRIPTION
## Summary
- redesign the inventory sticker as INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml using the existing SQL fields for inventory, customer, and location data plus an I4201 QR code
- build CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml to show the calibrator and last/next calibration dates formatted for Zebra ZD621 labels without altering the data query parameters

## Testing
- ./scripts/check_jasper_version.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2bda0a718832b94ffe183091de68f