### PR TITLE
Cast I4250 to string for sticker reports

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -82,7 +82,7 @@
   i.`I4247` AS inv_I4247,
   i.`I4248` AS inv_I4248,
   i.`I4249` AS inv_I4249,
-  i.`I4250` AS inv_I4250,
+  CAST(i.`I4250` AS CHAR) AS inv_I4250,
   i.`I4251` AS inv_I4251,
   i.`I4252` AS inv_I4252,
   i.`I4253` AS inv_I4253,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -88,7 +88,7 @@
   i.`I4247` AS inv_I4247,
   i.`I4248` AS inv_I4248,
   i.`I4249` AS inv_I4249,
-  i.`I4250` AS inv_I4250,
+  CAST(i.`I4250` AS CHAR) AS inv_I4250,
   i.`I4251` AS inv_I4251,
   i.`I4252` AS inv_I4252,
   i.`I4253` AS inv_I4253,


### PR DESCRIPTION
## Summary
- cast the inventory field I4250 to CHAR in both sticker report queries so JasperReports can read it as a string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2e247561c832ba3f03a76f0e057a2