### PR TITLE
Fix parentheses in pass/fail expression for report results

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -2764,7 +2764,8 @@
 					<textElement textAlignment="Right" verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
-					<textFieldExpression><![CDATA[($F{pass_fail}==null || $F{pass_fail}.trim().isEmpty())
+					<textFieldExpression><![CDATA[(
+              ($F{pass_fail}==null || $F{pass_fail}.trim().isEmpty())
               ? ""
               : (
                   $F{pass_fail}.trim().equalsIgnoreCase("pass")               ? "i.T." :
@@ -2773,6 +2774,7 @@
                   $F{pass_fail}.trim().equalsIgnoreCase("fail indeterminate") ? "!?" :
                   ""
                 )
+            )
             + ($V{AccredMark}==null ? "" : $V{AccredMark})]]></textFieldExpression>
 				</textField>
 			</frame>

--- a/DCC/subreports/DCC-Results.jrxml
+++ b/DCC/subreports/DCC-Results.jrxml
@@ -2563,7 +2563,8 @@
 					<textElement textAlignment="Right" verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
-					<textFieldExpression><![CDATA[($F{pass_fail}==null || $F{pass_fail}.trim().isEmpty())
+					<textFieldExpression><![CDATA[(
+              ($F{pass_fail}==null || $F{pass_fail}.trim().isEmpty())
               ? ""
               : (
                   $F{pass_fail}.trim().equalsIgnoreCase("pass")               ? "i.T." :
@@ -2572,6 +2573,7 @@
                   $F{pass_fail}.trim().equalsIgnoreCase("fail indeterminate") ? "!?" :
                   ""
                 )
+            )
             + ($V{AccredMark}==null ? "" : $V{AccredMark})]]></textFieldExpression>
 				</textField>
 			</frame>


### PR DESCRIPTION
## Summary
Fixed missing parentheses in JasperReports text field expressions that evaluate pass/fail status across multiple report templates.

## Key Changes
- Added opening parenthesis before the null/empty check condition in `Results.jrxml`
- Added closing parenthesis after the nested ternary operator in `Results.jrxml`
- Applied identical parentheses fix to `DCC-Results.jrxml` for consistency

## Implementation Details
The changes ensure proper operator precedence in the ternary conditional expression by wrapping the entire pass/fail evaluation logic in parentheses before concatenating with the `AccredMark` variable. This prevents potential evaluation issues where the string concatenation operator (`+`) could be evaluated before the ternary operator completes.

Both files received the same fix to maintain consistency across the report templates.

https://claude.ai/code/session_01VGYPMzK2fP1NPfpoReqbbh