### PR TITLE
Cast inventory field I4238 to char for stickers

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -62,7 +62,7 @@
   i.`I4235` AS inv_I4235,
   CAST(i.`I4236` AS CHAR) AS inv_I4236,
   i.`I4237` AS inv_I4237,
-  i.`I4238` AS inv_I4238,
+  CAST(i.`I4238` AS CHAR) AS inv_I4238,
   i.`I4239` AS inv_I4239,
   i.`I4240` AS inv_I4240,
   i.`I4299` AS inv_I4299,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -68,7 +68,7 @@
   i.`I4235` AS inv_I4235,
   CAST(i.`I4236` AS CHAR) AS inv_I4236,
   i.`I4237` AS inv_I4237,
-  i.`I4238` AS inv_I4238,
+  CAST(i.`I4238` AS CHAR) AS inv_I4238,
   i.`I4239` AS inv_I4239,
   i.`I4240` AS inv_I4240,
   i.`I4299` AS inv_I4299,


### PR DESCRIPTION
## Summary
- cast the inventory column I4238 to CHAR in both sticker reports so the field can be read as a string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2e10b1038832ba78478e4390b5126