### PR TITLE
Cast inventory I4221 field to string for sticker reports

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -46,7 +46,7 @@
   i.`I4218` AS inv_I4218,
   i.`I4219` AS inv_I4219,
   i.`I4220` AS inv_I4220,
-  i.`I4221` AS inv_I4221,
+  CAST(i.`I4221` AS CHAR) AS inv_I4221,
   i.`I4222` AS inv_I4222,
   i.`I4223` AS inv_I4223,
   i.`I4224` AS inv_I4224,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -52,7 +52,7 @@
   i.`I4218` AS inv_I4218,
   i.`I4219` AS inv_I4219,
   i.`I4220` AS inv_I4220,
-  i.`I4221` AS inv_I4221,
+  CAST(i.`I4221` AS CHAR) AS inv_I4221,
   i.`I4222` AS inv_I4222,
   i.`I4223` AS inv_I4223,
   i.`I4224` AS inv_I4224,


### PR DESCRIPTION
## Summary
- cast the inventory I4221 field to CHAR in both sticker report SQL queries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2d0321328832bab78698663e33f84