### PR TITLE
docs: Ausblick auf V2-Reportstrategie (JSON-Datasources) in README und robots.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ In diesem Repository bündeln wir Beispielberichte (JRXML) für den calServer, s
 - [Berichte im calServer hochladen](#berichte-im-calserver-hochladen)
 - [Skripte für Upload und Automatisierung](#skripte-für-upload-und-automatisierung)
 - [Repository klonen & Arbeiten mit GitHub Actions](#repository-klonen--arbeiten-mit-github-actions)
+- [Ausblick: calServer V2 und die Zukunft der Reportvorlagen](#ausblick-calserver-v2-und-die-zukunft-der-reportvorlagen)
 - [Contributing & Community](#contributing--community)
 - [Fehler melden & Support](#fehler-melden--support)
 - [Lizenz](#lizenz)
@@ -217,6 +218,17 @@ Für Entwickler:innen und zum Testen der jeweils frisch gebauten Version gibt es
 
 ---
 
+## Ausblick: calServer V2 und die Zukunft der Reportvorlagen
+
+calServer V2 verwendet ein neues Datenbankschema mit **lesbaren Feldnamen** (`serial_number`, `next_calibration_date`) statt der bisherigen Metrologie-Codes (`I4202`, `C2303`). Für die Reportvorlagen bedeutet das:
+
+- **Die bestehenden Bundles in diesem Repository bleiben der stabile V1-Stand** (eingebettetes SQL über JDBC mit den Codespalten). Sie laufen unverändert auf allen V1-Systemen und werden weiter mit Bugfixes gepflegt.
+- **Neue V2-Bundles** erscheinen künftig als Varianten mit **JSON-Datasource** und lesbaren API-Feldnamen (`$F{serial_number}` statt `$F{I4202}`). Die Daten liefert dann das calServer-Backend als berichtsförmiges JSON-Paket — die Vorlagen enthalten kein eigenes SQL mehr und funktionieren dadurch unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
+- Bestehende Vorlagen bitte **nicht** auf das V2-Schema-SQL umschreiben — die Strategie und der Migrationspfad sind hier dokumentiert: [Evaluierung: JasperReports-Strategie für calServer V2](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md).
+- Als Übersetzungshilfe zwischen alten Codes und neuen Feldnamen dient weiterhin der [FIELD-NAMES-Report](FIELD-NAMES/) sowie die Mapping-Referenz in der Strategie-Dokumentation.
+
+---
+
 ## Contributing & Community
 
 **Wir freuen uns auf deine Beiträge!**
@@ -264,6 +276,6 @@ E-Mail: [info@calhelp.de](mailto:info@calhelp.de)
 
 ---
 
-*Letzte Aktualisierung: 2026-03-31*
+*Letzte Aktualisierung: 2026-07-15*
 
 ```

--- a/robots.md
+++ b/robots.md
@@ -25,6 +25,17 @@ Use and target **JasperReports 6.20.6** for JRXML compatibility.
 
 ---
 
+## 0.2) V2 direction (announced)
+The existing bundles in this repo are the stable **V1 contract**: embedded SQL executed over a JDBC connection (`$P{REPORT_CONNECTION}`) against the V1 column codes (`I42xx`, `C23xx`, ...).
+
+### Rules
+- Do **NOT** rewrite existing bundles to query the calServer V2 schema (readable column names). They stay on the V1 contract and receive bug fixes only.
+- Future **V2 bundles** will use **JSON datasources** with readable API field names (`$F{serial_number}` instead of `$F{I4202}`); the data is supplied by the calServer backend, not by SQL inside the template. Structure and packaging rules for V2 bundles will be added here when the first V2 bundle lands.
+- Strategy and migration path: https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md
+- JasperReports 6.20.6 (section 0.1) remains binding for all bundles until the version policy is explicitly updated.
+
+---
+
 ## 1) Required bundle structure (MUST)
 For every report bundle folder (e.g. DAKKS-SAMPLE, DCC, ORDER-SAMPLE, STICKERS-*):
 - `main_reports/`  → contains the entry-point JRXML(s) users execute


### PR DESCRIPTION
## Zusammenfassung

Kuendigt die V2-Richtung fuer die Reportvorlagen an, damit Community-Autoren nicht in die falsche Richtung arbeiten:

- **README.md**: neue Sektion „Ausblick: calServer V2 und die Zukunft der Reportvorlagen" — bestehende Bundles bleiben der stabile V1-Stand (eingebettetes SQL ueber JDBC mit Codespalten `I42xx`/`C23xx`); kuenftige V2-Bundles nutzen JSON-Datasources mit lesbaren API-Feldnamen (`$F{serial_number}` statt `$F{I4202}`). Link auf die Strategie-Dokumentation im calServer-yii-Repo (Evaluierung + ADR-009).
- **robots.md**: neue Sektion `0.2) V2 direction (announced)` — bestehende Bundles NICHT auf V2-Schema-SQL umschreiben; JasperReports 6.20.6 bleibt verbindlich; Struktur-/Packaging-Regeln fuer V2-Bundles folgen mit dem ersten V2-Bundle.

## Hinweise

- Docs-only: keine JRXML-Datei beruehrt (`scripts/check_jasper_version.sh` weiterhin gruen)
- Nach dem Merge laeuft `package-reports.yml` einmal durch (Workflow hat keinen Path-Filter) — erwartet und idempotent
- Der referenzierte Strategie-Link zeigt auf `blob/develop/...` im calServer-yii-Repo; der zugehoerige PR dort ist calhelp/calServer-yii#2826 und sollte zuerst gemergt werden, damit der Link aufloest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_