### PR TITLE
DAkkS-Schein: Cert_field C2395 unterstützen

### DIFF
--- a/DAKKS-SAMPLE/README.md
+++ b/DAKKS-SAMPLE/README.md
@@ -125,7 +125,7 @@ für optionale Parameter.
 
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
-| `Cert_field` | ➖ | `""` | Quelle der Zertifikats­nummer und des Kalibrier­kennzeichens. Erlaubte Werte: `C2396`, `C2364` oder `C2356`; andere Werte fallen auf `C2356` zurück. Wird zugleich an den Subreport `Standard` durchgereicht. |
+| `Cert_field` | ➖ | `""` | Quelle der Zertifikats­nummer und des Kalibrier­kennzeichens. Erlaubte Werte: `C2396`, `C2395`, `C2364` oder `C2356`; andere Werte fallen auf `C2356` zurück. Wird zugleich an den Subreport `Standard` durchgereicht. |
 | `MeasurementDetails` | ➖ | `1` | Wählt eines der vier Messwert-Layouts im Subreport `Results` (`1` Basis­darstellung, `2` formatierte Eingaben, `3` autoformatierte Anzeige, `4` ISO-konforme Unsicherheit). Leere oder nicht-numerische Eingaben werden als `1` behandelt. |
 | `ModernResultsHeader` | ➖ | `N` | Schaltet im `Results`-Unterbericht den modernen Tabellen­kopf ein (`Y`) oder behält den klassischen Kopf bei (`N`). |
 | `ExpUncType` | ➖ | `""` | Freitext für ergänzende Hinweise zur erweiterten Messunsicherheit (z. B. `k=2`-Anmerkungen). |

--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -125,7 +125,7 @@
 : "Computer-assisted calibration according to the applicable internal procedure."]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Cert_field" class="java.lang.String">
-		<parameterDescription><![CDATA[Optionaler Text, der als Zertifikatsnummer angezeigt wird. Leer lassen, um den Standardwert aus C2396 zu verwenden.]]></parameterDescription>
+		<parameterDescription><![CDATA[Quelle der Zertifikatsnummer bzw. des Kalibrierkennzeichens. Erlaubte Werte: C2396, C2395, C2364 oder C2356; andere oder leere Werte fallen auf C2356 zurück.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="P_Image_Path" class="java.lang.String">
@@ -239,6 +239,7 @@
 	<queryString language="SQL">
 		<![CDATA[SELECT CASE UPPER(COALESCE($P{Cert_field}, ''))
   WHEN 'C2396' THEN COALESCE(c.C2396, "")
+  WHEN 'C2395' THEN COALESCE(c.C2395, "")
   WHEN 'C2364' THEN COALESCE(c.C2364, "")
   WHEN 'C2356' THEN COALESCE(c.C2356, "")
   ELSE COALESCE(c.C2356, "")

--- a/DAKKS-SAMPLE/subreports/Standard.jrxml
+++ b/DAKKS-SAMPLE/subreports/Standard.jrxml
@@ -26,7 +26,7 @@
                 <defaultValueExpression><![CDATA["d5bb8e240038b34eaa00d1f615c4b168"]]></defaultValueExpression>
         </parameter>
         <parameter name="Cert_field" class="java.lang.String">
-                <parameterDescription><![CDATA[Steuert das Kalibrierkennzeichen (z. B. C2396, C2364, C2356).]]></parameterDescription>
+                <parameterDescription><![CDATA[Steuert das Kalibrierkennzeichen (z. B. C2396, C2395, C2364, C2356).]]></parameterDescription>
                 <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
         </parameter>
         <queryString language="SQL">
@@ -38,6 +38,7 @@
   c.C2303 AS C2303,
   CASE UPPER(COALESCE($P{Cert_field}, ''))
     WHEN 'C2396' THEN COALESCE(c.C2396, "")
+    WHEN 'C2395' THEN COALESCE(c.C2395, "")
     WHEN 'C2364' THEN COALESCE(c.C2364, "")
     WHEN 'C2356' THEN COALESCE(c.C2356, "")
     ELSE COALESCE(c.C2356, "")


### PR DESCRIPTION
## Problem

Im DAkkS-Kalibrierschein wird die **Zertifikatsnummer** (Haupttitel) und das **Kalibrierkennzeichen** (Spalte in der Normale-Tabelle) über den Parameter `Cert_field` gesteuert. Dieser wird in zwei SQL-`CASE`-Ausdrücken ausgewertet, die bisher nur `C2396`, `C2364` und `C2356` kannten:

```sql
CASE UPPER(COALESCE($P{Cert_field}, ''))
  WHEN 'C2396' THEN COALESCE(c.C2396, "")
  WHEN 'C2364' THEN COALESCE(c.C2364, "")
  WHEN 'C2356' THEN COALESCE(c.C2356, "")
  ELSE COALESCE(c.C2356, "")
END
```

Ein Kunde, dessen Zertifikatsnummer in Spalte **`C2395`** liegt, erhielt mit `Cert_field=C2395` daher still den `ELSE`-Fallback **`C2356`** – also den falschen Wert, ohne Fehlermeldung. Reine Parameter-Konfiguration reichte nicht aus.

## Änderung

- `WHEN 'C2395' THEN COALESCE(c.C2395, "")` in **beiden** CASE-Statements ergänzt:
  - `DAKKS-SAMPLE/main_reports/dakks-sample.jrxml` → `cert_field` (Zertifikatsnummer)
  - `DAKKS-SAMPLE/subreports/Standard.jrxml` → `CalibrationMark` (Kalibrierkennzeichen)
- Parameterbeschreibungen in beiden `.jrxml` sowie README (Abschnitt 4.4) um `C2395` erweitert.

## Nutzung

Beim Aufruf des Reports `Cert_field=C2395` setzen. `C2395` wird damit zu einem regulär unterstützten Wert (zusätzlich zu `C2396`, `C2364`, `C2356`).

## Hinweise

- Keine `.jasper`-Dateien im Diff – diese sind per `.gitignore` ausgeschlossen und werden zur Laufzeit kompiliert.
- Beide `.jrxml` wurden auf XML-Wohlgeformtheit geprüft.
- Der gleiche `CASE`-Mechanismus existiert auch im DCC-Report (`DCC/main_reports/dcc-sample.jrxml`); dort bewusst **nicht** angefasst, da die Anfrage nur den DAkkS-Schein betraf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nstFjoJGfuZSWCMGE6dyw

---
_Generated by [Claude Code](https://claude.ai/code/session_014nstFjoJGfuZSWCMGE6dyw)_