### PR TITLE
Fix: konstanter Abstand vor der Gesamt-Seitenzahl (zentriert/rechts)

### DIFF
--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -1661,7 +1661,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderCenter")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="300" y="8" width="150" height="17" uuid="a1b2c3d4-0003-4a01-8e01-000000000005">
@@ -1675,7 +1675,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderRight")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="ScaleFont">
 				<reportElement x="496" y="9" width="51" height="17" uuid="51bf3d6d-24d5-46da-ad16-8c72fe133333">
@@ -1729,7 +1729,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="300" y="25" width="150" height="15" uuid="a2b2c3d4-0003-4a01-8e01-000000000005">
@@ -1747,7 +1747,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 		</band>
 	</pageHeader>
@@ -1780,7 +1780,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterCenter")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="400" y="8" width="138" height="17" uuid="a1b2c3d4-0006-4a01-8e01-00000000000b">
@@ -1794,7 +1794,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
@@ -1830,7 +1830,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="400" y="25" width="138" height="15" uuid="a2b2c3d4-0006-4a01-8e01-00000000000b">
@@ -1848,7 +1848,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 		</band>
 	</pageFooter>

--- a/DCC/main_reports/dcc-sample.jrxml
+++ b/DCC/main_reports/dcc-sample.jrxml
@@ -1610,7 +1610,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderCenter")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="300" y="8" width="150" height="17" uuid="a1b2c3d4-0003-4a01-8e01-000000000005">
@@ -1624,7 +1624,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderRight")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="ScaleFont">
 				<reportElement x="496" y="9" width="51" height="17" uuid="51bf3d6d-24d5-46da-ad16-8c72fe133333">
@@ -1678,7 +1678,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="300" y="25" width="150" height="15" uuid="a2b2c3d4-0003-4a01-8e01-000000000005">
@@ -1696,7 +1696,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 		</band>
 	</pageHeader>
@@ -1729,7 +1729,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterCenter")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="400" y="8" width="138" height="17" uuid="a1b2c3d4-0006-4a01-8e01-00000000000b">
@@ -1743,7 +1743,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterRight")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
@@ -1779,7 +1779,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="400" y="25" width="138" height="15" uuid="a2b2c3d4-0006-4a01-8e01-00000000000b">
@@ -1797,7 +1797,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 		</band>
 	</pageFooter>


### PR DESCRIPTION
## Symptom

Bei zentrierter Seitenzahl erscheint »Seite 3 von**6**« / »Page 3 of**6**« — das Leerzeichen zwischen »von«/»of« und der Gesamtzahl fehlt.

## Ursache

Die laufende Seitenzahl besteht aus **zwei** Feldern (Präfix »Seite 3 von « + separate Gesamtzahl »6«, weil die Gesamtzahl erst per `evaluationTime="Report"` am Report-Ende feststeht). Bei **rechtsbündigem Präfix** (HeaderCenter/-Right, FooterCenter/-Right) schneidet der PDF-Export das **abschließende Leerzeichen** des Präfix weg → die beiden Felder stoßen direkt aneinander. Bei linksbündigem Präfix (HeaderLeft/FooterLeft) entsteht die Lücke aus der Box-Geometrie, daher fiel es dort nicht auf.

## Fix

Die Gesamtzahl-Felder der vier **rechtsbündigen** Positionen bekommen ein **führendes geschütztes Leerzeichen** (` `):

```
"" + $V{PAGE_NUMBER}   →   " " + $V{PAGE_NUMBER}
```

Ein führendes Zeichen eines linksbündigen Feldes wird nie abgeschnitten, und ein geschütztes Leerzeichen überlebt jegliches Whitespace-Trimming. Ergebnis: eine **konstante** Lücke, unabhängig von der Seitenzahl (auch »weiter runter« bei mehrstelligen Seiten).

- Betroffen: je **8 Felder** pro Report (HeaderCenter, HeaderRight, FooterCenter, FooterRight × primär + zweisprachig), in **DAkkS** und **DCC**.
- **Links-Positionen** (HeaderLeft/FooterLeft) bleiben bewusst unverändert (sahen bereits korrekt aus).

## Verifikation

- `xmllint --noout` beide JRXML: OK.
- 8 NBSP-Totals + 4 unveränderte Links-Totals pro Report (geprüft).

## Hinweis fürs Testen

Nach dem Merge den Report neu in calServer hochladen. Danach sollte »Seite 3 von 6« / »Page 3 of 6« an allen Positionen einen sauberen, gleichbleibenden Abstand zeigen.

> Optionale Folge-Idee (nicht in dieser PR): Wenn der Abstand an **allen** Positionen pixelgenau identisch sein soll (auch Links-Positionen bei sehr langen Dokumenten mit ≥ 10 Seiten), könnte man die Links-Präfixe rechtsbündig setzen — das verschiebt allerdings den linken Rand der Zahl leicht. Sag Bescheid, falls gewünscht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUSSCAJ52j3k11mHRZqcQt

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUSSCAJ52j3k11mHRZqcQt)_