### PR TITLE
Cast inventory field I4236 to string for sticker reports

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -60,7 +60,7 @@
   i.`I4233` AS inv_I4233,
   i.`I4234` AS inv_I4234,
   i.`I4235` AS inv_I4235,
-  i.`I4236` AS inv_I4236,
+  CAST(i.`I4236` AS CHAR) AS inv_I4236,
   i.`I4237` AS inv_I4237,
   i.`I4238` AS inv_I4238,
   i.`I4239` AS inv_I4239,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -66,7 +66,7 @@
   i.`I4233` AS inv_I4233,
   i.`I4234` AS inv_I4234,
   i.`I4235` AS inv_I4235,
-  i.`I4236` AS inv_I4236,
+  CAST(i.`I4236` AS CHAR) AS inv_I4236,
   i.`I4237` AS inv_I4237,
   i.`I4238` AS inv_I4238,
   i.`I4239` AS inv_I4239,


### PR DESCRIPTION
## Summary
- cast the inventory field I4236 to CHAR in both sticker Jasper report queries to align with the field's string usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2df916634832bae645eaf76968f17