### PR TITLE
feat: DAKKS-JSON-SAMPLE — V2-Pilot-Bundle (JSON-Datasource statt SQL)

### DIFF
--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -1,0 +1,53 @@
+# DAKKS-JSON-SAMPLE — V2-Pilot (JSON-Datasource)
+
+Dies ist das **Pilot-Bundle für calServer V2** (Phase 0 der
+[JasperReports-V2-Strategie](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md),
+[ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md)).
+
+Im Gegensatz zu den bestehenden V1-Bundles (eingebettetes SQL über JDBC mit
+Codespalten wie `I4201`, `C2303`) wird dieses Bundle aus einem **JSON-Datensatz
+mit lesbaren API-Feldnamen** gefüllt — es enthält **kein SQL** und ist damit
+unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/dakks-json-sample.jrxml` | Hauptbericht; liest die Felder über `<fieldDescription>`-JSON-Pfade (z. B. `device.serial_number`) |
+| `subreports/results.jrxml` | Messergebnis-Tabelle; erhält das `results`-Array via `subDataSource("results")` |
+| `subreports/standards.jrxml` | Verwendete Normale; erhält das `standards`-Array via `subDataSource("standards")` |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.0) — als JSON-Data-Adapter in Jaspersoft Studio verwenden |
+
+## Datenanbindung
+
+- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
+- Der Runner füllt den Hauptbericht mit einer `JsonDataSource` aus dem
+  mitgelieferten Datensatz (`dataSourceType=json`, `dataJson`).
+- Subreports holen ihre Teilmenge über
+  `((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("<array>")` — keine
+  Connection, kein eigenes SQL.
+- Den Datensatz erzeugt das calServer-V2-Backend
+  (`CalibrationReportDataBuilder`); zum Testen/Entwerfen dient
+  `sample-data.json`, abrufbar auch über
+  `GET /api/v2/calibrations/{ctag}/report-dataset`.
+
+## Contract `calibration-certificate` (v1.0)
+
+Wurzelobjekt mit den Blöcken `meta`, `calibration`, `device`, `customer`,
+`standards[]`, `results[]`. Jeder Entitätsblock trägt zusätzlich ein
+`custom_fields`-Objekt mit den benutzerdefinierten Feldern unter ihrem
+`api_name`. Feldreferenz siehe `sample-data.json`.
+
+## Autoren-Hinweise (Jaspersoft Studio)
+
+1. In Studio einen **JSON-Data-Adapter** anlegen und auf `sample-data.json`
+   zeigen lassen.
+2. Felder über ihren JSON-Pfad (`<fieldDescription>`) binden, nicht über SQL.
+3. Für wiederkehrende Listen (Ergebnisse, Normale) ein Subreport mit
+   `subDataSource("<array>")` als Datenquelle verwenden.
+4. JasperReports-Version **6.20.6** bleibt verbindlich (siehe `robots.md`).
+
+> **Status:** Referenz-/Pilotvorlage. Das Layout demonstriert den
+> JSON-Datasource-Mechanismus; die layouttreue Nachbildung des akkreditierten
+> DAkkS-Scheins erfolgt im weiteren Verlauf von Phase 0 gegen den
+> Dual-Run-Sichtvergleich.

--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 pilot template (ADR-009): filled from the report-data-contract JSON
+  ("calibration-certificate") via a JSON data source — NO embedded SQL, NO V1
+  code columns. Every field reads a readable api_name via its <fieldDescription>
+  JSON path. Subreports receive their slice through
+  ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource(...), not a DB connection.
+  The dataset is produced by Laravel's CalibrationReportDataBuilder; see
+  main_reports/sample-data.json for a fixture matching this template.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-json-sample" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="30" bottomMargin="30" uuid="b1a7c0de-0001-4a10-9c01-000000000001">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false"/>
+	<style name="Label" fontSize="9" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<field name="certificate_number" class="java.lang.String">
+		<fieldDescription><![CDATA[meta.certificate_number]]></fieldDescription>
+	</field>
+	<field name="calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription>
+	</field>
+	<field name="next_calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription>
+	</field>
+	<field name="technician" class="java.lang.String">
+		<fieldDescription><![CDATA[calibration.technician]]></fieldDescription>
+	</field>
+	<field name="device_asset_number" class="java.lang.String">
+		<fieldDescription><![CDATA[device.asset_number]]></fieldDescription>
+	</field>
+	<field name="device_serial_number" class="java.lang.String">
+		<fieldDescription><![CDATA[device.serial_number]]></fieldDescription>
+	</field>
+	<field name="device_description" class="java.lang.String">
+		<fieldDescription><![CDATA[device.description]]></fieldDescription>
+	</field>
+	<field name="device_manufacturer" class="java.lang.String">
+		<fieldDescription><![CDATA[device.manufacturer]]></fieldDescription>
+	</field>
+	<field name="device_model" class="java.lang.String">
+		<fieldDescription><![CDATA[device.model]]></fieldDescription>
+	</field>
+	<field name="customer_name" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.name]]></fieldDescription>
+	</field>
+	<field name="customer_street" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.street]]></fieldDescription>
+	</field>
+	<field name="customer_zip" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.zip]]></fieldDescription>
+	</field>
+	<field name="customer_city" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.city]]></fieldDescription>
+	</field>
+	<title>
+		<band height="50">
+			<staticText>
+				<reportElement x="0" y="0" width="535" height="24"/>
+				<textElement><font size="16" isBold="true"/></textElement>
+				<text><![CDATA[DAkkS-Kalibrierschein (V2 · JSON-Datasource)]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="0" y="28" width="535" height="14"/>
+				<textElement><font size="10"/></textElement>
+				<textFieldExpression><![CDATA["Zertifikat-Nr.: " + ($F{certificate_number} == null ? "" : $F{certificate_number})]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<detail>
+		<band height="260">
+			<staticText>
+				<reportElement style="Label" x="0" y="0" width="120" height="14"/>
+				<text><![CDATA[Kalibrierdatum]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="0" width="160" height="14"/>
+				<textFieldExpression><![CDATA[$F{calibration_date}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="290" y="0" width="120" height="14"/>
+				<text><![CDATA[Nächste Kalibrierung]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="410" y="0" width="125" height="14"/>
+				<textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="16" width="120" height="14"/>
+				<text><![CDATA[Sachbearbeiter]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="16" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{technician}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="40" width="535" height="14"/>
+				<text><![CDATA[Prüfgegenstand]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Label" x="0" y="56" width="120" height="14"/>
+				<text><![CDATA[Inventar-Nr. / Serien-Nr.]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="56" width="415" height="14"/>
+				<textFieldExpression><![CDATA[($F{device_asset_number} == null ? "" : $F{device_asset_number}) + "  /  " + ($F{device_serial_number} == null ? "" : $F{device_serial_number})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="72" width="120" height="14"/>
+				<text><![CDATA[Bezeichnung]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="72" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{device_description}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="88" width="120" height="14"/>
+				<text><![CDATA[Hersteller / Typ]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="88" width="415" height="14"/>
+				<textFieldExpression><![CDATA[($F{device_manufacturer} == null ? "" : $F{device_manufacturer}) + "  " + ($F{device_model} == null ? "" : $F{device_model})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="112" width="535" height="14"/>
+				<text><![CDATA[Auftraggeber]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="0" y="128" width="535" height="14"/>
+				<textFieldExpression><![CDATA[$F{customer_name}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Value" x="0" y="144" width="535" height="14"/>
+				<textFieldExpression><![CDATA[($F{customer_street} == null ? "" : $F{customer_street}) + ", " + ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="168" width="535" height="14"/>
+				<text><![CDATA[Verwendete Normale]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="184" width="535" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("standards")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/standards.jasper"]]></subreportExpression>
+			</subreport>
+			<staticText>
+				<reportElement style="Label" positionType="Float" x="0" y="216" width="535" height="14"/>
+				<text><![CDATA[Messergebnisse]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="232" width="535" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("results")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/results.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+</jasperReport>

--- a/DAKKS-JSON-SAMPLE/main_reports/sample-data.json
+++ b/DAKKS-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,87 @@
+{
+  "meta": {
+    "contract": "calibration-certificate",
+    "schema_version": "1.0",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE",
+    "certificate_number": "DAkkS-K-2026-0042"
+  },
+  "calibration": {
+    "id": "c1a2b3c4-0000-4000-8000-000000000001",
+    "certificate_number": "DAkkS-K-2026-0042",
+    "calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30",
+    "technician": "Erika Musterfrau",
+    "temperature": 21.5,
+    "humidity": 45.0,
+    "status": 1,
+    "calibration_time": "10:15",
+    "custom_fields": {
+      "lab_reference": "LAB-4711"
+    }
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "accuracy_class": "0.05",
+    "custom_fields": {
+      "customer_tag": "KND-DMM-7"
+    }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "12345",
+    "city": "Musterstadt",
+    "country": "DE",
+    "email": "kontakt@muster.example",
+    "phone": "+49 30 1234567",
+    "contact_person": "Max Muster",
+    "custom_fields": []
+  },
+  "standards": [
+    {
+      "asset_number": "REF-001",
+      "serial_number": "N-778899",
+      "description": "Referenz-Kalibrator",
+      "manufacturer": "Keysight",
+      "model": "3458A"
+    },
+    {
+      "asset_number": "REF-002",
+      "serial_number": "N-112233",
+      "description": "Normalwiderstand 100 Ω",
+      "manufacturer": "Fluke",
+      "model": "742A"
+    }
+  ],
+  "results": [
+    {
+      "row_num": 1,
+      "test_desc": "Gleichspannung 10 V",
+      "fixq": "10.000",
+      "varq": "10.001",
+      "lower_limit": "9.995",
+      "upper_limit": "10.005",
+      "exp_uncert": "0.002",
+      "std_uncert": "0.001",
+      "pass_fail": "i.O."
+    },
+    {
+      "row_num": 2,
+      "test_desc": "Gleichstrom 1 A",
+      "fixq": "1.0000",
+      "varq": "0.9998",
+      "lower_limit": "0.9990",
+      "upper_limit": "1.0010",
+      "exp_uncert": "0.0003",
+      "std_uncert": "0.00015",
+      "pass_fail": "i.O."
+    }
+  ]
+}

--- a/DAKKS-JSON-SAMPLE/subreports/results.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/results.jrxml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 results subreport: fed the "results" array of the calibration-certificate
+  contract via ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("results").
+  Each field reads a readable api_name relative to a result element.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="results" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="b1a7c0de-0002-4a10-9c02-000000000002">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="row_num" class="java.lang.Integer">
+		<fieldDescription><![CDATA[row_num]]></fieldDescription>
+	</field>
+	<field name="test_desc" class="java.lang.String">
+		<fieldDescription><![CDATA[test_desc]]></fieldDescription>
+	</field>
+	<field name="fixq" class="java.lang.String">
+		<fieldDescription><![CDATA[fixq]]></fieldDescription>
+	</field>
+	<field name="varq" class="java.lang.String">
+		<fieldDescription><![CDATA[varq]]></fieldDescription>
+	</field>
+	<field name="lower_limit" class="java.lang.String">
+		<fieldDescription><![CDATA[lower_limit]]></fieldDescription>
+	</field>
+	<field name="upper_limit" class="java.lang.String">
+		<fieldDescription><![CDATA[upper_limit]]></fieldDescription>
+	</field>
+	<field name="exp_uncert" class="java.lang.String">
+		<fieldDescription><![CDATA[exp_uncert]]></fieldDescription>
+	</field>
+	<field name="pass_fail" class="java.lang.String">
+		<fieldDescription><![CDATA[pass_fail]]></fieldDescription>
+	</field>
+	<columnHeader>
+		<band height="16">
+			<staticText>
+				<reportElement x="0" y="0" width="30" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Nr.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="30" y="0" width="150" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Prüfpunkt]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="180" y="0" width="70" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Sollwert]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="250" y="0" width="70" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Istwert]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="320" y="0" width="70" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[untere Grenze]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="390" y="0" width="70" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[obere Grenze]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="460" y="0" width="45" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[U]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="505" y="0" width="30" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[i.O.]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="14">
+			<textField>
+				<reportElement x="0" y="0" width="30" height="13"/>
+				<textFieldExpression><![CDATA[$F{row_num}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="30" y="0" width="150" height="13"/>
+				<textFieldExpression><![CDATA[$F{test_desc}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="180" y="0" width="70" height="13"/>
+				<textFieldExpression><![CDATA[$F{fixq}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="250" y="0" width="70" height="13"/>
+				<textFieldExpression><![CDATA[$F{varq}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="320" y="0" width="70" height="13"/>
+				<textFieldExpression><![CDATA[$F{lower_limit}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="390" y="0" width="70" height="13"/>
+				<textFieldExpression><![CDATA[$F{upper_limit}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="460" y="0" width="45" height="13"/>
+				<textFieldExpression><![CDATA[$F{exp_uncert}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="505" y="0" width="30" height="13"/>
+				<textFieldExpression><![CDATA[$F{pass_fail}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/DAKKS-JSON-SAMPLE/subreports/standards.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/standards.jrxml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 standards subreport: fed the "standards" array of the
+  calibration-certificate contract via
+  ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("standards").
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="standards" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="b1a7c0de-0003-4a10-9c03-000000000003">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="asset_number" class="java.lang.String">
+		<fieldDescription><![CDATA[asset_number]]></fieldDescription>
+	</field>
+	<field name="description" class="java.lang.String">
+		<fieldDescription><![CDATA[description]]></fieldDescription>
+	</field>
+	<field name="manufacturer" class="java.lang.String">
+		<fieldDescription><![CDATA[manufacturer]]></fieldDescription>
+	</field>
+	<field name="model" class="java.lang.String">
+		<fieldDescription><![CDATA[model]]></fieldDescription>
+	</field>
+	<detail>
+		<band height="14">
+			<textField>
+				<reportElement x="0" y="0" width="90" height="13"/>
+				<textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="90" y="0" width="245" height="13"/>
+				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="335" y="0" width="200" height="13"/>
+				<textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
## Zusammenfassung

Erstes **V2-Bundle** im Sinne von [ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md): Der DAkkS-Kalibrierschein wird aus einem **JSON-Datensatz mit lesbaren API-Feldnamen** gefüllt statt aus eingebettetem SQL gegen V1-Codespalten (`I4201`, `C2303`). Damit ist das Bundle unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).

Pilot der Phase 0; der Backend-Teil (Runner-JSON-Pfad + `CalibrationReportDataBuilder`) liegt im Repo `calServer-yii` (separater PR).

## Inhalt (`DAKKS-JSON-SAMPLE/`)

| Datei | Zweck |
|-------|-------|
| `main_reports/dakks-json-sample.jrxml` | Hauptbericht; liest Felder über `<fieldDescription>`-JSON-Pfade (z. B. `device.serial_number`), **kein** `queryString`, **keine** `REPORT_CONNECTION` |
| `subreports/results.jrxml` | Messergebnis-Tabelle; erhält das `results`-Array via `subDataSource("results")` |
| `subreports/standards.jrxml` | Verwendete Normale; erhält das `standards`-Array via `subDataSource("standards")` |
| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.0) für den JSON-Data-Adapter in Jaspersoft Studio |
| `README.md` | Aufbau, Datenanbindung, Autoren-Hinweise |

## Verifikation
- Das reale Bundle wurde über den `report-runner` (JSON-Fill-Pfad, als ZIP) **zu PDF gerendert** — Haupt- und beide Subreports (`subDataSource`).
- `scripts/check_jasper_version.sh` grün (JasperReports **6.20.6**).
- Struktur nach `robots.md`: `main_reports/` + `subreports/` vorhanden.

## Hinweise
- Bestehende V1-Bundles bleiben unberührt (stabiler JDBC-Stand).
- Merge triggert `package-reports.yml` (kein Path-Filter) — erwartet, idempotent. Das neue Bundle wird noch nicht automatisch hochgeladen; die Packaging-Wiring folgt mit Phase 1.
- Status: Referenz-/Pilotvorlage — die layouttreue Nachbildung des akkreditierten DAkkS-Scheins erfolgt im weiteren Verlauf von Phase 0 gegen den Dual-Run-Sichtvergleich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_