### PR TITLE
Add Kalibrierkontrollblatt report with subreport and CI packaging/publishing

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -56,6 +56,15 @@ jobs:
             INVENTORY-SAMPLE/subreports
           if-no-files-found: error
 
+      - name: Upload KALIBRIERKONTROLLBLATT as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: KALIBRIERKONTROLLBLATT
+          path: |
+            KALIBRIERKONTROLLBLATT/main_reports
+            KALIBRIERKONTROLLBLATT/subreports
+          if-no-files-found: error
+
       - name: Upload DELIVERY-STANDALONE as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -243,6 +252,7 @@ jobs:
           create_zip "FIELD-NAMES" "field-names"
           create_zip "ORDER-SAMPLE" "order-sample"
           create_zip "INVENTORY-SAMPLE" "inventory-sample"
+          create_zip "KALIBRIERKONTROLLBLATT" "kalibrierkontrollblatt"
           create_zip "DELIVERY-STANDALONE" "delivery-standalone"
           create_zip "STICKERS/CAL-INV-STICKER_Zebra-ZD621_30x15-203dpi" "sticker-cal-inv-zebra-zd621-30x15-203dpi"
           create_zip "STICKERS/CAL-STICKER_Zebra-ZD621_30x15-203dpi" "sticker-cal-zebra-zd621-30x15-203dpi"
@@ -269,6 +279,7 @@ jobs:
           unzip -l zip_output/field-names.zip
           unzip -l zip_output/order-sample.zip
           unzip -l zip_output/inventory-sample.zip
+          unzip -l zip_output/kalibrierkontrollblatt.zip
           unzip -l zip_output/delivery-standalone.zip
           unzip -l zip_output/sticker-cal-inv-zebra-zd621-30x15-203dpi.zip
           unzip -l zip_output/sticker-cal-zebra-zd621-30x15-203dpi.zip

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -88,6 +88,7 @@ jobs:
           get_last_modified "FIELD-NAMES" "field-names"
           get_last_modified "ORDER-SAMPLE" "order-sample"
           get_last_modified "INVENTORY-SAMPLE" "inventory-sample"
+          get_last_modified "KALIBRIERKONTROLLBLATT" "kalibrierkontrollblatt"
           get_last_modified "DELIVERY-STANDALONE" "delivery-standalone"
           get_last_modified "STICKERS/CAL-INV-STICKER_Zebra-ZD621_30x15-203dpi" "sticker-cal-inv-zebra-zd621-30x15-203dpi"
           get_last_modified "STICKERS/CAL-STICKER_Zebra-ZD621_30x15-203dpi" "sticker-cal-zebra-zd621-30x15-203dpi"
@@ -156,6 +157,7 @@ jobs:
               "field-names":        "FIELD-NAMES/main_reports/README.md",
               "order-sample":       "ORDER-SAMPLE/main_reports/README.md",
               "inventory-sample":   "INVENTORY-SAMPLE/main_reports/README.md",
+              "kalibrierkontrollblatt": "KALIBRIERKONTROLLBLATT/main_reports/README.md",
               "delivery-standalone":"DELIVERY-STANDALONE/README.md",
               "trace-forward":     "TRACE-FORWARD/main_reports/README.md",
               "trace-backward":    "TRACE-BACKWARD/main_reports/README.md",

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -93,6 +93,7 @@ jobs:
           create_zip "FIELD-NAMES" "field-names"
           create_zip "ORDER-SAMPLE" "order-sample"
           create_zip "INVENTORY-SAMPLE" "inventory-sample"
+          create_zip "KALIBRIERKONTROLLBLATT" "kalibrierkontrollblatt"
           create_zip "DELIVERY-STANDALONE" "delivery-standalone"
           create_zip "STICKERS/CAL-INV-STICKER_Zebra-ZD621_30x15-203dpi" "sticker-cal-inv-zebra-zd621-30x15-203dpi"
           create_zip "STICKERS/CAL-STICKER_Zebra-ZD621_30x15-203dpi" "sticker-cal-zebra-zd621-30x15-203dpi"

--- a/KALIBRIERKONTROLLBLATT/main_reports/README.md
+++ b/KALIBRIERKONTROLLBLATT/main_reports/README.md
@@ -1,0 +1,12 @@
+# Kalibrierkontrollblatt
+
+Hauptreport für ein Kalibrierkontrollblatt inklusive Geräte- und Kundendaten.
+
+## Datei
+- `kalibrierkontrollblatt.jrxml`
+
+## Wichtige Parameter
+- `Reportpath`
+- `PrefixTable`
+- `Sprache`
+- `P_MTAG`

--- a/KALIBRIERKONTROLLBLATT/main_reports/kalibrierkontrollblatt.jrxml
+++ b/KALIBRIERKONTROLLBLATT/main_reports/kalibrierkontrollblatt.jrxml
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Inventory_0.1" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" isFloatColumnFooter="true" whenResourceMissingType="Empty" uuid="e59ec7b0-4a1b-436a-ac42-95f4c3c87ff8">
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="156"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="837"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="calserver"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="PrefixTable" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Sprache" class="java.lang.String">
+		<defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="P_MTAG" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="CurrentDate" class="java.util.Date" isForPrompting="false">
+		<defaultValueExpression><![CDATA[new Date()]]></defaultValueExpression>
+	</parameter>
+	<parameter name="QR_Code_Value" class="java.lang.String"/>
+	<queryString>
+		<![CDATA[SELECT i.MTAG, COALESCE(i.I4201, "") AS I4201, COALESCE(i.I4202, "") AS I4202, COALESCE(i.I4203, "") AS I4203, COALESCE(i.I4204, "") AS I4204, COALESCE(i.I4206, "") AS I4206, COALESCE(i.I4232, "") AS I4232, COALESCE(i.I4228, "") AS I4228, COALESCE(i.I4229, "") AS I4229, COALESCE(i.I4299, "") AS I4299,
+COALESCE(c.K4602, "") AS K4602, COALESCE(c.K4603, "") AS K4603, COALESCE(c.K4604, "") AS K4604, COALESCE(c.K4605, "") AS K4605, COALESCE(c.K4606, "") AS K4606, b.barcode_type, b.barcode_value, COALESCE(c.K4614, "") AS K4614, COALESCE(c.K4634, "") AS KST
+FROM $P!{PrefixTable}inventory i
+LEFT JOIN $P!{PrefixTable}customers c on i.ktag=c.KTAG
+LEFT JOIN $P!{PrefixTable}barcode b on i.MTAG=b.barcode_key
+WHERE i.MTAG=$P{P_MTAG}]]>
+	</queryString>
+	<field name="MTAG" class="java.lang.String"/>
+	<field name="I4201" class="java.lang.String"/>
+	<field name="I4202" class="java.lang.String"/>
+	<field name="I4203" class="java.lang.String"/>
+	<field name="I4204" class="java.lang.String"/>
+	<field name="I4206" class="java.lang.String"/>
+	<field name="I4232" class="java.lang.String"/>
+	<field name="I4228" class="java.lang.String"/>
+	<field name="I4229" class="java.lang.String"/>
+	<field name="I4299" class="java.lang.String"/>
+	<field name="K4602" class="java.lang.String"/>
+	<field name="K4603" class="java.lang.String"/>
+	<field name="K4604" class="java.lang.String"/>
+	<field name="K4605" class="java.lang.String"/>
+	<field name="K4606" class="java.lang.String"/>
+	<field name="barcode_type" class="java.lang.String"/>
+	<field name="barcode_value" class="java.lang.String"/>
+	<field name="K4614" class="java.lang.String"/>
+	<field name="KST" class="java.lang.String"/>
+	<variable name="Inventory_title" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[($P{Sprache}.equals("Deutsch") ? "Kalibrierkontrollblatt" : "Calibration control sheet: ")]]></variableExpression>
+	</variable>
+	<variable name="Barcode" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Barcode:" : "Barcode"]]></variableExpression>
+	</variable>
+	<variable name="Inventory_information" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Inventar informationen" : "Inventory information"]]></variableExpression>
+	</variable>
+	<variable name="Customer_information" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Kunden informationen" : "Customer information"]]></variableExpression>
+	</variable>
+	<variable name="Asset_number" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Prüfmittel Nr:" : "Asset Number"]]></variableExpression>
+	</variable>
+	<variable name="Serial_number" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "SN / Werk-Nr:" : "Serial Number"]]></variableExpression>
+	</variable>
+	<variable name="Manufacturer" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Hersteller:" : "Manufacturer"]]></variableExpression>
+	</variable>
+	<variable name="Model" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Modell:" : "Model"]]></variableExpression>
+	</variable>
+	<variable name="Description" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Beschreibung:" : "Description"]]></variableExpression>
+	</variable>
+	<variable name="Interval" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Intervall:" : "Intervall"]]></variableExpression>
+	</variable>
+	<variable name="F_Interval" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$F{I4229} + " " + $F{I4228}]]></variableExpression>
+	</variable>
+	<variable name="State_of_asset" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Zustand:" : "State of Asset"]]></variableExpression>
+	</variable>
+	<variable name="Customer_name" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Kunde:" : "Customer"]]></variableExpression>
+	</variable>
+	<variable name="Street" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Straße (Firma)" : "Street (Company)"]]></variableExpression>
+	</variable>
+	<variable name="City" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Ort" : "City"]]></variableExpression>
+	</variable>
+	<variable name="Country" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Land" : "Country"]]></variableExpression>
+	</variable>
+	<variable name="Zip" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "PLZ" : "Zip"]]></variableExpression>
+	</variable>
+	<variable name="Tel" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Tel. 02402-900180" : "Tel. 02402-900180"]]></variableExpression>
+	</variable>
+	<variable name="Fax" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Fax. 02402-27615" : "Fax. 02402-27615"]]></variableExpression>
+	</variable>
+	<title>
+		<band height="164" splitType="Stretch">
+			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+			<rectangle>
+				<reportElement stretchType="ContainerHeight" mode="Transparent" x="16" y="34" width="543" height="124" uuid="57f8e2b7-41b1-4221-868f-1fd20a9d76ae">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</rectangle>
+			<textField>
+				<reportElement x="400" y="102" width="58" height="20" uuid="64443f9f-09c8-4a57-82b2-0ffeb217ef2b">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Serial_number}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="161" y="132" width="77" height="20" uuid="c4328bd1-4cc5-4d56-be11-05914c90cdd8">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Manufacturer}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="161" y="101" width="77" height="20" uuid="993d5180-2365-4db3-80f6-86b0541b245b">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Model}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="160" y="71" width="78" height="20" uuid="0cb131ee-99a0-447b-b854-4b963f3273e4">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Description}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="160" y="40" width="78" height="20" uuid="d15750ec-ae55-4a7a-898b-128409a9ffe2">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Customer_name}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement stretchType="ContainerHeight" x="463" y="97" width="95" height="30" uuid="e43664a7-970d-45b4-84a2-adc4462e0b0a">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{I4206}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="132" width="169" height="20" uuid="9dbac371-ccea-4e5a-b71d-d09ba933236b">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{I4202}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="101" width="169" height="20" uuid="7ffd5e67-2ff5-4467-be2c-b9a42fde24d2">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{I4203}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="66" width="169" height="30" uuid="ff17bb9f-c246-44f9-b3e6-cbe9d060453f">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{I4204}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="157" y="34" width="1" height="124" uuid="1903bef4-f16f-4245-a95f-e2aabacd47e7">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement x="395" y="34" width="1" height="124" uuid="ed9f4cf0-8f60-4d74-aedd-37b085ca8083">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement x="158" y="66" width="237" height="1" uuid="5be16f3e-062c-46a5-9f9d-dcbb829821ec">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement x="158" y="96" width="237" height="1" uuid="04202673-a735-415c-aad3-4dd1770be273">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement x="158" y="126" width="237" height="1" uuid="5ebae67f-8b87-4a6c-8587-d691adb1f1a5">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement x="13" y="0" width="543" height="30" uuid="86dabf67-5fa7-468b-869c-3204b20496aa">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Carlito" size="16" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Inventory_title}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="396" y="96" width="163" height="1" uuid="e4b4b876-2d0a-465e-8c16-1ea8f6a0368c">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement x="396" y="126" width="163" height="1" uuid="d8e73004-b8c1-4653-aea7-ffe656261e52">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement stretchType="ContainerHeight" x="463" y="66" width="95" height="30" uuid="3bca21c9-26f6-4d69-affb-279eae048a67">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{I4232}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="400" y="133" width="58" height="20" uuid="c6d344c5-1c5d-44e0-bee8-0238240afac8"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Interval}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="463" y="127" width="95" height="30" uuid="4cccbe58-7a98-494e-8c28-79f97eec6d52"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{F_Interval}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="400" y="72" width="58" height="20" uuid="f4dea504-553e-4e0b-833f-2df48e790225">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Asset_number}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="39" y="135" width="98" height="20" uuid="c343b77f-dffa-443a-a87e-fc876bb3889c"/>
+				<textElement textAlignment="Center">
+					<font fontName="Arial" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Tel}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="40" y="146" width="97" height="10" uuid="0dfca516-e58f-4d2f-b401-c7aa5cecebcb"/>
+				<textElement textAlignment="Center">
+					<font fontName="Arial" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Fax}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="37" width="169" height="30" uuid="7e63fbed-8d0b-420c-a619-4ad1aa6184e5">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{K4614}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="396" y="66" width="163" height="1" uuid="d5239296-59c5-4ccb-a492-1791c25c2b34">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement x="400" y="41" width="58" height="20" uuid="0caf6eeb-caf9-4fb7-a981-f1de58194b08">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Kostenstelle:"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement stretchType="ContainerHeight" x="463" y="35" width="95" height="30" uuid="bb9f874f-45d9-4458-8386-89c9a03004d7"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{KST}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<detail>
+		<band height="29" splitType="Stretch">
+			<subreport isUsingCache="false">
+				<reportElement x="-7" y="4" width="566" height="20" uuid="bd3ae6b1-35cf-427c-8f6b-f307eb2749ba"/>
+				<subreportParameter name="PrefixTable">
+					<subreportParameterExpression><![CDATA[$P{PrefixTable}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="Sprache">
+					<subreportParameterExpression><![CDATA[$P{Sprache}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="P_MTAG">
+					<subreportParameterExpression><![CDATA[$P{P_MTAG}]]></subreportParameterExpression>
+				</subreportParameter>
+				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/Calibration-3.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="24" splitType="Stretch"/>
+	</pageFooter>
+	<lastPageFooter>
+		<band height="21"/>
+	</lastPageFooter>
+</jasperReport>

--- a/KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml
+++ b/KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Calibration" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="0" bottomMargin="0" uuid="c2964587-3815-4a67-a99a-4ff388cd57cc">
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="calserver"/>
+	<parameter name="PrefixTable" class="java.lang.String">
+		<defaultValueExpression><![CDATA["thermo_"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Sprache" class="java.lang.String">
+		<defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="P_MTAG" class="java.lang.String">
+		<defaultValueExpression><![CDATA["0000005005:1204109518"]]></defaultValueExpression>
+	</parameter>
+	<queryString language="SQL">
+		<![CDATA[SELECT C2301, COALESCE(C2314, "") AS C2314, COALESCE(C2341, "") AS C2341, COALESCE(C2307, "") AS C2307, COALESCE(C2303, "") AS C2303 
+FROM calibration	
+WHERE MTAG=$P{P_MTAG}
+order by  calserver.calibration.`C2301`  ASC]]>
+	</queryString>
+	<field name="C2301" class="java.lang.String"/>
+	<field name="C2314" class="java.lang.String"/>
+	<field name="C2341" class="java.lang.String"/>
+	<field name="C2307" class="java.lang.String"/>
+	<field name="C2303" class="java.lang.String"/>
+	<sortField name="C2301" order="Descending"/>
+	<variable name="Calibration_title" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Kalibrierungen" : "Calibrations"]]></variableExpression>
+	</variable>
+	<variable name="Cal_Date" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Datum" : "Date"]]></variableExpression>
+	</variable>
+	<variable name="Order_Number" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Auftrags-Nr" : "Order Number"]]></variableExpression>
+	</variable>
+	<variable name="Comment" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Befund / Bemerkung" : "Comment"]]></variableExpression>
+	</variable>
+	<variable name="C_Tech" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Prüfer" : "C-Tech"]]></variableExpression>
+	</variable>
+	<variable name="Next_DueDate" class="java.lang.String" resetType="None">
+		<variableExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? "Nächste Kal" : "Next Due"]]></variableExpression>
+	</variable>
+	<group name="calibration"/>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<pageHeader>
+		<band height="41">
+			<textField>
+				<reportElement mode="Opaque" x="3" y="10" width="71" height="30" forecolor="#000000" backcolor="#E8E6E6" uuid="8552b123-4d3d-4ed2-956e-9c31370eea02">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<box padding="5"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Cal_Date}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement mode="Opaque" x="74" y="10" width="69" height="30" backcolor="#E8E6E6" uuid="4478f8ba-efef-498f-b295-85959a8f3b85">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<box padding="5"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Order_Number}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement mode="Opaque" x="143" y="10" width="240" height="31" backcolor="#E8E6E6" uuid="0482c63b-2a1e-4230-90b7-ccfa1f270314">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<box padding="5"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Comment}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement mode="Opaque" x="383" y="10" width="98" height="31" backcolor="#E8E6E6" uuid="aaec2d34-7d24-43af-ac85-868969143139">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<box padding="5"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{C_Tech}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement mode="Opaque" x="481" y="10" width="65" height="31" backcolor="#E8E6E6" uuid="e3970d7c-0fe3-41f8-8371-e1db52b71126">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<box padding="5"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{Next_DueDate}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="3" y="10" width="543" height="1" uuid="0cbdcd99-9d66-4279-a821-11f0d33e68ca">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+		</band>
+	</pageHeader>
+	<detail>
+		<band height="32" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<textField textAdjust="StretchHeight" pattern="dd.mm.yyyy">
+				<reportElement stretchType="ContainerHeight" x="4" y="3" width="67" height="25" uuid="ffee13c8-d540-46c0-8a33-692d8fa613ae">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{C2301}]]></textFieldExpression>
+				<patternExpression><![CDATA[$F{C2301}]]></patternExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement stretchType="ContainerHeight" x="74" y="3" width="66" height="25" uuid="10c6d2e7-3e34-4eff-a70a-147355a4422d">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{C2314}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement stretchType="ContainerHeight" x="149" y="4" width="230" height="25" uuid="bb4da48e-b59e-4fd7-a0dd-412a7fbac8fb">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{C2341}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement stretchType="ContainerHeight" x="382" y="3" width="99" height="25" uuid="3d7bc564-ee06-4788-880d-7cea206d1593">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{C2307}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement stretchType="ContainerHeight" x="3" y="-30" width="1" height="61" uuid="590b409e-3b07-4add-9b17-cd4ecfe920b7">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement stretchType="ContainerHeight" x="73" y="-30" width="1" height="61" uuid="86bfcedd-a5b4-4b8f-bb25-080c32f4ad51">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement stretchType="ContainerHeight" x="143" y="-31" width="1" height="62" uuid="00f21411-ab17-4b83-98ee-8a5b460339ea">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement stretchType="ContainerHeight" x="382" y="-30" width="1" height="62" uuid="d57c4c79-e446-4770-a965-f0ebd14aa09d">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement stretchType="ContainerHeight" x="481" y="-30" width="1" height="61" uuid="501c5f94-af4c-4d17-8d72-5bff93699016">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement stretchType="ContainerHeight" x="546" y="-31" width="1" height="62" uuid="b8de98e2-4ed5-4f5a-bdad-bda5ec118f5c">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+			<line>
+				<reportElement x="3" y="-1" width="543" height="1" uuid="0e236f0e-b0d9-46ce-88c5-351d7db0f89d">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="10">
+			<line>
+				<reportElement x="3" y="-1" width="543" height="1" uuid="16e726c7-fbea-4bce-97ee-6a109c6a5305">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.5"/>
+				</graphicElement>
+			</line>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/KALIBRIERKONTROLLBLATT/subreports/README.md
+++ b/KALIBRIERKONTROLLBLATT/subreports/README.md
@@ -1,0 +1,6 @@
+# Subreports – Kalibrierkontrollblatt
+
+Enthält den Unterbericht mit Kalibrierhistorie für das Kalibrierkontrollblatt.
+
+## Datei
+- `Calibration-3.jrxml`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ INVENTORY-SAMPLE/
 ├── main_reports/       # Messmittelberichte & Inventarlisten
 └── subreports/         # Unterberichte für Messwerte, Historien usw.
 
+KALIBRIERKONTROLLBLATT/
+├── main_reports/       # Kalibrierkontrollblatt (Geräte- und Kundendaten)
+└── subreports/         # Kalibrierhistorie als Unterbericht
+
 ORDER-SAMPLE/
 ├── main_reports/       # Berichte für Aufträge, z. B. Angebots- oder Auftragsdokumente
 └── subreports/         # Unterberichte wie Positionslisten oder Summenfelder


### PR DESCRIPTION
### Motivation
- Add a new report package for a "Kalibrierkontrollblatt" (calibration control sheet) including a subreport for calibration history to match the existing DAKKS workflow.
- Automate packaging, release ZIP creation and GitHub Pages downloads metadata so the new report is included in CI artifacts and the project downloads site.

### Description
- Add `KALIBRIERKONTROLLBLATT` package with `main_reports/kalibrierkontrollblatt.jrxml`, `subreports/Calibration-3.jrxml`, and README files in both folders (`KALIBRIERKONTROLLBLATT/main_reports/README.md` and `KALIBRIERKONTROLLBLATT/subreports/README.md`).
- Integrate the new package into the packaging workflow by adding an artifact upload entry and `create_zip "KALIBRIERKONTROLLBLATT" "kalibrierkontrollblatt"` plus debug ZIP listing in `.github/workflows/package-reports.yml`.
- Include the package in release ZIP generation via `.github/workflows/release-reports.yml` by adding `create_zip "KALIBRIERKONTROLLBLATT" "kalibrierkontrollblatt"`.
- Add last-modified tracking and README mapping for the downloads site generation in `.github/workflows/publish-downloads.yml` and update the root `README.md` to document the new package.

### Testing
- Ran `scripts/check_jasper_version.sh` and confirmed that all JRXML files (including the new ones) report JasperReports Library version `6.20.6`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e11b0534832ba8029a839cfd1bea)