### PR TITLE
feat: INVENTORY-JSON-SAMPLE — zweites V2-Bundle (JSON-Datasource, Custom Field)

### DIFF
--- a/INVENTORY-JSON-SAMPLE/README.md
+++ b/INVENTORY-JSON-SAMPLE/README.md
@@ -1,0 +1,34 @@
+# INVENTORY-JSON-SAMPLE — V2-Bundle (JSON-Datasource)
+
+Geräte-Datenblatt als **V2-Bundle** im Sinne von
+[ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md):
+gefüllt aus dem Report-Data-Contract `inventory-datasheet` (JSON) mit lesbaren
+API-Feldnamen statt aus eingebettetem SQL gegen V1-Codespalten.
+
+Zweite Bundle-Familie neben `DAKKS-JSON-SAMPLE` — sie zeigt zusätzlich die
+Bindung eines **Custom Fields** (`device.custom_fields.customer_tag`) und einer
+wiederkehrenden Liste (Kalibrierhistorie) per `subDataSource`.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/inventory-json-sample.jrxml` | Datenblatt; liest Gerätefelder + ein Custom Field über `<fieldDescription>`-JSON-Pfade |
+| `subreports/calibrations.jrxml` | Kalibrierhistorie; erhält das `calibrations`-Array via `subDataSource("calibrations")` |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `inventory-datasheet` v1.0) für den JSON-Data-Adapter in Jaspersoft Studio |
+
+## Datenanbindung
+
+- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
+- Der Runner füllt den Hauptbericht mit einer `JsonDataSource`; das Datenblatt
+  ist genau ein Datensatz (Wurzelobjekt).
+- Custom Fields stehen unter ihrem `api_name` im `custom_fields`-Objekt bereit
+  (`device.custom_fields.customer_tag`).
+- Den Datensatz erzeugt das calServer-V2-Backend (`InventoryReportDataBuilder`).
+
+Aktivierung in calServer: dem Report-Setting eine Report-Variable
+`data_contract = inventory-datasheet` zuweisen (Details siehe V2-Doku
+„V2-Berichte mit JSON-Datenquelle").
+
+> **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
+> verbindlich (siehe `robots.md`).

--- a/INVENTORY-JSON-SAMPLE/main_reports/inventory-json-sample.jrxml
+++ b/INVENTORY-JSON-SAMPLE/main_reports/inventory-json-sample.jrxml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 sample template (ADR-009): inventory datasheet filled from the
+  "inventory-datasheet" report-data-contract JSON via a JSON data source — NO SQL,
+  NO V1 code columns. Fields read readable api_names via <fieldDescription> JSON
+  paths, including a custom field (device.custom_fields.customer_tag). The
+  calibration history is rendered from the "calibrations" array via subDataSource.
+  Dataset builder: Laravel InventoryReportDataBuilder; see sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="inventory-json-sample" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="30" bottomMargin="30" uuid="c2b8d1ef-0001-4b20-9d01-000000000101">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false"/>
+	<style name="Label" fontSize="9" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<field name="asset_number" class="java.lang.String">
+		<fieldDescription><![CDATA[device.asset_number]]></fieldDescription>
+	</field>
+	<field name="serial_number" class="java.lang.String">
+		<fieldDescription><![CDATA[device.serial_number]]></fieldDescription>
+	</field>
+	<field name="description" class="java.lang.String">
+		<fieldDescription><![CDATA[device.description]]></fieldDescription>
+	</field>
+	<field name="manufacturer" class="java.lang.String">
+		<fieldDescription><![CDATA[device.manufacturer]]></fieldDescription>
+	</field>
+	<field name="model" class="java.lang.String">
+		<fieldDescription><![CDATA[device.model]]></fieldDescription>
+	</field>
+	<field name="type_code" class="java.lang.String">
+		<fieldDescription><![CDATA[device.type_code]]></fieldDescription>
+	</field>
+	<field name="accuracy_class" class="java.lang.String">
+		<fieldDescription><![CDATA[device.accuracy_class]]></fieldDescription>
+	</field>
+	<field name="location" class="java.lang.String">
+		<fieldDescription><![CDATA[device.location]]></fieldDescription>
+	</field>
+	<field name="next_calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription>
+	</field>
+	<field name="customer_tag" class="java.lang.String">
+		<fieldDescription><![CDATA[device.custom_fields.customer_tag]]></fieldDescription>
+	</field>
+	<field name="customer_name" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.name]]></fieldDescription>
+	</field>
+	<field name="customer_city" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.city]]></fieldDescription>
+	</field>
+	<title>
+		<band height="50">
+			<staticText>
+				<reportElement x="0" y="0" width="535" height="24"/>
+				<textElement><font size="16" isBold="true"/></textElement>
+				<text><![CDATA[Geräte-Datenblatt (V2 · JSON-Datasource)]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="0" y="28" width="535" height="14"/>
+				<textElement><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($F{asset_number} == null ? "" : $F{asset_number}) + "  ·  " + ($F{description} == null ? "" : $F{description})]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<detail>
+		<band height="180">
+			<staticText>
+				<reportElement style="Label" x="0" y="0" width="120" height="14"/>
+				<text><![CDATA[Inventar-Nr.]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="0" width="160" height="14"/>
+				<textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="290" y="0" width="120" height="14"/>
+				<text><![CDATA[Serien-Nr.]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="410" y="0" width="125" height="14"/>
+				<textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="16" width="120" height="14"/>
+				<text><![CDATA[Hersteller / Typ]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="16" width="415" height="14"/>
+				<textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + "  " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="32" width="120" height="14"/>
+				<text><![CDATA[Typ / Genauigkeit]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="32" width="415" height="14"/>
+				<textFieldExpression><![CDATA[($F{type_code} == null ? "" : $F{type_code}) + "   Kl. " + ($F{accuracy_class} == null ? "" : $F{accuracy_class})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="48" width="120" height="14"/>
+				<text><![CDATA[Standort]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="48" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{location}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="64" width="120" height="14"/>
+				<text><![CDATA[Nächste Kalibrierung]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="64" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="80" width="120" height="14"/>
+				<text><![CDATA[Kundenkennung]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="80" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{customer_tag}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="104" width="535" height="14"/>
+				<text><![CDATA[Eigentümer / Kunde]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="0" y="120" width="535" height="14"/>
+				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + ", " + ($F{customer_city} == null ? "" : $F{customer_city})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" positionType="Float" x="0" y="150" width="535" height="14"/>
+				<text><![CDATA[Kalibrierhistorie]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="166" width="535" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("calibrations")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/calibrations.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+</jasperReport>

--- a/INVENTORY-JSON-SAMPLE/main_reports/sample-data.json
+++ b/INVENTORY-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,46 @@
+{
+  "meta": {
+    "contract": "inventory-datasheet",
+    "schema_version": "1.0",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "accuracy_class": "0.05",
+    "location": "Labor 1 / Schrank A",
+    "status": 1,
+    "calibration_interval": 12,
+    "next_calibration_date": "2027-06-30",
+    "custom_fields": {
+      "customer_tag": "KND-DMM-7"
+    }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "12345",
+    "city": "Musterstadt",
+    "custom_fields": []
+  },
+  "calibrations": [
+    {
+      "calibration_date": "2026-06-30",
+      "next_calibration_date": "2027-06-30",
+      "certificate_number": "DAkkS-K-2026-0042",
+      "technician": "Erika Musterfrau"
+    },
+    {
+      "calibration_date": "2025-06-30",
+      "next_calibration_date": "2026-06-30",
+      "certificate_number": "DAkkS-K-2025-0031",
+      "technician": "Max Mustermann"
+    }
+  ]
+}

--- a/INVENTORY-JSON-SAMPLE/subreports/calibrations.jrxml
+++ b/INVENTORY-JSON-SAMPLE/subreports/calibrations.jrxml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 calibration-history subreport: fed the "calibrations" array of the
+  inventory-datasheet contract via
+  ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("calibrations").
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="calibrations" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="c2b8d1ef-0002-4b20-9d02-000000000102">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[calibration_date]]></fieldDescription>
+	</field>
+	<field name="next_calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[next_calibration_date]]></fieldDescription>
+	</field>
+	<field name="certificate_number" class="java.lang.String">
+		<fieldDescription><![CDATA[certificate_number]]></fieldDescription>
+	</field>
+	<field name="technician" class="java.lang.String">
+		<fieldDescription><![CDATA[technician]]></fieldDescription>
+	</field>
+	<columnHeader>
+		<band height="16">
+			<staticText>
+				<reportElement x="0" y="0" width="110" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Kalibriert am]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="110" y="0" width="110" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Nächste Kal.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="220" y="0" width="180" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Zertifikat-Nr.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="400" y="0" width="135" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Sachbearbeiter]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="14">
+			<textField>
+				<reportElement x="0" y="0" width="110" height="13"/>
+				<textFieldExpression><![CDATA[$F{calibration_date}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="110" y="0" width="110" height="13"/>
+				<textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="220" y="0" width="180" height="13"/>
+				<textFieldExpression><![CDATA[$F{certificate_number}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="400" y="0" width="135" height="13"/>
+				<textFieldExpression><![CDATA[$F{technician}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
## Zusammenfassung

Zweite **V2-Bundle-Familie** neben `DAKKS-JSON-SAMPLE` (ADR-009): ein Geräte-Datenblatt, gefüllt aus dem Report-Data-Contract `inventory-datasheet` (JSON) mit lesbaren API-Feldnamen — kein SQL, DB-unabhängig. Beweist, dass der Contract-Ansatz über Kalibrierscheine hinaus generalisiert.

Neu gegenüber dem DAkkS-Bundle: die Bindung eines **Custom Fields** (`device.custom_fields.customer_tag`) und einer wiederkehrenden Liste (Kalibrierhistorie) via `subDataSource`.

## Inhalt (`INVENTORY-JSON-SAMPLE/`)

| Datei | Zweck |
|-------|-------|
| `main_reports/inventory-json-sample.jrxml` | Datenblatt; Gerätefelder + Custom Field über `<fieldDescription>`-JSON-Pfade |
| `subreports/calibrations.jrxml` | Kalibrierhistorie via `subDataSource("calibrations")` |
| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `inventory-datasheet` v1.0) |
| `README.md` | Aufbau, Datenanbindung, Aktivierung |

## Verifikation
- Das reale Bundle wurde über den `report-runner` (JSON-Fill, als ZIP) **zu PDF gerendert** — Hauptbericht (inkl. Custom-Field-Bindung) und Subreport.
- `scripts/check_jasper_version.sh` grün (JasperReports **6.20.6**).

## Hinweise
- Bestehende V1-Bundles bleiben unberührt.
- Der Backend-Teil (`InventoryReportDataBuilder` + Controller-Wiring) liegt im calServer-yii-PR.
- Merge triggert `package-reports.yml` (kein Path-Filter) — erwartet, idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_