### PR TITLE
Enhance downloads filtering by category and description

### DIFF
--- a/downloads/assets/style.css
+++ b/downloads/assets/style.css
@@ -58,6 +58,8 @@ h1 {
 
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   justify-content: flex-end;
   margin-bottom: 16px;
 }
@@ -78,12 +80,26 @@ h1 {
   font-size: 0.95rem;
 }
 
+.search select {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #d5dbe7;
+  min-width: 220px;
+  font-size: 0.95rem;
+  background: #fff;
+}
+
 .card {
   background: #ffffff;
   padding: 8px 0;
   border-radius: 16px;
   box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
   overflow: hidden;
+}
+
+#downloads-sections {
+  display: grid;
+  gap: 16px;
 }
 
 .downloads {
@@ -141,6 +157,20 @@ h1 {
 @media (max-width: 860px) {
   .page__header {
     flex-direction: column;
+  }
+
+  .toolbar {
+    justify-content: stretch;
+  }
+
+  .search {
+    width: 100%;
+  }
+
+  .search input,
+  .search select {
+    min-width: 0;
+    width: 100%;
   }
 
   .downloads th:nth-child(3),

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -21,6 +21,12 @@
 
       <section class="toolbar">
         <label class="search">
+          <span>Kategorie</span>
+          <select id="category-filter" aria-label="Kategorie filtern">
+            <option value="">Alle</option>
+          </select>
+        </label>
+        <label class="search">
           <span>Suche</span>
           <input id="search" type="search" placeholder="Artefakte filtern…" />
         </label>
@@ -109,10 +115,11 @@
           "Weitere",
         ];
 
-        const renderRow = (artifact) => {
+        const renderRow = (artifact, category) => {
           const date = artifact.lastModified
             ? new Date(artifact.lastModified).toLocaleDateString()
             : "-";
+          const description = artifact.description || "";
           const downloadUrl = (() => {
             if (!artifact.url) return "#";
             try {
@@ -123,12 +130,16 @@
             }
           })();
           return `
-            <tr data-name="${artifact.name.toLowerCase()}">
+            <tr
+              data-name="${artifact.name.toLowerCase()}"
+              data-category="${category.toLowerCase()}"
+              data-description="${description.toLowerCase()}"
+            >
               <td>
                 <div class="artifact-name">${artifact.name}</div>
               </td>
               <td>
-                <span class="artifact-description">${artifact.description || ""}</span>
+                <span class="artifact-description">${description}</span>
               </td>
               <td>${artifact.filename}</td>
               <td>${bytesToSize(artifact.sizeBytes)}</td>
@@ -144,7 +155,9 @@
           .filter((category) => groupedArtifacts[category]?.length)
           .map((category) => {
             const artifacts = groupedArtifacts[category];
-            const rows = artifacts.map((artifact) => renderRow(artifact)).join("");
+            const rows = artifacts
+              .map((artifact) => renderRow(artifact, category))
+              .join("");
 
             return `
               <section class="card">
@@ -172,20 +185,47 @@
           sections.join("") ||
           `<section class="card"><table class="downloads"><tbody><tr><td colspan="6">Keine Artefakte gefunden.</td></tr></tbody></table></section>`;
 
+        const categoryFilter = document.getElementById("category-filter");
+        categoryFilter.innerHTML = `
+          <option value="">Alle</option>
+          ${categoryOrder
+            .filter((category) => groupedArtifacts[category]?.length)
+            .map(
+              (category) =>
+                `<option value="${category.toLowerCase()}">${category}</option>`
+            )
+            .join("")}
+        `;
+
         const search = document.getElementById("search");
-        search.addEventListener("input", (event) => {
-          const query = event.target.value.toLowerCase();
+        const applyFilters = () => {
+          const query = search.value.trim().toLowerCase();
+          const selectedCategory = categoryFilter.value;
           document.querySelectorAll("tbody tr[data-name]").forEach((row) => {
-            row.hidden = !row.dataset.name.includes(query);
+            const matchesQuery =
+              !query ||
+              row.dataset.name.includes(query) ||
+              row.dataset.category.includes(query) ||
+              row.dataset.description.includes(query);
+            const matchesCategory =
+              !selectedCategory || row.dataset.category === selectedCategory;
+            row.hidden = !(matchesQuery && matchesCategory);
           });
 
-          document.querySelectorAll("#downloads-sections section.card").forEach((section) => {
-            const rows = section.querySelectorAll("tbody tr[data-name]");
-            if (!rows.length) return;
-            const visibleCount = Array.from(rows).filter((row) => !row.hidden).length;
-            section.hidden = visibleCount === 0;
-          });
-        });
+          document
+            .querySelectorAll("#downloads-sections section.card")
+            .forEach((section) => {
+              const rows = section.querySelectorAll("tbody tr[data-name]");
+              if (!rows.length) return;
+              const visibleCount = Array.from(rows).filter(
+                (row) => !row.hidden
+              ).length;
+              section.hidden = visibleCount === 0;
+            });
+        };
+
+        search.addEventListener("input", applyFilters);
+        categoryFilter.addEventListener("change", applyFilters);
       };
 
       const primaryUrl = "./latest.json";


### PR DESCRIPTION
### Motivation
- Make the downloads page search more useful by matching user queries against artifact name, category and description. 
- Allow quick category-based narrowing with a compact dropdown while keeping text search combinable with the category filter. 
- Hide empty grouped categories when no contained artifacts match the active filters and keep the toolbar usable on small screens.

### Description
- Add `data-category` and `data-description` attributes to each rendered artifact row and populate them from the artifact metadata. 
- Extend the client-side filter to consider `name`, `category` and `description` when deciding matches and combine text search with a new category dropdown (`#category-filter`).
- Keep grouped category sections fully hidden when none of their rows are visible by updating the section-visibility calculation inside the combined filter function. 
- Update `downloads/assets/style.css` to make the toolbar wrap, add styles for the new select control, introduce grid spacing for sections and ensure the controls behave correctly under `@media (max-width: 860px)`.

### Testing
- Executed an inline script sanity check with Node to validate the embedded `<script>` syntax: `node -e "const fs=require('fs');const html=fs.readFileSync('downloads/index.html','utf8');const js=html.match(/<script>([\s\S]*)<\/script>/)[1];new Function(js);console.log('inline script syntax ok')"` which completed successfully.
- No browser/UI automation was run in this rollout (no headless browser tool available), so visual verification was not automated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1499e165c832ba9d8df494f8cce13)