### PR TITLE
Remove redundant closing sentence from INVENTORY-SAMPLE README

### DIFF
--- a/INVENTORY-SAMPLE/main_reports/README.md
+++ b/INVENTORY-SAMPLE/main_reports/README.md
@@ -144,7 +144,3 @@ WHERE i.MTAG = $P{P_MTAG};
 * **Leere Felder?** – Prüfen, ob die Werte in der Datenbank gepflegt sind.
 * **Mehrere Standort- oder Kalibrierungseinträge?** – Der Report holt immer nur den aktuellsten (`L2815 = 1`, `C2339 = 1`).
 * **Performance optimieren** – bei großen Datenmengen empfiehlt sich ein vorbereiteter View in MySQL.
-
----
-
-Damit ist der Bericht sowohl für **Endanwender:innen verständlich** als auch für **Administrator:innen/Entwickler:innen** leicht anpassbar dokumentiert.


### PR DESCRIPTION
## Summary

Entfernt den überflüssigen Schlusssatz „Damit ist der Bericht sowohl für **Endanwender:innen verständlich** als auch für **Administrator:innen/Entwickler:innen** leicht anpassbar dokumentiert." aus `INVENTORY-SAMPLE/main_reports/README.md`. Der Satz erschien auch auf der gerenderten Info-Page und liefert keinen inhaltlichen Mehrwert.

## Test plan
- [ ] Workflow `publish-downloads` läuft durch
- [ ] Info-Page für `inventory-sample` zeigt den Satz nicht mehr


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxMvdLcXxZUp2EuqvjXYbt)_