### PR TITLE
Add stylized wireframe schema overlay to DAkkS info page

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -103,8 +103,8 @@ jobs:
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
 
-      - name: Install Markdown + image renderer
-        run: python -m pip install --upgrade "markdown==3.6" "Pygments==2.17.2" "Pillow==10.4.0"
+      - name: Install Markdown renderer
+        run: python -m pip install --upgrade "markdown==3.6" "Pygments==2.17.2"
 
       - name: Build downloads site
         env:
@@ -211,76 +211,101 @@ jobs:
           </html>
           """
 
-          def render_schema(artifact_name, schema_path, info_assets_dir):
+          def render_schema(artifact_name, schema_path):
               if not schema_path or not Path(schema_path).exists():
                   return ""
               data = json.loads(Path(schema_path).read_text(encoding="utf-8"))
-              vb = data.get("viewBox", {})
-              vw, vh = vb.get("width", 1000), vb.get("height", 1000)
-              regions = data.get("regions", [])
-              image_rel = data.get("image", "preview.jpg")
-              report_root = Path(schema_path).parent
-              image_src = report_root / image_rel
+              blocks = data.get("blocks", [])
+              if not blocks:
+                  return ""
 
-              # Scaled preview destination (relative to info_dir)
-              dest_dir = info_assets_dir / artifact_name
-              dest_dir.mkdir(parents=True, exist_ok=True)
-              dest_image = dest_dir / "preview.jpg"
-              try:
-                  from PIL import Image
-                  img = Image.open(image_src)
-                  img.thumbnail((1100, 6000))
-                  img.convert("RGB").save(dest_image, "JPEG", quality=80, optimize=True)
-              except Exception as exc:
-                  print(f"WARN: could not scale preview for {artifact_name}: {exc}")
-                  if image_src.exists():
-                      dest_image.write_bytes(Path(image_src).read_bytes())
-                  else:
-                      return ""
+              # Layout constants for the wireframe SVG.
+              vw = 600
+              pad_outer = 24
+              gap = 12
+              total_h = pad_outer + sum(b.get("height", 100) for b in blocks) + gap * (len(blocks) - 1) + pad_outer
+              vh = total_h
 
-              image_url = f"assets/{artifact_name}/preview.jpg"
-              original_url = data.get("originalUrl", "")
+              tone_styles = {
+                  "default":  ("#ffffff",      "#cdd6e4"),
+                  "accent":   ("#eaf0fb",      "#9bb3e8"),
+                  "highlight":("#fff7e6",      "#e6b86a"),
+              }
 
               hotspots, legend_items = [], []
-              for idx, r in enumerate(regions, start=1):
-                  rid = r.get("id", f"region-{idx}")
-                  label = r.get("label", rid)
-                  anchor = r.get("anchor", "")
-                  x, y, w, h = r.get("x", 0), r.get("y", 0), r.get("w", 0), r.get("h", 0)
-                  cx, cy = x + 70, y + 70
+              y = pad_outer
+              for idx, b in enumerate(blocks, start=1):
+                  bh = b.get("height", 100)
+                  label = b.get("label", b.get("id", f"Block {idx}"))
+                  subtitle = b.get("subtitle", "")
+                  anchor = b.get("anchor", "")
+                  params = b.get("params", []) or []
+                  fill, stroke = tone_styles.get(b.get("tone", "default"), tone_styles["default"])
                   esc_label = html.escape(label)
+                  esc_subtitle = html.escape(subtitle)
                   esc_anchor = html.escape(anchor, quote=True)
+                  x = pad_outer
+                  w = vw - 2 * pad_outer
+                  cx, cy = x + 36, y + 36
+
+                  # Parameter-Chips: nur die ersten 4–5 anzeigen, Rest mit "+N".
+                  visible = params[:5]
+                  remaining = len(params) - len(visible)
+                  chips_svg = []
+                  chip_x = x + 78
+                  chip_y = y + bh - 26
+                  for p in visible:
+                      width = max(60, 9 * len(p) + 18)
+                      chips_svg.append(
+                          f'<g class="schema-chip">'
+                          f'<rect x="{chip_x}" y="{chip_y - 16}" width="{width}" height="22" rx="11" />'
+                          f'<text x="{chip_x + width/2:.1f}" y="{chip_y - 1}" text-anchor="middle">{html.escape(p)}</text>'
+                          f'</g>'
+                      )
+                      chip_x += width + 6
+                  if remaining > 0:
+                      chips_svg.append(
+                          f'<g class="schema-chip schema-chip--more">'
+                          f'<rect x="{chip_x}" y="{chip_y - 16}" width="56" height="22" rx="11" />'
+                          f'<text x="{chip_x + 28}" y="{chip_y - 1}" text-anchor="middle">+{remaining}</text>'
+                          f'</g>'
+                      )
+
                   hotspots.append(
                       f'<a href="{esc_anchor}" class="report-schema__link">'
                       f'<title>{idx}. {esc_label}</title>'
-                      f'<rect class="hotspot" x="{x}" y="{y}" width="{w}" height="{h}" rx="18" />'
-                      f'<circle class="marker" cx="{cx}" cy="{cy}" r="55" />'
+                      f'<rect class="schema-block" x="{x}" y="{y}" width="{w}" height="{bh}" rx="14" '
+                      f'fill="{fill}" stroke="{stroke}" />'
+                      f'<circle class="marker" cx="{cx}" cy="{cy}" r="22" />'
                       f'<text class="marker-label" x="{cx}" y="{cy}" text-anchor="middle" '
                       f'dominant-baseline="central">{idx}</text>'
+                      f'<text class="schema-title" x="{x + 78}" y="{y + 32}">{esc_label}</text>'
+                      + (f'<text class="schema-subtitle" x="{x + 78}" y="{y + 54}">{esc_subtitle}</text>' if subtitle else '')
+                      + f'{"".join(chips_svg)}'
                       f'</a>'
                   )
+
+                  param_summary = ", ".join(params[:3]) + (f" …" if len(params) > 3 else "")
                   legend_items.append(
-                      f'<li><a href="{esc_anchor}"><span class="legend-num">{idx}</span> {esc_label}</a></li>'
+                      f'<li><a href="{esc_anchor}">'
+                      f'<span class="legend-num">{idx}</span>'
+                      f'<span class="legend-text"><strong>{esc_label}</strong>'
+                      + (f'<span class="legend-params">{html.escape(param_summary)}</span>' if param_summary else '')
+                      + f'</span></a></li>'
                   )
+                  y += bh + gap
 
-              original_link_html = (
-                  f'<p class="report-schema__original">'
-                  f'<a href="{html.escape(original_url, quote=True)}" target="_blank" rel="noopener">'
-                  f'Originalvorschau in voller Auflösung &rarr;</a></p>'
-                  if original_url else ""
-              )
-
+              schema_title = html.escape(data.get("title", "Aufbau des Berichts"))
               return (
                   '<section class="card report-schema">'
                   '<details open class="report-schema__panel">'
-                  '<summary>Schemabild – Parameter im Bericht verorten</summary>'
-                  '<p class="report-schema__hint">Klicke auf eine markierte Region oder auf eine Nummer in der Legende, '
-                  'um zur passenden Parametergruppe zu springen.</p>'
+                  f'<summary>{schema_title} – Parameter im Bericht verorten</summary>'
+                  '<p class="report-schema__hint">Klicke auf eine Region oder auf einen Eintrag in der Legende, '
+                  'um zur passenden Parametergruppe in der Tabelle zu springen.</p>'
                   '<div class="report-schema__layout">'
                   f'<div class="report-schema__stage">'
-                  f'<img src="{image_url}" alt="Schematische Vorschau des Berichts" loading="lazy" />'
                   f'<svg viewBox="0 0 {vw} {vh}" preserveAspectRatio="xMidYMid meet" '
-                  f'class="report-schema__svg" aria-label="Interaktives Schema">'
+                  f'class="report-schema__svg" role="img" aria-label="{schema_title}">'
                   f'{"".join(hotspots)}'
                   f'</svg>'
                   f'</div>'
@@ -288,7 +313,6 @@ jobs:
                   f'{"".join(legend_items)}'
                   '</ol>'
                   '</div>'
-                  f'{original_link_html}'
                   '</details>'
                   '</section>'
               )
@@ -349,8 +373,6 @@ jobs:
           metadata_path = Path("site/downloads/metadata.tsv")
           info_dir = Path("site/downloads/info")
           info_dir.mkdir(parents=True, exist_ok=True)
-          info_assets_dir = info_dir / "assets"
-          info_assets_dir.mkdir(parents=True, exist_ok=True)
           artifacts = []
           if metadata_path.exists():
               for line in metadata_path.read_text().splitlines():
@@ -358,7 +380,7 @@ jobs:
                   readme_path = README_MAP.get(name, "")
                   description = extract_description(readme_path)
                   info_url = None
-                  schema_html = render_schema(name, SCHEMA_MAP.get(name, ""), info_assets_dir)
+                  schema_html = render_schema(name, SCHEMA_MAP.get(name, ""))
                   if readme_path and Path(readme_path).exists():
                       page = render_info_page(name, readme_path, schema_html)
                       if page:

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -103,8 +103,8 @@ jobs:
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
 
-      - name: Install Markdown renderer
-        run: python -m pip install --upgrade "markdown==3.6" "Pygments==2.17.2"
+      - name: Install Markdown + image renderer
+        run: python -m pip install --upgrade "markdown==3.6" "Pygments==2.17.2" "Pillow==10.4.0"
 
       - name: Build downloads site
         env:
@@ -169,6 +169,10 @@ jobs:
               "trace-backward":    "TRACE-BACKWARD/main_reports/README.md",
           }
 
+          SCHEMA_MAP = {
+              "dakks-sample": "DAKKS-SAMPLE/schema.json",
+          }
+
           TITLE_MAP = {
               "dakks-sample":           "DAkkS-Kalibrierschein",
               "dcc-sample":             "DCC – Digitaler Kalibrierschein",
@@ -182,23 +186,24 @@ jobs:
           }
 
           INFO_TEMPLATE = """<!doctype html>
-          <html lang=\"de\">
+          <html lang="de">
             <head>
-              <meta charset=\"utf-8\" />
-              <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
               <title>{title} – Info</title>
-              <link rel=\"stylesheet\" href=\"../assets/style.css\" />
+              <link rel="stylesheet" href="../assets/style.css" />
             </head>
             <body>
-              <main class=\"page\">
-                <header class=\"page__header\">
+              <main class="page">
+                <header class="page__header">
                   <div>
-                    <p class=\"page__eyebrow\"><a href=\"../\">&larr; Zurück zu den Downloads</a></p>
+                    <p class="page__eyebrow"><a href="../">&larr; Zurück zu den Downloads</a></p>
                     <h1>{title}</h1>
-                    <p class=\"page__subhead\">Artefakt: <code>{artifact}</code></p>
+                    <p class="page__subhead">Artefakt: <code>{artifact}</code></p>
                   </div>
                 </header>
-                <section class=\"card report-info\">
+                {schema}
+                <section class="card report-info">
                   {body}
                 </section>
               </main>
@@ -206,20 +211,103 @@ jobs:
           </html>
           """
 
-          def render_info_page(artifact_name, readme_path):
+          def render_schema(artifact_name, schema_path, info_assets_dir):
+              if not schema_path or not Path(schema_path).exists():
+                  return ""
+              data = json.loads(Path(schema_path).read_text(encoding="utf-8"))
+              vb = data.get("viewBox", {})
+              vw, vh = vb.get("width", 1000), vb.get("height", 1000)
+              regions = data.get("regions", [])
+              image_rel = data.get("image", "preview.jpg")
+              report_root = Path(schema_path).parent
+              image_src = report_root / image_rel
+
+              # Scaled preview destination (relative to info_dir)
+              dest_dir = info_assets_dir / artifact_name
+              dest_dir.mkdir(parents=True, exist_ok=True)
+              dest_image = dest_dir / "preview.jpg"
               try:
-                  text = Path(readme_path).read_text(encoding=\"utf-8\")
+                  from PIL import Image
+                  img = Image.open(image_src)
+                  img.thumbnail((1100, 6000))
+                  img.convert("RGB").save(dest_image, "JPEG", quality=80, optimize=True)
+              except Exception as exc:
+                  print(f"WARN: could not scale preview for {artifact_name}: {exc}")
+                  if image_src.exists():
+                      dest_image.write_bytes(Path(image_src).read_bytes())
+                  else:
+                      return ""
+
+              image_url = f"assets/{artifact_name}/preview.jpg"
+              original_url = data.get("originalUrl", "")
+
+              hotspots, legend_items = [], []
+              for idx, r in enumerate(regions, start=1):
+                  rid = r.get("id", f"region-{idx}")
+                  label = r.get("label", rid)
+                  anchor = r.get("anchor", "")
+                  x, y, w, h = r.get("x", 0), r.get("y", 0), r.get("w", 0), r.get("h", 0)
+                  cx, cy = x + 70, y + 70
+                  esc_label = html.escape(label)
+                  esc_anchor = html.escape(anchor, quote=True)
+                  hotspots.append(
+                      f'<a href="{esc_anchor}" class="report-schema__link">'
+                      f'<title>{idx}. {esc_label}</title>'
+                      f'<rect class="hotspot" x="{x}" y="{y}" width="{w}" height="{h}" rx="18" />'
+                      f'<circle class="marker" cx="{cx}" cy="{cy}" r="55" />'
+                      f'<text class="marker-label" x="{cx}" y="{cy}" text-anchor="middle" '
+                      f'dominant-baseline="central">{idx}</text>'
+                      f'</a>'
+                  )
+                  legend_items.append(
+                      f'<li><a href="{esc_anchor}"><span class="legend-num">{idx}</span> {esc_label}</a></li>'
+                  )
+
+              original_link_html = (
+                  f'<p class="report-schema__original">'
+                  f'<a href="{html.escape(original_url, quote=True)}" target="_blank" rel="noopener">'
+                  f'Originalvorschau in voller Auflösung &rarr;</a></p>'
+                  if original_url else ""
+              )
+
+              return (
+                  '<section class="card report-schema">'
+                  '<details open class="report-schema__panel">'
+                  '<summary>Schemabild – Parameter im Bericht verorten</summary>'
+                  '<p class="report-schema__hint">Klicke auf eine markierte Region oder auf eine Nummer in der Legende, '
+                  'um zur passenden Parametergruppe zu springen.</p>'
+                  '<div class="report-schema__layout">'
+                  f'<div class="report-schema__stage">'
+                  f'<img src="{image_url}" alt="Schematische Vorschau des Berichts" loading="lazy" />'
+                  f'<svg viewBox="0 0 {vw} {vh}" preserveAspectRatio="xMidYMid meet" '
+                  f'class="report-schema__svg" aria-label="Interaktives Schema">'
+                  f'{"".join(hotspots)}'
+                  f'</svg>'
+                  f'</div>'
+                  '<ol class="report-schema__legend">'
+                  f'{"".join(legend_items)}'
+                  '</ol>'
+                  '</div>'
+                  f'{original_link_html}'
+                  '</details>'
+                  '</section>'
+              )
+
+          def render_info_page(artifact_name, readme_path, schema_html):
+              try:
+                  text = Path(readme_path).read_text(encoding="utf-8")
               except OSError:
                   return None
               body = md.markdown(
                   text,
-                  extensions=[\"extra\", \"sane_lists\", \"toc\", \"fenced_code\", \"tables\", \"codehilite\"],
-                  output_format=\"html5\",
+                  extensions=["extra", "sane_lists", "toc", "fenced_code", "tables", "codehilite", "attr_list"],
+                  output_format="html5",
               )
               title = TITLE_MAP.get(artifact_name, artifact_name)
               return INFO_TEMPLATE.format(
                   title=html.escape(title),
                   artifact=html.escape(artifact_name),
+                  schema=schema_html,
                   body=body,
               )
 
@@ -261,6 +349,8 @@ jobs:
           metadata_path = Path("site/downloads/metadata.tsv")
           info_dir = Path("site/downloads/info")
           info_dir.mkdir(parents=True, exist_ok=True)
+          info_assets_dir = info_dir / "assets"
+          info_assets_dir.mkdir(parents=True, exist_ok=True)
           artifacts = []
           if metadata_path.exists():
               for line in metadata_path.read_text().splitlines():
@@ -268,8 +358,9 @@ jobs:
                   readme_path = README_MAP.get(name, "")
                   description = extract_description(readme_path)
                   info_url = None
+                  schema_html = render_schema(name, SCHEMA_MAP.get(name, ""), info_assets_dir)
                   if readme_path and Path(readme_path).exists():
-                      page = render_info_page(name, readme_path)
+                      page = render_info_page(name, readme_path, schema_html)
                       if page:
                           info_file = info_dir / f"{name}.html"
                           info_file.write_text(page, encoding="utf-8")

--- a/DAKKS-SAMPLE/README.md
+++ b/DAKKS-SAMPLE/README.md
@@ -93,14 +93,14 @@ der JRXML-Datei und greifen automatisch, wenn der Parameter beim Aufruf nicht
 gesetzt wird. Die Spalte „Pflicht“ verwendet ✅ für zwingend erforderliche und ➖
 für optionale Parameter.
 
-### 4.1 Pflichtparameter
+### 4.1 Pflichtparameter {#params-required}
 
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
 | `P_CTAG` | ✅ | – | Schlüssel (CTAG) der Kalibrierung in der calServer-Datenbank. Steuert sämtliche Datenbank­abfragen im Haupt- und in den Unterberichten und entscheidet damit, welche Kalibrierung gedruckt wird. |
 | `Reportpath` | ✅ | `""` | Absolutes Basis­verzeichnis, in dem Haupt- und Unterberichte als `.jrxml`/`.jasper` liegen (typischerweise `.../DAKKS-SAMPLE`). Wird vom Hauptreport benötigt, um die Subreports `Standard` und `Results` zur Laufzeit auflösen zu können. |
 
-### 4.2 Mandanten-, Sprach- und Anzeige­parameter
+### 4.2 Mandanten-, Sprach- und Anzeige­parameter {#params-locale}
 
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
@@ -109,7 +109,7 @@ für optionale Parameter.
 | `ReportVersion` | ➖ | `V0.8.2` | Versions­kennzeichnung, die im Titelbereich des Berichts ausgegeben wird. |
 | `ReportVariantCode` | ➖ | `""` | Ressourcenname für die Layout­steuerung. Steht in `resource.report_template` für diesen Namen der Wert `1`, wird Variante `1` (mit Lücken) aktiviert; sonst läuft Variante `0` (Standard). Leer = Variante `0`. |
 
-### 4.3 Bilder, Codes und Akkreditierungs­block
+### 4.3 Bilder, Codes und Akkreditierungs­block {#params-images}
 
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
@@ -119,7 +119,7 @@ für optionale Parameter.
 | `MarkNumber2` | ➖ | `D-K-\nYYYYY-ZZ-N` | Zweite Markennummer (Akkreditierungs­kennung). `\n` erzeugt einen Zeilenumbruch im gedruckten Block. |
 | `sign_names` | ➖ | `Y` | Steuert die Anzeige der Namen im Unterschriftsbereich. Werte: `Y` (anzeigen, Default auch bei fehlendem Parameter) oder `N` (ausblenden). |
 
-### 4.4 Zertifikats- und Inhaltssteuerung
+### 4.4 Zertifikats- und Inhaltssteuerung {#params-content}
 
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
@@ -129,7 +129,7 @@ für optionale Parameter.
 | `ExpUncType` | ➖ | `""` | Freitext für ergänzende Hinweise zur erweiterten Messunsicherheit (z. B. `k=2`-Anmerkungen). |
 | `environmental_conditions` | ➖ | `""` | Optionaler Freitext für Umgebungs­temperatur und relative Luft­feuchte im Format `Text_Temperatur \| Text_Feuchte`. Ersetzt die Werte aus `C2311`/`C2312`, wenn angegeben. Ist ein Ressourcen­name übergeben, werden Temperatur und Feuchte aus `resource.environment_resources` derselben Zeile übernommen. |
 
-### 4.5 Normative Textbausteine
+### 4.5 Normative Textbausteine {#params-textblocks}
 
 Alle Textbaustein-Parameter sind optional. Sie sind im JRXML mit DAkkS-konformen
 Standard­formulierungen (de/en gemäß `Sprache`) vorbelegt; durch Übergabe eines
@@ -152,7 +152,7 @@ eigenen Werts wird der Standard überschrieben.
 | `Calibration_procedure_2` | ➖ | sprachabhängig | Zweiter Textbaustein zum Kalibrier­verfahren (z. B. Verweis auf Norm). |
 | `Calibration_document` | ➖ | sprachabhängig | Verweis auf Verfahrens­anweisung bzw. QMS-Dokument. |
 
-### 4.6 Abschnittsumschalter (`ShowGroup1*`)
+### 4.6 Abschnittsumschalter (`ShowGroup1*`) {#params-showgroup}
 
 Alle Abschnitts­parameter sind Strings (Default bzw. fehlender Parameter: `Y`)
 und können auf `Y` (anzeigen) oder `N` (ausblenden) gesetzt werden. Die Werte

--- a/DAKKS-SAMPLE/schema.json
+++ b/DAKKS-SAMPLE/schema.json
@@ -1,0 +1,90 @@
+{
+  "_comment": "Region-Koordinaten beziehen sich auf die Originalauflösung von preview.jpg (2379×8263). Werte sind eine Erstkalibrierung – falls einzelne Marker daneben sitzen, hier nachjustieren. Das SVG-Overlay skaliert automatisch mit; keine weiteren Änderungen nötig.",
+  "image": "preview.jpg",
+  "originalUrl": "https://github.com/calhelp/calServer-reports/blob/main/DAKKS-SAMPLE/preview.jpg",
+  "viewBox": { "width": 2379, "height": 8263 },
+  "regions": [
+    {
+      "id": "header",
+      "label": "Titel & Zertifikatsnummer",
+      "x": 120, "y": 60, "w": 2140, "h": 320,
+      "anchor": "#params-images",
+      "params": ["Cert_field", "QR_Code_Value", "ReportVersion"]
+    },
+    {
+      "id": "asset",
+      "label": "Messmittel-Stammdaten & Auftraggeber:in",
+      "x": 120, "y": 420, "w": 2140, "h": 520,
+      "anchor": "#params-textblocks",
+      "params": ["Asset_description", "P_CTAG"]
+    },
+    {
+      "id": "status",
+      "label": "Eingang, Zustand & Kalibrierdaten",
+      "x": 120, "y": 970, "w": 2140, "h": 380,
+      "anchor": "#params-showgroup",
+      "params": ["ShowGroup1IncomingDate", "ShowGroup1Condition"]
+    },
+    {
+      "id": "procedure",
+      "label": "Verfahren, Messbedingungen & Umgebung",
+      "x": 120, "y": 1380, "w": 2140, "h": 900,
+      "anchor": "#params-showgroup",
+      "params": [
+        "ShowGroup1Procedure",
+        "ShowGroup1ProcedureDocument",
+        "ShowGroup1MeasurementConditions",
+        "ShowGroup1EnvironmentalConditions",
+        "Calibration_procedure_1",
+        "Calibration_procedure_2",
+        "Calibration_document",
+        "environmental_conditions"
+      ]
+    },
+    {
+      "id": "standards",
+      "label": "Eingesetzte Normale (Subreport Standard)",
+      "x": 120, "y": 2310, "w": 2140, "h": 620,
+      "anchor": "#5-unterberichte",
+      "params": ["ShowGroup1StandardsTraceability"]
+    },
+    {
+      "id": "results",
+      "label": "Messergebnisse (Subreport Results)",
+      "x": 120, "y": 2960, "w": 2140, "h": 2400,
+      "anchor": "#params-content",
+      "params": [
+        "MeasurementDetails",
+        "ModernResultsHeader",
+        "ShowGroup1ResultsDetails",
+        "Results_description"
+      ]
+    },
+    {
+      "id": "conformity",
+      "label": "Messunsicherheit, Konformität & Zusatzhinweise",
+      "x": 120, "y": 5390, "w": 2140, "h": 1200,
+      "anchor": "#params-textblocks",
+      "params": [
+        "Uncertainty_description",
+        "Measurements_description",
+        "Measurements_description_1",
+        "Conformity_description_1",
+        "Conformity_description_2",
+        "Conformity_description_3",
+        "Additional_information",
+        "ExpUncType",
+        "ShowGroup1MeasurementUncertainty",
+        "ShowGroup1Conformity",
+        "ShowGroup1AdditionalInformation"
+      ]
+    },
+    {
+      "id": "accreditation",
+      "label": "DAkkS-Akkreditierung & Unterschriften",
+      "x": 120, "y": 6620, "w": 2140, "h": 1560,
+      "anchor": "#params-images",
+      "params": ["MarkNumber1", "MarkNumber2", "P_Image_Path", "sign_names"]
+    }
+  ]
+}

--- a/DAKKS-SAMPLE/schema.json
+++ b/DAKKS-SAMPLE/schema.json
@@ -1,69 +1,78 @@
 {
-  "_comment": "Region-Koordinaten beziehen sich auf die Originalauflösung von preview.jpg (2379×8263). Werte sind eine Erstkalibrierung – falls einzelne Marker daneben sitzen, hier nachjustieren. Das SVG-Overlay skaliert automatisch mit; keine weiteren Änderungen nötig.",
-  "image": "preview.jpg",
-  "originalUrl": "https://github.com/calhelp/calServer-reports/blob/main/DAKKS-SAMPLE/preview.jpg",
-  "viewBox": { "width": 2379, "height": 8263 },
-  "regions": [
+  "_comment": "Stilisiertes Wireframe der Berichtsstruktur. Blöcke werden zur Build-Zeit vertikal als SVG gestapelt; height ist das Höhenverhältnis innerhalb der Skizze. anchor verlinkt auf die passende Parametergruppe in der Info-Seite.",
+  "title": "Aufbau des DAkkS-Kalibrierscheins",
+  "blocks": [
     {
       "id": "header",
       "label": "Titel & Zertifikatsnummer",
-      "x": 120, "y": 60, "w": 2140, "h": 320,
+      "subtitle": "Kopfbereich, Akkreditierungssiegel",
       "anchor": "#params-images",
-      "params": ["Cert_field", "QR_Code_Value", "ReportVersion"]
+      "params": ["Cert_field", "QR_Code_Value", "ReportVersion", "P_Image_Path"],
+      "height": 90,
+      "tone": "accent"
     },
     {
       "id": "asset",
-      "label": "Messmittel-Stammdaten & Auftraggeber:in",
-      "x": 120, "y": 420, "w": 2140, "h": 520,
+      "label": "Messmittel-Stammdaten",
+      "subtitle": "Bezeichnung, Typ, Inventar-/Seriennummer",
       "anchor": "#params-textblocks",
-      "params": ["Asset_description", "P_CTAG"]
+      "params": ["Asset_description"],
+      "height": 110
     },
     {
-      "id": "status",
-      "label": "Eingang, Zustand & Kalibrierdaten",
-      "x": 120, "y": 970, "w": 2140, "h": 380,
-      "anchor": "#params-showgroup",
-      "params": ["ShowGroup1IncomingDate", "ShowGroup1Condition"]
+      "id": "customer",
+      "label": "Auftraggeber:in & Kalibrierdatum",
+      "subtitle": "Kunde, Adresse, interne Referenzen",
+      "anchor": "#params-required",
+      "params": ["P_CTAG", "PrefixTable", "Sprache"],
+      "height": 100
     },
     {
       "id": "procedure",
-      "label": "Verfahren, Messbedingungen & Umgebung",
-      "x": 120, "y": 1380, "w": 2140, "h": 900,
+      "label": "Verfahren · Messbedingungen · Umgebung",
+      "subtitle": "Eingang, Zustand, Ort, Umgebungsbedingungen",
       "anchor": "#params-showgroup",
       "params": [
         "ShowGroup1Procedure",
         "ShowGroup1ProcedureDocument",
         "ShowGroup1MeasurementConditions",
         "ShowGroup1EnvironmentalConditions",
+        "ShowGroup1IncomingDate",
+        "ShowGroup1Condition",
         "Calibration_procedure_1",
         "Calibration_procedure_2",
         "Calibration_document",
         "environmental_conditions"
-      ]
+      ],
+      "height": 150
     },
     {
       "id": "standards",
-      "label": "Eingesetzte Normale (Subreport Standard)",
-      "x": 120, "y": 2310, "w": 2140, "h": 620,
+      "label": "Eingesetzte Normale",
+      "subtitle": "Subreport Standard.jrxml · Rückführbarkeit",
       "anchor": "#5-unterberichte",
-      "params": ["ShowGroup1StandardsTraceability"]
+      "params": ["ShowGroup1StandardsTraceability", "Cert_description", "Cert_description_1"],
+      "height": 110
     },
     {
       "id": "results",
-      "label": "Messergebnisse (Subreport Results)",
-      "x": 120, "y": 2960, "w": 2140, "h": 2400,
+      "label": "Messergebnisse",
+      "subtitle": "Subreport Results.jrxml · Toleranzen, Unsicherheit",
       "anchor": "#params-content",
       "params": [
         "MeasurementDetails",
         "ModernResultsHeader",
         "ShowGroup1ResultsDetails",
+        "ShowGroup1ResultsIntro",
         "Results_description"
-      ]
+      ],
+      "height": 200,
+      "tone": "highlight"
     },
     {
-      "id": "conformity",
-      "label": "Messunsicherheit, Konformität & Zusatzhinweise",
-      "x": 120, "y": 5390, "w": 2140, "h": 1200,
+      "id": "uncertainty",
+      "label": "Messunsicherheit & Konformität",
+      "subtitle": "GUM-Hinweise, Symbol-Legende, weitere Hinweise",
       "anchor": "#params-textblocks",
       "params": [
         "Uncertainty_description",
@@ -77,14 +86,17 @@
         "ShowGroup1MeasurementUncertainty",
         "ShowGroup1Conformity",
         "ShowGroup1AdditionalInformation"
-      ]
+      ],
+      "height": 140
     },
     {
-      "id": "accreditation",
-      "label": "DAkkS-Akkreditierung & Unterschriften",
-      "x": 120, "y": 6620, "w": 2140, "h": 1560,
+      "id": "footer",
+      "label": "Akkreditierung & Unterschriften",
+      "subtitle": "Markennummern, DAkkS-Logo, Signaturen",
       "anchor": "#params-images",
-      "params": ["MarkNumber1", "MarkNumber2", "P_Image_Path", "sign_names"]
+      "params": ["MarkNumber1", "MarkNumber2", "sign_names", "P_Image_Path"],
+      "height": 100,
+      "tone": "accent"
     }
   ]
 }

--- a/downloads/assets/style.css
+++ b/downloads/assets/style.css
@@ -322,25 +322,17 @@ h1 {
 }
 
 .report-schema__stage {
-  position: relative;
   width: 100%;
-  background: #f5f7fb;
-  border-radius: 12px;
-  overflow: hidden;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+  border-radius: 14px;
   border: 1px solid #e1e7f0;
-}
-
-.report-schema__stage img {
-  width: 100%;
-  display: block;
-  height: auto;
+  padding: 14px;
 }
 
 .report-schema__svg {
-  position: absolute;
-  inset: 0;
   width: 100%;
-  height: 100%;
+  height: auto;
+  display: block;
 }
 
 .report-schema__link {
@@ -348,25 +340,22 @@ h1 {
   outline: none;
 }
 
-.report-schema__link .hotspot {
-  fill: rgba(29, 78, 216, 0.06);
-  stroke: rgba(29, 78, 216, 0.55);
-  stroke-width: 6;
-  stroke-dasharray: 14 8;
-  transition: fill 0.15s ease, stroke 0.15s ease;
+.report-schema__link .schema-block {
+  stroke-width: 1.5;
+  transition: filter 0.15s ease, stroke 0.15s ease;
+  filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.08));
 }
 
-.report-schema__link:hover .hotspot,
-.report-schema__link:focus .hotspot {
-  fill: rgba(29, 78, 216, 0.18);
-  stroke: rgba(29, 78, 216, 0.95);
+.report-schema__link:hover .schema-block,
+.report-schema__link:focus .schema-block {
+  stroke: #1d4ed8;
+  filter: drop-shadow(0 6px 14px rgba(29, 78, 216, 0.22));
 }
 
 .report-schema__link .marker {
   fill: #1d4ed8;
   stroke: #ffffff;
-  stroke-width: 6;
-  filter: drop-shadow(0 6px 14px rgba(15, 23, 42, 0.25));
+  stroke-width: 2.5;
   transition: fill 0.15s ease, transform 0.15s ease;
   transform-origin: center;
   transform-box: fill-box;
@@ -375,15 +364,53 @@ h1 {
 .report-schema__link:hover .marker,
 .report-schema__link:focus .marker {
   fill: #15348a;
-  transform: scale(1.08);
+  transform: scale(1.1);
 }
 
 .report-schema__link .marker-label {
   fill: #ffffff;
   font-weight: 700;
-  font-size: 64px;
+  font-size: 18px;
   pointer-events: none;
   font-family: "Inter", system-ui, sans-serif;
+}
+
+.report-schema__link .schema-title {
+  fill: #1f2a44;
+  font-weight: 600;
+  font-size: 16px;
+  font-family: "Inter", system-ui, sans-serif;
+  pointer-events: none;
+}
+
+.report-schema__link .schema-subtitle {
+  fill: #4e5d78;
+  font-size: 12px;
+  font-family: "Inter", system-ui, sans-serif;
+  pointer-events: none;
+}
+
+.report-schema__link .schema-chip rect {
+  fill: rgba(29, 78, 216, 0.1);
+  stroke: rgba(29, 78, 216, 0.35);
+  stroke-width: 1;
+}
+
+.report-schema__link .schema-chip text {
+  fill: #1d4ed8;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: "Inter", system-ui, sans-serif;
+  pointer-events: none;
+}
+
+.report-schema__link .schema-chip--more rect {
+  fill: rgba(75, 85, 99, 0.1);
+  stroke: rgba(75, 85, 99, 0.35);
+}
+
+.report-schema__link .schema-chip--more text {
+  fill: #475569;
 }
 
 .report-schema__legend {
@@ -399,13 +426,26 @@ h1 {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 8px 12px;
+  padding: 10px 12px;
   border-radius: 10px;
   text-decoration: none;
   color: #1f2a44;
   background: #f5f7fb;
   border: 1px solid transparent;
   transition: background 0.15s ease, border-color 0.15s ease;
+  line-height: 1.35;
+}
+
+.report-schema__legend .legend-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.report-schema__legend .legend-params {
+  font-size: 0.8rem;
+  color: #4e5d78;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
 .report-schema__legend a:hover {

--- a/downloads/assets/style.css
+++ b/downloads/assets/style.css
@@ -279,6 +279,169 @@ h1 {
   margin: 2em 0;
 }
 
+.report-schema {
+  padding: 24px 28px;
+  margin-bottom: 24px;
+}
+
+.report-schema__panel > summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1.1rem;
+  padding: 4px 0 12px;
+  color: #1f2a44;
+  list-style: none;
+}
+
+.report-schema__panel > summary::-webkit-details-marker {
+  display: none;
+}
+
+.report-schema__panel > summary::before {
+  content: "▾";
+  display: inline-block;
+  margin-right: 8px;
+  transition: transform 0.2s ease;
+}
+
+.report-schema__panel:not([open]) > summary::before {
+  transform: rotate(-90deg);
+}
+
+.report-schema__hint {
+  margin: 0 0 16px;
+  color: #4e5d78;
+  font-size: 0.95rem;
+}
+
+.report-schema__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+  gap: 24px;
+  align-items: start;
+}
+
+.report-schema__stage {
+  position: relative;
+  width: 100%;
+  background: #f5f7fb;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e1e7f0;
+}
+
+.report-schema__stage img {
+  width: 100%;
+  display: block;
+  height: auto;
+}
+
+.report-schema__svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.report-schema__link {
+  cursor: pointer;
+  outline: none;
+}
+
+.report-schema__link .hotspot {
+  fill: rgba(29, 78, 216, 0.06);
+  stroke: rgba(29, 78, 216, 0.55);
+  stroke-width: 6;
+  stroke-dasharray: 14 8;
+  transition: fill 0.15s ease, stroke 0.15s ease;
+}
+
+.report-schema__link:hover .hotspot,
+.report-schema__link:focus .hotspot {
+  fill: rgba(29, 78, 216, 0.18);
+  stroke: rgba(29, 78, 216, 0.95);
+}
+
+.report-schema__link .marker {
+  fill: #1d4ed8;
+  stroke: #ffffff;
+  stroke-width: 6;
+  filter: drop-shadow(0 6px 14px rgba(15, 23, 42, 0.25));
+  transition: fill 0.15s ease, transform 0.15s ease;
+  transform-origin: center;
+  transform-box: fill-box;
+}
+
+.report-schema__link:hover .marker,
+.report-schema__link:focus .marker {
+  fill: #15348a;
+  transform: scale(1.08);
+}
+
+.report-schema__link .marker-label {
+  fill: #ffffff;
+  font-weight: 700;
+  font-size: 64px;
+  pointer-events: none;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+.report-schema__legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+  font-size: 0.92rem;
+}
+
+.report-schema__legend a {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  text-decoration: none;
+  color: #1f2a44;
+  background: #f5f7fb;
+  border: 1px solid transparent;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.report-schema__legend a:hover {
+  background: #eaf0fb;
+  border-color: rgba(29, 78, 216, 0.4);
+}
+
+.report-schema__legend .legend-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #1d4ed8;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.report-schema__original {
+  margin: 16px 0 0;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 860px) {
+  .report-schema__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .report-schema {
+    padding: 18px 16px;
+  }
+}
+
 @media (max-width: 860px) {
   .page__header {
     flex-direction: column;


### PR DESCRIPTION
## Summary

Erweitert die DAkkS-Info-Seite um ein **kompaktes, interaktives Schemabild**: statt der echten Berichtsvorschau wird ein stilisiertes SVG-Wireframe der Berichtsstruktur gerendert. Jeder Block ist klickbar und scrollt zu der passenden Parametergruppe in der Tabelle.

Vorteile gegenüber dem ersten Wurf (preview.jpg + Hotspots):
- robust ohne Pixel-Kalibrierung,
- ~1000 px hoch statt 8263 px,
- ohne `Pillow`-Abhängigkeit,
- druckbar und kontrastreich.

### Änderungen

- **`DAKKS-SAMPLE/schema.json`** *(neu)*: Blockbasierte Struktur – `label`, `subtitle`, `height`, `params`, `anchor`, `tone`. 8 Bereiche (Header → Akkreditierung).
- **`DAKKS-SAMPLE/README.md`**: Stabile Anker `{#params-required | locale | images | content | textblocks | showgroup}` an den §4-Untertiteln (`attr_list`-Extension).
- **`.github/workflows/publish-downloads.yml`**:
  - `SCHEMA_MAP` (zunächst nur `dakks-sample`) steuert, für welche Artefakte ein Wireframe gerendert wird.
  - `render_schema()` stapelt die Blöcke automatisch vertikal in einer 600 px breiten SVG-Vorlage. Jeder Block bekommt einen Marker-Kreis, Titel, Subtitel und bis zu 5 Parameter-Chips (mit „+N"-Hinweis bei Überlauf).
  - `markdown` zusätzlich mit `attr_list`.
- **`downloads/assets/style.css`**: `.report-schema__*`, `schema-block`, `schema-chip`, Hover-/Focus-Stile, responsives 2-Spalten-Layout (Legende rückt unter 860 px unter das Schema).

### Generisch

Weitere Berichte können später einfach angedockt werden: neue `schema.json` mit `blocks` + Eintrag in `SCHEMA_MAP`. Fehlt eine `schema.json`, wird die Schema-Sektion stillschweigend weggelassen.

> Hinweis: Dieser Branch wurde von `main` vor PR #469 (Hotfix für den `\"`-SyntaxError) abgezweigt und enthält die identische Korrektur als Teil dieses PR. Nach Mergen von #469 ggf. trivial rebasen.

## Test plan

- [ ] Workflow `publish-downloads` läuft (workflow_dispatch oder nächster Build).
- [ ] `site/downloads/info/dakks-sample.html` zeigt direkt unter dem Header ein `<details>`-Panel:
  - 8 nummerierte Blöcke mit Titel, Subtitel und Parameter-Chips,
  - Klick auf Block oder Legende springt zum passenden Anker (§4.1, §4.3, §4.4, §4.5, §4.6, §5),
  - Hover-/Focus-State hebt den Block deutlich hervor.
- [ ] Responsive: <860 px Viewport → Legende rückt unter das Schema; Marker bleiben sauber positioniert.
- [ ] `latest.json` enthält weiterhin `infoUrl` für `dakks-sample`.
- [ ] Lokal getestet: 8 Hotspots, 8 Legendeneinträge, 30 Parameter-Chips, alle Anker korrekt gerendert.

https://claude.ai/code/session_01SQeneSkvxa2hEYkMUH8r9B
