### PR TITLE
Fix join condition for field names language overview report

### DIFF
--- a/FIELD-NAMES/main_reports/field-names-language-overview.jrxml
+++ b/FIELD-NAMES/main_reports/field-names-language-overview.jrxml
@@ -39,7 +39,7 @@ FROM $P!{PrefixTable}field_metadata fn
 LEFT JOIN $P!{PrefixTable}field_metadata_translation tr
        ON tr.schema_name = fn.schema_name
       AND tr.table_name = fn.table_name
-      AND tr.field_name = fn.field_name
+      AND tr.field_key = fn.field_key
       AND (tr.language_code = $P{LanguageCode} OR $P{LanguageCode} IS NULL)
 WHERE fn.schema_name = $P{SchemaName}
 ORDER BY fn.table_name, fn.field_name


### PR DESCRIPTION
## Summary
- ensure the field metadata translation join uses the field key instead of the field name to match the schema definition

## Testing
- ./scripts/check_jasper_version.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2e412385c832b9542f4b57912cb82