### PR TITLE
Cast inventory field I4212 to string

### DIFF
--- a/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
+++ b/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
@@ -28,7 +28,7 @@
   i.`I4209` AS inv_I4209,
   i.`I4210` AS inv_I4210,
   i.`I4211` AS inv_I4211,
-  i.`I4212` AS inv_I4212,
+  CAST(i.`I4212` AS CHAR) AS inv_I4212,
   i.`I4213` AS inv_I4213,
   i.`I4214` AS inv_I4214,
   i.`I4215` AS inv_I4215,

--- a/STICKERS/Sticker_Vorlage.jrxml
+++ b/STICKERS/Sticker_Vorlage.jrxml
@@ -28,7 +28,7 @@
   i.`I4209` AS inv_I4209,
   i.`I4210` AS inv_I4210,
   i.`I4211` AS inv_I4211,
-  i.`I4212` AS inv_I4212,
+  CAST(i.`I4212` AS CHAR) AS inv_I4212,
   i.`I4213` AS inv_I4213,
   i.`I4214` AS inv_I4214,
   i.`I4215` AS inv_I4215,

--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -39,7 +39,7 @@
   i.`I4209` AS inv_I4209,
   i.`I4210` AS inv_I4210,
   i.`I4211` AS inv_I4211,
-  i.`I4212` AS inv_I4212,
+  CAST(i.`I4212` AS CHAR) AS inv_I4212,
   i.`I4213` AS inv_I4213,
   i.`I4214` AS inv_I4214,
   i.`I4215` AS inv_I4215,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -41,7 +41,7 @@
   i.`I4209` AS inv_I4209,
   i.`I4210` AS inv_I4210,
   i.`I4211` AS inv_I4211,
-  i.`I4212` AS inv_I4212,
+  CAST(i.`I4212` AS CHAR) AS inv_I4212,
   i.`I4213` AS inv_I4213,
   i.`I4214` AS inv_I4214,
   i.`I4215` AS inv_I4215,


### PR DESCRIPTION
## Summary
- cast the inventory field I4212 to CHAR in every sticker and sample report SQL query
- avoid Jasper type mismatches when fetching inv_I4212 as a string

## Testing
- not run (queries only)

------
https://chatgpt.com/codex/tasks/task_e_68d2c9889430832b8b9cae976a0cbaf5