### PR TITLE
Adjust inventory sticker layout to 30x15 mm

### DIFF
--- a/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="INV_STICKER_Zebra_ZD621_30x15_203dpi" pageWidth="240" pageHeight="120" columnWidth="240" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="7319ca2b-fb83-4536-82c6-43bf6403a8ef">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="INV_STICKER_Zebra_ZD621_30x15_203dpi" pageWidth="85" pageHeight="43" columnWidth="85" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="7319ca2b-fb83-4536-82c6-43bf6403a8ef">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="calServer"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -592,57 +592,57 @@ WHERE i.MTAG = $P{P_MTAG}]]>
 		<band splitType="Stretch"/>
 	</background>
 	<detail>
-		<band height="120" splitType="Prevent">
+		<band height="43" splitType="Prevent">
 			<componentElement>
-				<reportElement x="8" y="12" width="96" height="96" uuid="b9276c7f-112e-4ae0-b6bc-0fb8d7257dc1"/>
+				<reportElement x="3" y="4" width="34" height="34" uuid="b9276c7f-112e-4ae0-b6bc-0fb8d7257dc1"/>
 				<jr:QRCode xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
 					<jr:codeExpression><![CDATA[$F{inv_I4201} == null || $F{inv_I4201}.trim().isEmpty() ? "" : $F{inv_I4201}.trim()]]></jr:codeExpression>
 				</jr:QRCode>
 			</componentElement>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="8" y="103" width="96" height="15" uuid="27c363dc-57eb-4ee7-9a7e-69b32e5174a5"/>
+				<reportElement x="3" y="37" width="34" height="5" uuid="27c363dc-57eb-4ee7-9a7e-69b32e5174a5"/>
 				<textElement textAlignment="Center" verticalAlignment="Middle">
 					<font size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{inv_I4201} == null ? "" : $F{inv_I4201}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="112" y="6" width="120" height="14" uuid="3c008baa-d7f5-4819-bf3f-6bf0d9090f6d"/>
+				<reportElement x="40" y="2" width="43" height="5" uuid="3c008baa-d7f5-4819-bf3f-6bf0d9090f6d"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8" isBold="true"/>
 				</textElement>
 				<text><![CDATA[OE-Bezeichnung]]></text>
 			</staticText>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="112" y="20" width="120" height="28" uuid="85dd7099-8882-4fc8-9ce0-d3c61f91a4af"/>
+				<reportElement x="40" y="7" width="43" height="10" uuid="85dd7099-8882-4fc8-9ce0-d3c61f91a4af"/>
 				<textElement verticalAlignment="Top">
 					<font size="11" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{cust_K4602} == null || $F{cust_K4602}.trim().isEmpty() ? "-" : $F{cust_K4602}.trim()]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="112" y="50" width="120" height="14" uuid="fbe5c3a4-3955-4ed4-b79a-422655c8d5cd"/>
+				<reportElement x="40" y="18" width="43" height="5" uuid="fbe5c3a4-3955-4ed4-b79a-422655c8d5cd"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Kostenstelle]]></text>
 			</staticText>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="112" y="64" width="120" height="18" uuid="31b4a303-6cd2-4e74-bf63-8e4244dcb70c"/>
+				<reportElement x="40" y="23" width="43" height="6" uuid="31b4a303-6cd2-4e74-bf63-8e4244dcb70c"/>
 				<textElement verticalAlignment="Middle">
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{cust_K4601} == null || $F{cust_K4601}.trim().isEmpty() ? "-" : $F{cust_K4601}.trim()]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="112" y="84" width="120" height="14" uuid="44c9064b-2f5d-4d75-966f-b9914949a8b3"/>
+				<reportElement x="40" y="30" width="43" height="5" uuid="44c9064b-2f5d-4d75-966f-b9914949a8b3"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Gebäude / Raum]]></text>
 			</staticText>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="112" y="98" width="120" height="20" uuid="a1b3a44d-4c9b-4e4e-88e6-04675c9d260d"/>
+				<reportElement x="40" y="35" width="43" height="7" uuid="a1b3a44d-4c9b-4e4e-88e6-04675c9d260d"/>
 				<textElement verticalAlignment="Top">
 					<font size="9"/>
 				</textElement>


### PR DESCRIPTION
## Summary
- resize the inventory sticker template to 30×15 mm and update the detail band height
- reposition the QR code and descriptive fields so they fit within the reduced label area

## Testing
- not run (JRXML change)


------
https://chatgpt.com/codex/tasks/task_e_68d4fc50efd0832bbf2c4ee037c7cdea