### PR TITLE
Fix SyntaxError in publish-downloads workflow heredoc

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -182,23 +182,23 @@ jobs:
           }
 
           INFO_TEMPLATE = """<!doctype html>
-          <html lang=\"de\">
+          <html lang="de">
             <head>
-              <meta charset=\"utf-8\" />
-              <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
               <title>{title} – Info</title>
-              <link rel=\"stylesheet\" href=\"../assets/style.css\" />
+              <link rel="stylesheet" href="../assets/style.css" />
             </head>
             <body>
-              <main class=\"page\">
-                <header class=\"page__header\">
+              <main class="page">
+                <header class="page__header">
                   <div>
-                    <p class=\"page__eyebrow\"><a href=\"../\">&larr; Zurück zu den Downloads</a></p>
+                    <p class="page__eyebrow"><a href="../">&larr; Zurück zu den Downloads</a></p>
                     <h1>{title}</h1>
-                    <p class=\"page__subhead\">Artefakt: <code>{artifact}</code></p>
+                    <p class="page__subhead">Artefakt: <code>{artifact}</code></p>
                   </div>
                 </header>
-                <section class=\"card report-info\">
+                <section class="card report-info">
                   {body}
                 </section>
               </main>
@@ -208,13 +208,13 @@ jobs:
 
           def render_info_page(artifact_name, readme_path):
               try:
-                  text = Path(readme_path).read_text(encoding=\"utf-8\")
+                  text = Path(readme_path).read_text(encoding="utf-8")
               except OSError:
                   return None
               body = md.markdown(
                   text,
-                  extensions=[\"extra\", \"sane_lists\", \"toc\", \"fenced_code\", \"tables\", \"codehilite\"],
-                  output_format=\"html5\",
+                  extensions=["extra", "sane_lists", "toc", "fenced_code", "tables", "codehilite"],
+                  output_format="html5",
               )
               title = TITLE_MAP.get(artifact_name, artifact_name)
               return INFO_TEMPLATE.format(


### PR DESCRIPTION
## Summary

Hotfix für den `publish-downloads`-Workflow. Der Python-Heredoc enthielt mehrfach `\"` außerhalb von String-Literalen (z. B. `read_text(encoding=\"utf-8\")`), was Python als ungültige Escape-Sequenz ablehnt:

```
text = Path(readme_path).read_text(encoding=\"utf-8\")
                                             ^
SyntaxError: unexpected character after line continuation character
```

Da der Heredoc mit `<<'PY'` (single quotes) eingeleitet wird, werden Anführungszeichen literal übernommen – das Backslash-Escaping ist unnötig und führt erst zum Fehler. Die Anführungszeichen wurden auf normales `"` zurückgeführt.

Lokal mit `ast.parse` validiert: `OK, parses`.

## Test plan

- [ ] Workflow `publish-downloads` (workflow_dispatch oder nächster Build) läuft ohne `SyntaxError` durch.
- [ ] `site/downloads/info/dakks-sample.html` wird korrekt gerendert.
- [ ] `latest.json` enthält weiterhin `infoUrl` für DAKKS.

https://claude.ai/code/session_01SQeneSkvxa2hEYkMUH8r9B


---
_Generated by [Claude Code](https://claude.ai/code/session_01SQeneSkvxa2hEYkMUH8r9B)_