### PR TITLE
Show C2303 (Nächste Kal) value in Kalibrierkontrollblatt rows

### DIFF
--- a/KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml
+++ b/KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml
@@ -160,6 +160,17 @@ order by  calibration.`C2301`  ASC]]>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{C2307}]]></textFieldExpression>
 			</textField>
+			<textField textAdjust="StretchHeight" pattern="dd.mm.yyyy">
+				<reportElement stretchType="ContainerHeight" x="481" y="3" width="65" height="25" uuid="b6f3a2c5-1a4d-4e3b-9b7a-5b1c2e8d4a01">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{C2303}]]></textFieldExpression>
+				<patternExpression><![CDATA[$F{C2303}]]></patternExpression>
+			</textField>
 			<line>
 				<reportElement stretchType="ContainerHeight" x="3" y="-30" width="1" height="61" uuid="590b409e-3b07-4add-9b17-cd4ecfe920b7">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>


### PR DESCRIPTION
## Problem
Im Kalibrierkontrollblatt-Report war die Spalte „Nächste Kal" in jeder Zeile leer, obwohl der Spaltenkopf gerendert wurde.

## Ursache
In `KALIBRIERKONTROLLBLATT/subreports/Calibration-3.jrxml` wurde das Feld `C2303` zwar in der SQL-Query selektiert und als `field` deklariert, aber im `<detail>`-Band fehlte das zugehörige `textField`, das `$F{C2303}` rendert.

## Fix
Ein `textField` für `$F{C2303}` im Detail-Band an Position `x=481, width=65` hinzugefügt – passend zur Spaltenkopf-Position. Datumsformatierung `dd.mm.yyyy` analog zur `C2301`-Spalte.

## Test plan
- [ ] Report mit Prüfmittel rendern, das zukünftige Kalibrierungstermine (C2303) hat, und prüfen, dass die Werte in der Spalte „Nächste Kal" angezeigt werden.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CcFJYmDLoMTyJS1iMVE8N2)_