### PR TITLE
Fix page break for inventory sticker report

### DIFF
--- a/STICKERS/main_reports/CAL-INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
+++ b/STICKERS/main_reports/CAL-INV-STICKER_Zebra-ZD621_30x15-203dpi.jrxml
@@ -666,9 +666,8 @@ WHERE i.MTAG = $P{P_MTAG}]]>
                                 </textElement>
                                 <textFieldExpression><![CDATA[$V{FormattedNextCalibration}]]></textFieldExpression>
                         </textField>
-                        <break>
+                        <break type="Page">
                                 <reportElement x="0" y="118" width="1" height="2" uuid="6d7d4bbd-b692-4a47-a0e7-efb8b61c5232"/>
-                                <breakType>Page</breakType>
                         </break>
                         <componentElement>
                                 <reportElement x="10" y="8" width="80" height="80" uuid="1740c4f3-03f7-4c6c-89d3-5c6a5d24a4d2"/>


### PR DESCRIPTION
## Summary
- update the inventory sticker report to use the JasperReports 6.20.6 break syntax
- ensure the report creates a page break so two stickers are generated sequentially

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d506e78028832bad0e00305bd6dc07