### PR TITLE
Fix sticker report layout warnings

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -47,7 +47,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
         : $F{CAL_C2303}.toString())]]></variableExpression>
     </variable>
     <background>
-        <band splitType="Stretch">
+        <band height="120" splitType="Stretch">
             <rectangle>
                 <reportElement x="0" y="0" width="240" height="120" backcolor="#FFFFFF" uuid="a53d301f-3c72-4dea-bac7-3bcd708dd05b"/>
             </rectangle>
@@ -62,7 +62,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                 </textElement>
                 <text><![CDATA[Inventar-Nr.]]></text>
             </staticText>
-            <textField isStretchWithOverflow="true">
+            <textField textAdjust="StretchHeight">
                 <reportElement x="10" y="22" width="220" height="20" uuid="06673d21-a482-4f75-9f77-e8cfba39fb9d"/>
                 <textElement verticalAlignment="Middle">
                     <font size="14" isBold="true"/>
@@ -79,7 +79,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                 </textElement>
                 <text><![CDATA[Kalibriert durch]]></text>
             </staticText>
-            <textField isStretchWithOverflow="true">
+            <textField textAdjust="StretchHeight">
                 <reportElement x="10" y="68" width="220" height="16" uuid="ad8d8d46-086b-47c7-a768-453ad62c611f"/>
                 <textElement verticalAlignment="Middle">
                     <font size="10"/>

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -38,7 +38,7 @@ WHERE i.MTAG = $P{P_MTAG}]]>
     <field name="LOC_L2801" class="java.lang.String"/>
     <field name="LOC_L2802" class="java.lang.String"/>
     <background>
-        <band splitType="Stretch">
+        <band height="120" splitType="Stretch">
             <rectangle>
                 <reportElement x="0" y="0" width="240" height="120" backcolor="#FFFFFF" uuid="f06892b2-713d-41ab-b880-d1201d3e0a83"/>
             </rectangle>


### PR DESCRIPTION
## Summary
- set explicit band height for the sticker background to keep elements within the band
- replace deprecated isStretchWithOverflow usage with textAdjust on sticker text fields

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c7000d9c832b8474e7d58deca5ab