### PR TITLE
Fix: Messergebnis-Header (MeasurementDetails=3) an Datenspalten ausrichten

### DIFF
--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -1894,7 +1894,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="370" y="0" width="100" height="21" uuid="8c6894ab-80a7-45eb-9dcc-5b39c939d9c7"/>
+					<reportElement x="350" y="0" width="100" height="21" uuid="8c6894ab-80a7-45eb-9dcc-5b39c939d9c7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1906,7 +1906,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="370" y="21" width="100" height="19" uuid="bdbe7508-292f-463e-b8a3-45c91a07d169"/>
+					<reportElement x="350" y="21" width="100" height="19" uuid="bdbe7508-292f-463e-b8a3-45c91a07d169"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1918,7 +1918,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="470" y="0" width="25" height="21" uuid="d5599b28-05ae-41c8-9ff2-6c319f60be39"/>
+					<reportElement x="450" y="0" width="25" height="21" uuid="d5599b28-05ae-41c8-9ff2-6c319f60be39"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1930,7 +1930,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="470" y="21" width="25" height="19" uuid="90a651d4-5514-4fd5-8a0a-1723f3d434db"/>
+					<reportElement x="450" y="21" width="25" height="19" uuid="90a651d4-5514-4fd5-8a0a-1723f3d434db"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1942,7 +1942,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="495" y="0" width="40" height="21" uuid="8dbac63f-7c0c-4a6a-a3ab-4b035453deab"/>
+					<reportElement x="475" y="0" width="60" height="21" uuid="8dbac63f-7c0c-4a6a-a3ab-4b035453deab"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1954,7 +1954,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="495" y="21" width="40" height="19" uuid="f876b3de-9f36-40e0-beee-3e76efcbd2d5"/>
+					<reportElement x="475" y="21" width="60" height="19" uuid="f876b3de-9f36-40e0-beee-3e76efcbd2d5"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>

--- a/DCC/subreports/DCC-Results.jrxml
+++ b/DCC/subreports/DCC-Results.jrxml
@@ -1769,7 +1769,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="370" y="0" width="100" height="21" uuid="8c6894ab-80a7-45eb-9dcc-5b39c939d9c7"/>
+					<reportElement x="350" y="0" width="100" height="21" uuid="8c6894ab-80a7-45eb-9dcc-5b39c939d9c7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1781,7 +1781,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="370" y="21" width="100" height="19" uuid="bdbe7508-292f-463e-b8a3-45c91a07d169"/>
+					<reportElement x="350" y="21" width="100" height="19" uuid="bdbe7508-292f-463e-b8a3-45c91a07d169"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1793,7 +1793,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="470" y="0" width="25" height="21" uuid="d5599b28-05ae-41c8-9ff2-6c319f60be39"/>
+					<reportElement x="450" y="0" width="25" height="21" uuid="d5599b28-05ae-41c8-9ff2-6c319f60be39"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1805,7 +1805,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="470" y="21" width="25" height="19" uuid="90a651d4-5514-4fd5-8a0a-1723f3d434db"/>
+					<reportElement x="450" y="21" width="25" height="19" uuid="90a651d4-5514-4fd5-8a0a-1723f3d434db"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1817,7 +1817,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="495" y="0" width="40" height="21" uuid="8dbac63f-7c0c-4a6a-a3ab-4b035453deab"/>
+					<reportElement x="475" y="0" width="60" height="21" uuid="8dbac63f-7c0c-4a6a-a3ab-4b035453deab"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1829,7 +1829,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="495" y="21" width="40" height="19" uuid="f876b3de-9f36-40e0-beee-3e76efcbd2d5"/>
+					<reportElement x="475" y="21" width="60" height="19" uuid="f876b3de-9f36-40e0-beee-3e76efcbd2d5"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>


### PR DESCRIPTION
## Problem

Im **Messergebnis-Subreport** (`MESSERGEBNISSE / MEASUREMENTS RESULTS`) war der klassische Spaltenkopf der Layout-Variante **`MeasurementDetails = 3`** (Sollwert/Messwert ohne Spezifikations-Limits) fehlerhaft gestaltet:

- Die Kopfspalten **„erweiterte Messunsicherheit“, „% Tol“ und „Konformität“** waren um **20 px nach rechts versetzt** und deckten sich nicht mit den darunterliegenden Datenspalten.
- Dadurch entstand eine **sichtbare Lücke hinter „% rel. Abweichung“** (der Kopf zerfiel optisch in zwei Blöcke), und die Messwerte standen unter dem falschen Spaltenkopf.
- Die Konformität-Kopfspalte war mit nur **40 px zu schmal**, sodass das Wort **„Konformität“ auf zwei Zeilen umbrach** („Konformitä“ / „t“).

Die Ursache: Der klassische Layout-3-Header wurde von Anfang an mit falschen X-Koordinaten (370 / 470 / 495) angelegt. Layout 4 und der moderne Header (`ModernResultsHeader=Y`) verwenden bereits die korrekten Werte (350 / 450 / 475) und dienten als Referenz.

## Änderung

Kopfspalten an die – bereits korrekten – Datenspalten angeglichen (jeweils Kopf-Zeile DE **und** EN):

| Spalte | vorher (x / Breite) | nachher (x / Breite) |
|---|---|---|
| erweiterte Messunsicherheit | 370 / 100 | **350** / 100 |
| % Tol | 470 / 25 | **450** / 25 |
| Konformität | 495 / **40** | **475** / **60** |

Damit liegen Kopf- und Datenspalten exakt bündig (`350–450 / 450–475 / 475–535`), die Lücke verschwindet und „Konformität“ passt einzeilig.

Identische Korrektur in beiden betroffenen Subreports:
- `DAKKS-SAMPLE/subreports/Results.jrxml`
- `DCC/subreports/DCC-Results.jrxml`

## Geprüft

- ✅ Kopf- und Detailspalten von Layout 3 sind nun deckungsgleich (Koordinaten-Vergleich).
- ✅ Beide JRXML-Dateien weiterhin wohlgeformt (XML-Parse).
- ✅ `scripts/check_jasper_version.sh` → JasperReports 6.20.6 unverändert.
- Reine Layout-/Koordinaten-Änderung (12 Zeilen), keine Logik-, Text- oder Strukturänderung.

## Hinweis

Die im Screenshot zusätzlich sichtbaren Apostroph-Zeichen (`'`) in einzelnen Zeilen stammen aus den **Werten des Test-/Vorschaudatensatzes** (die Felder werden per SQL geliefert), nicht aus dem Report-Design – die Vorlage gibt an diesen Stellen keine Apostrophe aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrE6jefgMWsjZzpLt1Zi3v)_