### PR TITLE
Add procedure metadata bindings to DAkkS report

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -87,12 +87,14 @@
 		<defaultValueExpression><![CDATA["V0.8.2"]]></defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
-		<![CDATA[SELECT COALESCE(c.$P!{Cert_field}, "") AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C2327, DATE_FORMAT(C2301, '%Y-%m') AS cal_date, CONCAT(cu.K4602, IF(cu.K4603 IS NOT NULL, CONCAT("\n", cu.K4603), ""), "\n", cu.K4606, " ", cu.k4604) AS customer,
+		<![CDATA[SELECT COALESCE(c.$P!{Cert_field}, "") AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C2327, COALESCE(c.C2320, "") AS C2320, DATE_FORMAT(C2301, '%Y-%m') AS cal_date, CONCAT(cu.K4602, IF(cu.K4603 IS NOT NULL, CONCAT("\n", cu.K4603), ""), "\n", cu.K4606, " ", cu.k4604) AS customer,
 COALESCE(i.I4204, "") AS I4204, COALESCE(i.I4202, "") AS I4202, COALESCE(i.I4203, "") AS I4203, COALESCE(i.I4201, "") AS I4201, COALESCE(i.I4206, "") AS I4206, IF(i.I4224 IS NOT NULL AND i.I4224 != "", DATE_FORMAT(i.I4224, '%Y-%m-%d'), NULL) AS I4224,
-c.C2301, COALESCE(c.C2314, "--") AS C2314, COALESCE(c.C2308, "") AS C2308, COALESCE(c.C2311, "--") AS C2311, COALESCE(c.C2312, "--") AS C2312
+c.C2301, COALESCE(c.C2314, "--") AS C2314, COALESCE(c.C2308, "") AS C2308, COALESCE(c.C2311, "--") AS C2311, COALESCE(c.C2312, "--") AS C2312,
+p.procedure_name, p.calibration_item, p.calibration_method, p.procedure_description, p.measurement_conditions, p.standards, p.scope
 FROM $P!{PrefixTable}calibration c
 LEFT JOIN $P!{PrefixTable}inventory i on i.MTAG=c.MTAG
 LEFT JOIN $P!{PrefixTable}customers cu on cu.KTAG=i.ktag
+LEFT JOIN $P!{PrefixTable}procedures p ON p.procedure_name = c.C2320
 WHERE c.CTAG=$P{P_CTAG}]]>
 	</queryString>
 	<field name="C2301" class="java.util.Date"/>
@@ -101,8 +103,9 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<field name="C2311" class="java.lang.String"/>
 	<field name="C2312" class="java.lang.String"/>
 	<field name="C2314" class="java.lang.String"/>
-	<field name="C2327" class="java.lang.String"/>
-	<field name="cert_field" class="java.lang.String"/>
+        <field name="C2327" class="java.lang.String"/>
+        <field name="C2320" class="java.lang.String"/>
+        <field name="cert_field" class="java.lang.String"/>
 	<field name="cal_date" class="java.lang.String"/>
 	<field name="customer" class="java.lang.String"/>
 	<field name="I4201" class="java.lang.String"/>
@@ -110,7 +113,14 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<field name="I4203" class="java.lang.String"/>
 	<field name="I4204" class="java.lang.String"/>
 	<field name="I4206" class="java.lang.String"/>
-	<field name="I4224" class="java.util.Date"/>
+        <field name="I4224" class="java.util.Date"/>
+        <field name="procedure_name" class="java.lang.String"/>
+        <field name="calibration_item" class="java.lang.String"/>
+        <field name="calibration_method" class="java.lang.String"/>
+        <field name="procedure_description" class="java.lang.String"/>
+        <field name="measurement_conditions" class="java.lang.String"/>
+        <field name="standards" class="java.lang.String"/>
+        <field name="scope" class="java.lang.String"/>
 	<variable name="title" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Kalibrierschein" : "Calibration Certificate"]]></variableExpression>
 	</variable>
@@ -204,13 +214,72 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 	<variable name="Group_header_4a" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "MESSERGEBNISSE" : "MEASUREMENTS RESULTS"]]></variableExpression>
 	</variable>
-	<variable name="Foundleft" class="java.lang.String" resetType="None">
-		<variableExpression><![CDATA[($F{C2308} != null && $F{C2308}.equals("AS-FOUND")) ? "Der Ergebnisbericht beschreibt den Zustand des Gerätes bei Eingang nicht jedoch bei Ausgang." 
+        <variable name="Foundleft" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{C2308} != null && $F{C2308}.equals("AS-FOUND")) ? "Der Ergebnisbericht beschreibt den Zustand des Gerätes bei Eingang nicht jedoch bei Ausgang."
 : ( ($F{C2308} != null && $F{C2308}.equals("AS-LEFT")) ? "Der Ergebnisbericht beschreibt den Zustand des Gerätes bei Ausgang nicht jedoch bei Eingang." : "Der Ergebnisbericht beschreibt den Zustand des Gerätes bei Eingang und bei Ausgang.")]]></variableExpression>
-	</variable>
-	<variable name="Group_header_1h_1" class="java.lang.String" resetType="None">
-		<variableExpression><![CDATA["im permanenten Labor"]]></variableExpression>
-	</variable>
+        </variable>
+        <variable name="procedure_name_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{procedure_name} != null && !$F{procedure_name}.trim().isEmpty())
+        ? $F{procedure_name}
+        : ($F{C2320} != null ? $F{C2320} : "")]]></variableExpression>
+        </variable>
+        <variable name="procedure_calibration_item_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{calibration_item} != null && !$F{calibration_item}.trim().isEmpty())
+        ? $F{calibration_item}
+        : ""]]></variableExpression>
+        </variable>
+        <variable name="procedure_description_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{procedure_description} != null && !$F{procedure_description}.trim().isEmpty())
+        ? $F{procedure_description}
+        : (
+            ($P{Calibration_procedure_1} == null || $P{Calibration_procedure_1}.trim().isEmpty())
+                ? (
+                    $P{Sprache}.equals("Deutsch")
+                        ? "Die Kalibrierung erfolgte durch Vergleich der durch die Normale dargestellten Werten mit der Anzeige des Digitalmultimeters. Bezug ist die Realisierung der Einheiten in der PTB. Die Kalibrierung erfolgte gemäß den Vorgaben des Herstellers im Service Guide 34401A (Part Nr. 34401-90013 Ed7.)"
+                        : "Calibration was performed by comparing the values represented by the normal values with the display of the digital multimeter. Reference is the realization of the units in the PTB. The calibration was carried out according to the specifications of the manufacturer in Service Guide 34401A (Part No. 34401-90013 Ed7.)"
+                )
+                : $P{Calibration_procedure_1}
+        )]]></variableExpression>
+        </variable>
+        <variable name="procedure_calibration_method_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{calibration_method} != null && !$F{calibration_method}.trim().isEmpty())
+        ? $F{calibration_method}
+        : (
+            ($P{Calibration_document} == null || $P{Calibration_document}.trim().isEmpty())
+                ? ($P{Sprache}.equals("Deutsch") ? "GA3 02xx VA Kalibrieren von Digitalmultimetern" : "GA3 02xx VA Calibration of digital multimeters")
+                : $P{Calibration_document}
+        )]]></variableExpression>
+        </variable>
+        <variable name="procedure_measurement_conditions_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{measurement_conditions} != null && !$F{measurement_conditions}.trim().isEmpty())
+        ? $F{measurement_conditions}
+        : "im permanenten Labor"]]></variableExpression>
+        </variable>
+        <variable name="procedure_standards_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{standards} != null && !$F{standards}.trim().isEmpty())
+        ? $F{standards}
+        : ""]]></variableExpression>
+        </variable>
+        <variable name="procedure_scope_var" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[($F{scope} != null && !$F{scope}.trim().isEmpty())
+        ? $F{scope}
+        : (
+            ($F{calibration_item} != null && !$F{calibration_item}.trim().isEmpty())
+                ? $F{calibration_item}
+                : (
+                    ($F{standards} != null && !$F{standards}.trim().isEmpty())
+                        ? $F{standards}
+                        : (
+                            ($P{Calibration_procedure_2} == null || $P{Calibration_procedure_2}.trim().isEmpty())
+                                ? ($P{Sprache}.equals("Deutsch") ? "GA3 0224  AA- Computergestützte Kalibrierung von Digitalmultimetern" : "GA3 0224 AA- Computer based calibration of digital multimeters")
+                                : $P{Calibration_procedure_2}
+                        )
+                )
+        )]]></variableExpression>
+        </variable>
+        <variable name="Group_header_1h_1" class="java.lang.String" resetType="None">
+                <variableExpression><![CDATA[$V{procedure_measurement_conditions_var}]]></variableExpression>
+        </variable>
 	<variable name="Group_header_1i_1" class="java.lang.String" resetType="None">
 		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Umgebungstemperatur:" : "Temperature"]]></variableExpression>
 	</variable>
@@ -318,12 +387,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 					<textElement>
 						<font fontName="SansSerif" size="10"/>
 					</textElement>
-					<textFieldExpression><![CDATA[( $P{Calibration_procedure_1} == null || $P{Calibration_procedure_1}.trim().isEmpty() )
-? ( $P{Sprache}.equals("Deutsch")
-    ? "Die Kalibrierung erfolgte durch Vergleich der durch die Normale dargestellten Werten mit der Anzeige des Digitalmultimeters. Bezug ist die Realisierung der Einheiten in der PTB. Die Kalibrierung erfolgte gemäß den Vorgaben des Herstellers im Service Guide 34401A (Part Nr. 34401-90013 Ed7.)"
-    : "Calibration was performed by comparing the values represented by the normal values with the display of the digital multimeter. Reference is the realization of the units in the PTB. The calibration was carried out according to the specifications of the manufacturer in Service Guide 34401A (Part No. 34401-90013 Ed7.)"
-  )
-: $P{Calibration_procedure_1}]]></textFieldExpression>
+                                        <textFieldExpression><![CDATA[$V{procedure_description_var}]]></textFieldExpression>
 				</textField>
 			</band>
 			<band height="62">
@@ -346,9 +410,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 					<textElement>
 						<font fontName="SansSerif" size="10"/>
 					</textElement>
-					<textFieldExpression><![CDATA[( $P{Calibration_document} == null || $P{Calibration_document}.trim().isEmpty() )
-? ( $P{Sprache}.equals("Deutsch") ? "GA3 02xx VA Kalibrieren von Digitalmultimetern" : "GA3 02xx VA Calibration of digital multimeters" )
-: $P{Calibration_document}]]></textFieldExpression>
+                                        <textFieldExpression><![CDATA[$V{procedure_calibration_method_var}]]></textFieldExpression>
 				</textField>
 			</band>
 			<band height="62">
@@ -371,9 +433,7 @@ WHERE c.CTAG=$P{P_CTAG}]]>
 					<textElement>
 						<font fontName="SansSerif" size="10"/>
 					</textElement>
-					<textFieldExpression><![CDATA[( $P{Calibration_procedure_2} == null || $P{Calibration_procedure_2}.trim().isEmpty() )
-? ( $P{Sprache}.equals("Deutsch") ? "GA3 0224  AA- Computergestützte Kalibrierung von Digitalmultimetern" : "GA3 0224 AA- Computer based calibration of digital multimeters" )
-: $P{Calibration_procedure_2}]]></textFieldExpression>
+                                        <textFieldExpression><![CDATA[$V{procedure_scope_var}]]></textFieldExpression>
 				</textField>
 			</band>
 			<band height="54">


### PR DESCRIPTION
## Summary
- join the procedures table to the DAkkS report dataset so calibration records can resolve their procedure metadata
- expose the resolved procedure fields as Jasper variables and use them to populate the calibration procedure, document, and work instruction sections
- keep the resolved measurement conditions available for reuse via the existing place of calibration variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63feea814832ba927c5ff267d2e57