### PR TITLE
Improve grouped downloads layout spacing and headers

### DIFF
--- a/downloads/assets/style.css
+++ b/downloads/assets/style.css
@@ -99,7 +99,7 @@ h1 {
 
 #downloads-sections {
   display: grid;
-  gap: 16px;
+  gap: 20px;
 }
 
 .downloads {
@@ -107,9 +107,20 @@ h1 {
   border-collapse: collapse;
 }
 
+.downloads-category__header {
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid #e6ebf2;
+}
+
+.downloads-category__header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  line-height: 1.3;
+}
+
 .downloads th,
 .downloads td {
-  padding: 16px 20px;
+  padding: 14px 18px;
   text-align: left;
   font-size: 0.95rem;
 }
@@ -171,6 +182,14 @@ h1 {
   .search select {
     min-width: 0;
     width: 100%;
+  }
+
+  #downloads-sections {
+    gap: 14px;
+  }
+
+  .downloads-category__header {
+    padding: 12px 14px;
   }
 
   .downloads th:nth-child(3),

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -161,7 +161,9 @@
 
             return `
               <section class="card">
-                <h2>${category} (${artifacts.length})</h2>
+                <div class="downloads-category__header">
+                  <h2>${category} (${artifacts.length})</h2>
+                </div>
                 <table class="downloads">
                   <thead>
                     <tr>


### PR DESCRIPTION
### Motivation
- Make grouped download cards visually clearer by adding vertical spacing and a distinct header area so categories read better and cards feel lighter.
- Keep the existing search/filter behavior intact so hidden sections do not leave empty gaps in the layout.

### Description
- Add a header wrapper in the card template: `<div class="downloads-category__header"><h2>…</h2></div>` in `downloads/index.html` to separate the category title from the table.
- Add `.downloads-category__header` CSS with `padding: 16px 20px 12px` and `border-bottom: 1px solid #e6ebf2`, and style its `h2` with `font-size: 1.15rem; margin: 0; line-height: 1.3` in `downloads/assets/style.css`.
- Increase card gap on desktop via `#downloads-sections { gap: 20px; }` and reduce it on mobile in an `@media (max-width: 860px)` block to `gap: 14px`.
- Reduce table cell padding from `16px 20px` to `14px 18px` in `.downloads th, .downloads td` to make cards feel airier.
- Add responsive header padding for mobile with `.downloads-category__header { padding: 12px 14px; }` inside the existing media query.
- Leave the filtering logic untouched; `section.hidden = visibleCount === 0` remains in `downloads/index.html` so hidden sections are removed from the layout flow.

### Testing
- Ran `git diff -- downloads/index.html downloads/assets/style.css` to inspect the exact changes and it matched intended edits.
- Ran `git diff --check` and `git status --short` with no issues reported.
- Inspected `downloads/index.html` to confirm the filtering code still uses `section.hidden = visibleCount === 0`, ensuring no empty gaps when sections are hidden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14b0ba368832b80d89801f0b31d55)