### PR TITLE
Update data sources in field names README

### DIFF
--- a/FIELD-NAMES/main_reports/README.md
+++ b/FIELD-NAMES/main_reports/README.md
@@ -37,11 +37,14 @@ calServer zu pflegen.
 
 Die Vorlage greift auf folgende Tabellen zu:
 
-* `${PrefixTable}field_metadata`
+* `${PrefixTable}field_configuration`
   * Stammdaten der Felder, inklusive technischem Schlüssel, Datentyp und
     Standardlabel.
-* `${PrefixTable}field_metadata_translation`
-  * Übersetzungen/Sprachvarianten der Feldlabels und Hilfetexte.
+* `${PrefixTable}messages`
+  * Enthält sprachspezifische Texte für Feldlabels, Hinweise und weitere UI-
+    Elemente.
+* `${PrefixTable}languages`
+  * Referenztabelle mit verfügbaren Sprachen inklusive Kürzeln und Metadaten.
 
 > ⚠️ Passe Tabellen- und Spaltennamen an deine calServer-Instanz an, falls sie
 > abweichen. Die Struktur orientiert sich an der Standardinstallation.


### PR DESCRIPTION
## Summary
- document the updated table names `field_configuration`, `messages`, and `languages` in the data basis section of the field names report README
- adjust the remaining text in that section to remove references to the former table names

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d2feacfbcc832baf09d06e0d845c2c