### PR TITLE
Cast inventory field I4252 to CHAR for sticker reports

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -84,7 +84,7 @@
   i.`I4249` AS inv_I4249,
   CAST(i.`I4250` AS CHAR) AS inv_I4250,
   CAST(i.`I4251` AS CHAR) AS inv_I4251,
-  i.`I4252` AS inv_I4252,
+  CAST(i.`I4252` AS CHAR) AS inv_I4252,
   i.`I4253` AS inv_I4253,
   i.`I4254` AS inv_I4254,
   i.`I4255` AS inv_I4255,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -90,7 +90,7 @@
   i.`I4249` AS inv_I4249,
   CAST(i.`I4250` AS CHAR) AS inv_I4250,
   CAST(i.`I4251` AS CHAR) AS inv_I4251,
-  i.`I4252` AS inv_I4252,
+  CAST(i.`I4252` AS CHAR) AS inv_I4252,
   i.`I4253` AS inv_I4253,
   i.`I4254` AS inv_I4254,
   i.`I4255` AS inv_I4255,


### PR DESCRIPTION
## Summary
- cast the inventory field I4252 to CHAR in both sticker report SQL queries to avoid type conversion errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2e4d95630832ba91984b60c9de0fb