### PR TITLE
Fix: Laufende Seitenzahl fehlt bei leerem PageNumberPosition

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -1637,14 +1637,14 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 			</line>
 			<textField>
 				<reportElement x="16" y="8" width="70" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000001">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
 				<reportElement x="86" y="8" width="30" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000002">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
 				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
@@ -1697,7 +1697,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 			</textField>
 			<textField>
 				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
@@ -1706,7 +1706,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 			</textField>
 			<textField evaluationTime="Report">
 				<reportElement x="86" y="25" width="30" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000002">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>

--- a/DCC/main_reports/dcc-sample.jrxml
+++ b/DCC/main_reports/dcc-sample.jrxml
@@ -1586,14 +1586,14 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 			</line>
 			<textField>
 				<reportElement x="16" y="8" width="70" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000001">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
 				<reportElement x="86" y="8" width="30" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000002">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
 				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
@@ -1646,7 +1646,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 			</textField>
 			<textField>
 				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
@@ -1655,7 +1655,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 			</textField>
 			<textField evaluationTime="Report">
 				<reportElement x="86" y="25" width="30" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000002">
-					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
+					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>


### PR DESCRIPTION
## Symptom

In DAkkS (und DCC) erscheint **gar keine laufende Seitenzahl** – obwohl der Default `HeaderLeft` ist und andere Parameter (z. B. `MarkNumber1`) normal wirken. Seit #475 die alte, fest sichtbare Seitenzahl durch die positionierbaren Felder ersetzt hat, ist dadurch die Seitenzahl ganz verschwunden.

## Root Cause

calServer reicht `PageNumberPosition` aus `_params.properties` (dort steht `PageNumberPosition=`, also **leer**) als **leeren String** an den Report durch. Damit greift der JRXML-`defaultValueExpression="HeaderLeft"` nicht (Defaults gelten nur, wenn der Parameter *fehlt*, nicht wenn er leer übergeben wird).

Die Gating-Bedingung der Default-Position war aber strikt:

```
$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")
```

Bei leerem Wert ist das `false` → keine Position trifft → **keine Seitenzahl**.

Die Kennzeichnungs-Box war nie betroffen, weil ihr Gating `null` bereits abfängt: `($P{ShowMarkOnFollowingPages} == null ? "y" : …)`. Genau diese Asymmetrie erklärt „MarkNumber funktioniert, Seitenzahl nicht".

## Fix

Die **HeaderLeft**-Bedingung (Default) behandelt jetzt `null`/leer wie `HeaderLeft` – analog zur null-toleranten Box-Logik:

```
$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")
```

- Betroffen: je 4 Ausdrücke pro Report (primäre + zweisprachige HeaderLeft-Felder), in **DAkkS** und **DCC**.
- `HeaderCenter`/`HeaderRight`/`Footer*` bleiben **strikt** (nur exakter Treffer).
- `None` blendet weiterhin alles aus.

## Verifikation

- `xmllint --noout` beide JRXML: OK.
- Alte strikte HeaderLeft-Bedingung: 0 verbleibend; neue robuste: 4/Report.
- Andere Positionen unverändert; `scripts/check_jasper_version.sh`: 6.20.6.

## Wichtig fürs Testen

Nach dem Merge muss der Report **neu in calServer hochgeladen** werden (serverseitige Kompilierung) – ein Merge allein deployt nicht. Danach erscheint die Seitenzahl im Default oben links (zweisprachig, da `PageNumberBilingual=Y`); `HeaderCenter` etc. bleiben wählbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUSSCAJ52j3k11mHRZqcQt

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUSSCAJ52j3k11mHRZqcQt)_