### PR TITLE
Cast inventory I4252 field to string

### DIFF
--- a/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
+++ b/INVENTORY-SAMPLE/main_reports/inventory-sample.jrxml
@@ -75,7 +75,7 @@
   i.`I4249` AS inv_I4249,
   CAST(i.`I4250` AS CHAR) AS inv_I4250,
   CAST(i.`I4251` AS CHAR) AS inv_I4251,
-  i.`I4252` AS inv_I4252,
+  CAST(i.`I4252` AS CHAR) AS inv_I4252,
   i.`I4253` AS inv_I4253,
   i.`I4254` AS inv_I4254,
   i.`I4255` AS inv_I4255,

--- a/STICKERS/Sticker_Vorlage.jrxml
+++ b/STICKERS/Sticker_Vorlage.jrxml
@@ -75,7 +75,7 @@
   i.`I4249` AS inv_I4249,
   CAST(i.`I4250` AS CHAR) AS inv_I4250,
   CAST(i.`I4251` AS CHAR) AS inv_I4251,
-  i.`I4252` AS inv_I4252,
+  CAST(i.`I4252` AS CHAR) AS inv_I4252,
   i.`I4253` AS inv_I4253,
   i.`I4254` AS inv_I4254,
   i.`I4255` AS inv_I4255,


### PR DESCRIPTION
## Summary
- cast the `I4252` inventory column to CHAR in the sticker template query
- do the same cast in the inventory sample report query

## Testing
- not run (deployment and report generation require calServer environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2e62bb398832bbad712eb4b6910dd