### PR TITLE
Optionale zweisprachige Seitenzahl (PageNumberBilingual, Default Y) – DAkkS + DCC

### DIFF
--- a/DAKKS-SAMPLE/README.md
+++ b/DAKKS-SAMPLE/README.md
@@ -105,6 +105,7 @@ für optionale Parameter.
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
 | `PageNumberPosition` | ➖ | `HeaderLeft` | Position der Seitenzahl »Seite x von y« (Sprachwahl über `Sprache`). Erlaubte Werte: `HeaderLeft`, `HeaderCenter`, `HeaderRight`, `FooterLeft`, `FooterCenter`, `FooterRight` oder `None` (Seitenzahl ausblenden). `HeaderLeft` (Default) entspricht der bisherigen Anzeige oben links; bei einer `Footer*`-Wahl wird die Seitenzahl auch auf Seite 1 in der Fußzeile gedruckt. |
+| `PageNumberBilingual` | ➖ | `Y` | Zweisprachige Seitenzahl. `Y` (Default) = zweizeilig: primäre Sprache (gemäß `Sprache`) oben, die andere Sprache darunter (kleiner/kursiv), z. B. »Seite 3 von 7« über »Page 3 of 7«. `N` = nur eine Sprache gemäß `Sprache`. Wirkt an der über `PageNumberPosition` gewählten Position; `None` blendet weiterhin alles aus. |
 | `PrefixTable` | ➖ | `""` | Tabellen­präfix für mandanten­fähige Installationen (z. B. `cal_`). Wird per `$P!{PrefixTable}` direkt in die SQL-Statements eingesetzt und gilt zugleich für die Unterberichte. |
 | `Sprache` | ➖ | `Deutsch` | Sprache aller Labels und eingebetteten Textbausteine. Erlaubte Werte: exakt `Deutsch` oder `Englisch`; abweichende Werte fallen auf `Deutsch` zurück. |
 | `ReportVersion` | ➖ | `V0.8.2` | Versions­kennzeichnung, die im Titelbereich des Berichts ausgegeben wird. |

--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -152,6 +152,10 @@
 		<parameterDescription><![CDATA[Position der Seitenzahl "Seite x von y" (sprachabhängig über Sprache). Erlaubte Werte: HeaderLeft, HeaderCenter, HeaderRight, FooterLeft, FooterCenter, FooterRight, None. Default HeaderLeft entspricht der bisherigen Position oben links. None blendet die Seitenzahl vollständig aus.]]></parameterDescription>
 		<defaultValueExpression><![CDATA["HeaderLeft"]]></defaultValueExpression>
 	</parameter>
+	<parameter name="PageNumberBilingual" class="java.lang.String">
+		<parameterDescription><![CDATA[Zweisprachige Seitenzahl. Y = zweizeilig: primäre Sprache (gemäß Sprache) oben, die andere Sprache darunter (kleiner/kursiv) (Standard). N = nur eine Sprache gemäß Sprache. Greift an der über PageNumberPosition gewählten Position; None blendet weiterhin alles aus.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="ShowMarkOnFollowingPages" class="java.lang.String">
 		<parameterDescription><![CDATA[Steuert die Anzeige des Kennzeichnungs-/Akkreditierungsblocks (Markennummern, DAkkS-Kalibrierzeichen, Kalibrierdatum) auf Folgeseiten. Y = auf allen Seiten anzeigen (Standard). N = nur auf Seite 1 anzeigen, ab Seite 2 ausblenden.]]></parameterDescription>
 		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
@@ -1690,6 +1694,60 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
     ? ""
     : $P{MarkNumber2}.replace("/n", "\n").replace("\\n", "\n")]]></textFieldExpression>
 			</textField>
+			<textField>
+				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="86" y="25" width="30" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000002">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="180" y="25" width="100" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000003">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="280" y="25" width="40" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000004">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="300" y="25" width="150" height="15" uuid="a2b2c3d4-0003-4a01-8e01-000000000005">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="452" y="25" width="36" height="15" uuid="a2b2c3d4-0003-4a01-8e01-000000000006">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
 		</band>
 	</pageHeader>
 	<pageFooter>
@@ -1735,6 +1793,60 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="70" y="25" width="30" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000008">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="25" width="100" height="15" uuid="a2b2c3d4-0005-4a01-8e01-000000000009">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="320" y="25" width="40" height="15" uuid="a2b2c3d4-0005-4a01-8e01-00000000000a">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="400" y="25" width="138" height="15" uuid="a2b2c3d4-0006-4a01-8e01-00000000000b">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="538" y="25" width="23" height="15" uuid="a2b2c3d4-0006-4a01-8e01-00000000000c">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
 				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 		</band>

--- a/DAKKS-SAMPLE/main_reports/dakks-sample_params.properties
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample_params.properties
@@ -31,6 +31,7 @@ ReportVersion=
 MarkNumber1=
 MarkNumber2=
 PageNumberPosition=
+PageNumberBilingual=
 ShowMarkOnFollowingPages=
 sign_names=
 ShowGroup1CalibrationItem=

--- a/DAKKS-SAMPLE/schema.json
+++ b/DAKKS-SAMPLE/schema.json
@@ -7,7 +7,7 @@
       "label": "Titel & Zertifikatsnummer",
       "subtitle": "Kopfbereich, Akkreditierungssiegel",
       "anchor": "#params-images",
-      "params": ["Cert_field", "QR_Code_Value", "ReportVersion", "P_Image_Path", "PageNumberPosition"],
+      "params": ["Cert_field", "QR_Code_Value", "ReportVersion", "P_Image_Path", "PageNumberPosition", "PageNumberBilingual"],
       "height": 90,
       "tone": "accent"
     },

--- a/DCC/main_reports/dcc-sample.jrxml
+++ b/DCC/main_reports/dcc-sample.jrxml
@@ -152,6 +152,10 @@
 		<parameterDescription><![CDATA[Position der Seitenzahl "Seite x von y" (sprachabhängig über Sprache). Erlaubte Werte: HeaderLeft, HeaderCenter, HeaderRight, FooterLeft, FooterCenter, FooterRight, None. Default HeaderLeft entspricht der bisherigen Position oben links. None blendet die Seitenzahl vollständig aus.]]></parameterDescription>
 		<defaultValueExpression><![CDATA["HeaderLeft"]]></defaultValueExpression>
 	</parameter>
+	<parameter name="PageNumberBilingual" class="java.lang.String">
+		<parameterDescription><![CDATA[Zweisprachige Seitenzahl. Y = zweizeilig: primäre Sprache (gemäß Sprache) oben, die andere Sprache darunter (kleiner/kursiv) (Standard). N = nur eine Sprache gemäß Sprache. Greift an der über PageNumberPosition gewählten Position; None blendet weiterhin alles aus.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="ShowMarkOnFollowingPages" class="java.lang.String">
 		<parameterDescription><![CDATA[Steuert die Anzeige des Kennzeichnungs-/Akkreditierungsblocks (Markennummern, digitales Kalibrierzeichen, Kalibrierdatum) auf Folgeseiten. Y = auf allen Seiten anzeigen (Standard). N = nur auf Seite 1 anzeigen, ab Seite 2 ausblenden.]]></parameterDescription>
 		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
@@ -1640,6 +1644,60 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
     ? ""
     : $P{MarkNumber2}.replace("/n", "\n").replace("\\n", "\n")]]></textFieldExpression>
 			</textField>
+			<textField>
+				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="86" y="25" width="30" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000002">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="180" y="25" width="100" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000003">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="280" y="25" width="40" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000004">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="300" y="25" width="150" height="15" uuid="a2b2c3d4-0003-4a01-8e01-000000000005">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="452" y="25" width="36" height="15" uuid="a2b2c3d4-0003-4a01-8e01-000000000006">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
 		</band>
 	</pageHeader>
 	<pageFooter>
@@ -1685,6 +1743,60 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="70" y="25" width="30" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000008">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="25" width="100" height="15" uuid="a2b2c3d4-0005-4a01-8e01-000000000009">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="320" y="25" width="40" height="15" uuid="a2b2c3d4-0005-4a01-8e01-00000000000a">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterCenter") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="400" y="25" width="138" height="15" uuid="a2b2c3d4-0006-4a01-8e01-00000000000b">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font size="8" isItalic="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="538" y="25" width="23" height="15" uuid="a2b2c3d4-0006-4a01-8e01-00000000000c">
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font size="8" isItalic="true"/>
+				</textElement>
 				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 		</band>

--- a/DCC/main_reports/dcc-sample_params.properties
+++ b/DCC/main_reports/dcc-sample_params.properties
@@ -13,6 +13,7 @@ Reportpath=/app/httpdocs/filemanager/reports/calibrations/dcc-sample
 PrefixTable=
 Sprache=Deutsch
 PageNumberPosition=
+PageNumberBilingual=
 ShowMarkOnFollowingPages=
 MeasurementDetails=22
 REPORT_LOCALE=de_DE


### PR DESCRIPTION
## Worum geht es

Folge-Änderung zu #475: neuer optionaler Parameter **`PageNumberBilingual`** für **DAKKS-SAMPLE** und **DCC**, um die Seitenzahl wieder **zweisprachig** darzustellen.

### `PageNumberBilingual` (Default `Y`)
- **`Y`** (Default): zweizeilige Seitenzahl an der über `PageNumberPosition` gewählten Position — primäre Sprache (gemäß `Sprache`) oben, die andere Sprache darunter (kleiner/kursiv), jeweils mit Gesamtseitenzahl, z. B. **»Seite 3 von 7«** über **»Page 3 of 7«**.
- **`N`**: nur eine Sprache (gemäß `Sprache`).

Damit ist die Kopf-Seitenzahl per Default wieder **zweisprachig** wie im ursprünglichen Report — jetzt zusätzlich mit »von y« / »of y«.

## Umsetzung
- Pro Position eine zweite Zeile: zusätzliches Präfix-Feld (`Now`) + Gesamt-Feld (`evaluationTime="Report"`), also **+12 Felder je Report** (3 Kopf- + 3 Fußzeilen-Positionen). Die Primärzeile aus #475 bleibt unverändert.
- Sichtbarkeit per `printWhenExpression`: `PageNumberPosition` **und** ein null-sicherer, case-insensitiver Truthy-Check von `PageNumberBilingual` (fehlend/null ⇒ zweisprachig).
- Zweite Zeile in `size 8 isItalic` (wie die ursprüngliche »Page«-Zeile); passt in die Bandhöhen (Kopf 88, Fuß 63).
- Beide Reports erhalten identische Änderungen.

## Geänderte Dateien
- `DAKKS-SAMPLE/main_reports/dakks-sample.jrxml`, `DCC/main_reports/dcc-sample.jrxml`
- `*_params.properties` (Beispielschlüssel `PageNumberBilingual=`, leer = Default `Y`)
- `DAKKS-SAMPLE/README.md` (§4.2), `DAKKS-SAMPLE/schema.json`

## Verifikation
- ✅ `xmllint --noout` auf beiden JRXML (wohlgeformt)
- ✅ `schema.json` gültiges JSON
- ✅ `scripts/check_jasper_version.sh` (Versionskommentar 6.20.6 intakt)
- ✅ Referenz-Zählung je Report: 13× `PageNumberBilingual` (1 Parameter + 12 Feld-Gates), 12× null-Fallback `"y"`
- ⏳ Visuelle PDF-Prüfung über calServer: `PageNumberBilingual=Y` ⇒ zwei Zeilen; `=N` ⇒ eine Zeile; `Sprache=Englisch` ⇒ englische Zeile oben.

Nach dem Merge rebaut die Pipeline (`Package Reports` → `Publish Downloads`) die Info-Seite automatisch, sodass `PageNumberBilingual` auch unter `downloads/info/dakks-sample.html` erscheint und die aktualisierten Reports an die calServer-API gehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUSSCAJ52j3k11mHRZqcQt)_