### PR TITLE
Fix sticker reports to treat I4253 as string

### DIFF
--- a/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -85,7 +85,7 @@
   CAST(i.`I4250` AS CHAR) AS inv_I4250,
   CAST(i.`I4251` AS CHAR) AS inv_I4251,
   CAST(i.`I4252` AS CHAR) AS inv_I4252,
-  i.`I4253` AS inv_I4253,
+  CAST(i.`I4253` AS CHAR) AS inv_I4253,
   i.`I4254` AS inv_I4254,
   i.`I4255` AS inv_I4255,
   i.`I4256` AS inv_I4256,

--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -91,7 +91,7 @@
   CAST(i.`I4250` AS CHAR) AS inv_I4250,
   CAST(i.`I4251` AS CHAR) AS inv_I4251,
   CAST(i.`I4252` AS CHAR) AS inv_I4252,
-  i.`I4253` AS inv_I4253,
+  CAST(i.`I4253` AS CHAR) AS inv_I4253,
   i.`I4254` AS inv_I4254,
   i.`I4255` AS inv_I4255,
   i.`I4256` AS inv_I4256,


### PR DESCRIPTION
## Summary
- cast inventory column I4253 to CHAR in both sticker JasperReports templates so the field can be read as a string

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2e5fab724832b8d8c5fc66a7d46bf