### PR TITLE
Kalibrierkontrollblatt: README ergänzen & DB-Präfix aus ORDER BY entfernen

### DIFF
--- a/KALIBRIERKONTROLLBLATT/README.md
+++ b/KALIBRIERKONTROLLBLATT/README.md
@@ -1,0 +1,33 @@
+# 🧾 Kalibrierkontrollblatt
+
+Dieses Verzeichnis enthält die Reportvorlagen für das **Kalibrierkontrollblatt** – ein kompaktes Übersichtsdokument mit Geräte-/Kundendaten und der Kalibrierhistorie als Unterbericht.
+
+## Struktur
+- `main_reports/kalibrierkontrollblatt.jrxml` – Hauptbericht (Geräte- und Kundendaten, Rahmenlayout).
+- `subreports/Calibration-3.jrxml` – Unterbericht mit der Liste der Kalibrierungen zum jeweiligen Messmittel (`MTAG`).
+
+## Wichtige Parameter
+| Parameter      | Beschreibung                                                                 |
+| -------------- | ---------------------------------------------------------------------------- |
+| `Reportpath`   | Verzeichnispfad zur Vorlage im calServer (Standardwert leer, wird gesetzt).  |
+| `PrefixTable`  | Präfix der Inventartabelle, z. B. `thermo_`.                                 |
+| `Sprache`      | Anzeigesprache (`Deutsch` oder `English`).                                   |
+| `P_MTAG`       | Eindeutiger Messmittel-Tag, für den die Kalibrierhistorie geladen wird.      |
+
+## Hinweise zum Deploy
+- Beim Kompilieren muss der Unterbericht als `Calibration-3.jasper` im Unterordner `subreports` liegen, damit der Hauptreport ihn findet.
+- Die Vorlagen sind für **JasperReports Library 6.20.6** (Jaspersoft Studio 7.0.2.final) ausgelegt.
+- Der Unterbericht erwartet die calServer-Tabelle `calibration` mit den Spalten `C2301`, `C2303`, `C2307`, `C2314` und `C2341`. Diese Spalten sind installationsabhängig (Custom Fields) – fehlen sie, schlägt das Rendern mit einer `Unknown column`-Meldung fehl.
+- Die `ORDER BY`-Klausel referenziert die Tabelle ohne hartkodierten Schemanamen (`calibration.\`C2301\``), damit der Report unabhängig vom Datenbanknamen (z. B. `calserver`, `metbase`) funktioniert.
+
+## Lokaler Testaufruf
+
+```bash
+cd KALIBRIERKONTROLLBLATT/main_reports
+jasperstarter process kalibrierkontrollblatt.jrxml \
+  -o "../pdf/_" -f pdf \
+  -P REPORT_LOCALE=de_DE @kalibrierkontrollblatt_params.properties \
+  -t mysql -u <USER> -p <PASS> -H <HOST> -n <DBNAME>
+```
+
+Stelle sicher, dass `<DBNAME>` auf die tatsächliche calServer-Datenbank zeigt (z. B. `calserver` oder `metbase`).

--- a/KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml
+++ b/KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml
@@ -25,7 +25,7 @@
 		<![CDATA[SELECT C2301, COALESCE(C2314, "") AS C2314, COALESCE(C2341, "") AS C2341, COALESCE(C2307, "") AS C2307, COALESCE(C2303, "") AS C2303 
 FROM calibration	
 WHERE MTAG=$P{P_MTAG}
-order by  calserver.calibration.`C2301`  ASC]]>
+order by  calibration.`C2301`  ASC]]>
 	</queryString>
 	<field name="C2301" class="java.lang.String"/>
 	<field name="C2314" class="java.lang.String"/>


### PR DESCRIPTION
## Summary
- Neue `KALIBRIERKONTROLLBLATT/README.md` (Struktur, Parameter, Deploy-Hinweise, Testaufruf). Der Packaging-Workflow nimmt Top-Level-READMEs automatisch ins Artefakt/ZIP auf.
- Hartkodiertes Schema `calserver.` aus der ORDER-BY-Klausel in `KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml` entfernt. Auf Installationen mit anderem Datenbanknamen (z. B. `metbase`) brach der Report mit `Unknown column 'calserver.calibration.C2301' in 'order clause'` ab.

## Hintergrund
Der gemeldete Stacktrace stammt aus einem `jasperstarter`-Lauf gegen die DB `metbase`. Da `calserver.` in der `ORDER BY`-Klausel fix verdrahtet war, suchte MySQL die Spalte in einer fremden Datenbank. Mit `calibration.\`C2301\`` ist der Report jetzt datenbankname-unabhängig.

## Test plan
- [ ] `scripts/check_jasper_version.sh` läuft fehlerfrei.
- [ ] Packaging-Workflow erzeugt `kalibrierkontrollblatt.zip` inkl. `README.md`.
- [ ] Auf einer calServer-Instanz mit DB-Name `calserver` rendert der Report wie zuvor.
- [ ] Auf einer Instanz mit abweichendem DB-Namen (`metbase`) wirft der Report keine `Unknown column`-Fehlermeldung mehr.

https://claude.ai/code/session_01LKyeeyPv2LNiqxWuzBm5Ne

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKyeeyPv2LNiqxWuzBm5Ne)_