### PR TITLE
feat: V2-Bundles als eigene „APEX (V2)"-Kategorie veröffentlichen

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -155,6 +155,25 @@ jobs:
             STICKERS/Sticker_Vorlage/subreports
           if-no-files-found: error
 
+      # V2 (APEX) — JSON-Datasource-Bundles
+      - name: Upload DAKKS-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: DAKKS-JSON-SAMPLE
+          path: |
+            DAKKS-JSON-SAMPLE/main_reports
+            DAKKS-JSON-SAMPLE/subreports
+          if-no-files-found: error
+
+      - name: Upload INVENTORY-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: INVENTORY-JSON-SAMPLE
+          path: |
+            INVENTORY-JSON-SAMPLE/main_reports
+            INVENTORY-JSON-SAMPLE/subreports
+          if-no-files-found: error
+
       - name: List files before zipping (Debug)
         run: |
           echo "📂 Inhalt von DAKKS-SAMPLE:"
@@ -195,6 +214,10 @@ jobs:
               allowed_patterns+=('*.properties')
             elif [ "$sample" = "DCC" ]; then
               allowed_patterns+=('*.xsd' '*.json')
+            elif [[ "$sample" == *-JSON-SAMPLE ]]; then
+              # V2 (APEX) bundles ship a JSON data-adapter sample (sample-data.json)
+              # next to the JRXML — keep *.json in the ZIP.
+              allowed_patterns+=('*.json')
             fi
 
             rm -rf "${stage_dir}"
@@ -267,6 +290,10 @@ jobs:
           create_zip "STICKERS/Sticker_Vorlage" "sticker-vorlage"
           create_zip "TRACE-FORWARD" "trace-forward"
           create_zip "TRACE-BACKWARD" "trace-backward"
+
+          # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL)
+          create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"
+          create_zip "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
 
 
       - name: Upload report ZIPs as artifact

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -99,6 +99,8 @@ jobs:
           get_last_modified "TRACE-FORWARD" "trace-forward"
           get_last_modified "TRACE-BACKWARD" "trace-backward"
           get_last_modified "STICKERS/Sticker_Vorlage" "sticker-vorlage"
+          get_last_modified "DAKKS-JSON-SAMPLE" "dakks-json-sample"
+          get_last_modified "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
 
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
@@ -167,6 +169,8 @@ jobs:
               "delivery-standalone":"DELIVERY-STANDALONE/README.md",
               "trace-forward":     "TRACE-FORWARD/main_reports/README.md",
               "trace-backward":    "TRACE-BACKWARD/main_reports/README.md",
+              "dakks-json-sample":     "DAKKS-JSON-SAMPLE/README.md",
+              "inventory-json-sample": "INVENTORY-JSON-SAMPLE/README.md",
           }
 
           SCHEMA_MAP = {
@@ -183,6 +187,8 @@ jobs:
               "delivery-standalone":    "Lieferschein (Standalone)",
               "trace-forward":          "Trace-Forward (Wirkungsanalyse)",
               "trace-backward":         "Trace-Backward (Rückführungskette)",
+              "dakks-json-sample":      "DAkkS-Kalibrierschein (APEX · V2)",
+              "inventory-json-sample":  "Geräte-Datenblatt (APEX · V2)",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Alle aktuellen und früheren ZIP-Archive mit Reportvorlagen stehen als Release-P
 - [Letztes Release herunterladen (empfohlen)](https://github.com/calhelp/calServer-reports/releases/latest)
 - [Alle Releases durchsuchen](https://github.com/calhelp/calServer-reports/releases)
 
-**Hinweis für GitHub Pages:** Die Downloads-Seite funktioniert nur, wenn GitHub Pages auf den Branch `gh-pages` zeigt und der Workflow `publish-downloads` mindestens einmal erfolgreich gelaufen ist.
+**Hinweis für GitHub Pages:** Die Downloads-Seite wird vom Workflow `publish-downloads` gebaut und über die GitHub-Actions-Pages-Quelle (`actions/deploy-pages`) veröffentlicht — die Pages-Quelle muss in den Repo-Einstellungen auf **„GitHub Actions"** stehen (kein `gh-pages`-Branch nötig). Der Workflow muss mindestens einmal erfolgreich gelaufen sein.
 
 **Troubleshooting-Checkliste (optional):**
 - Existiert der Branch `gh-pages`?
@@ -223,7 +223,7 @@ Für Entwickler:innen und zum Testen der jeweils frisch gebauten Version gibt es
 calServer V2 verwendet ein neues Datenbankschema mit **lesbaren Feldnamen** (`serial_number`, `next_calibration_date`) statt der bisherigen Metrologie-Codes (`I4202`, `C2303`). Für die Reportvorlagen bedeutet das:
 
 - **Die bestehenden Bundles in diesem Repository bleiben der stabile V1-Stand** (eingebettetes SQL über JDBC mit den Codespalten). Sie laufen unverändert auf allen V1-Systemen und werden weiter mit Bugfixes gepflegt.
-- **Neue V2-Bundles** erscheinen künftig als Varianten mit **JSON-Datasource** und lesbaren API-Feldnamen (`$F{serial_number}` statt `$F{I4202}`). Die Daten liefert dann das calServer-Backend als berichtsförmiges JSON-Paket — die Vorlagen enthalten kein eigenes SQL mehr und funktionieren dadurch unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
+- **V2-Bundles** (Ordner mit Endung `-JSON-SAMPLE`, z. B. `DAKKS-JSON-SAMPLE`, `INVENTORY-JSON-SAMPLE`) nutzen eine **JSON-Datasource** mit lesbaren API-Feldnamen (`$F{serial_number}` statt `$F{I4202}`). Die Daten liefert das calServer-Backend als berichtsförmiges JSON-Paket — die Vorlagen enthalten kein eigenes SQL mehr und funktionieren dadurch unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL). Auf der [Downloads-Seite](https://calhelp.github.io/calServer-reports/downloads/) erscheinen sie in der eigenen Kategorie **„APEX · V2 (JSON-Datenquelle)"** (APEX = interner Codename für V2), getrennt von den V1-Vorlagen.
 - Bestehende Vorlagen bitte **nicht** auf das V2-Schema-SQL umschreiben — die Strategie und der Migrationspfad sind hier dokumentiert: [Evaluierung: JasperReports-Strategie für calServer V2](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md).
 - Als Übersetzungshilfe zwischen alten Codes und neuen Feldnamen dient weiterhin der [FIELD-NAMES-Report](FIELD-NAMES/) sowie die Mapping-Referenz in der Strategie-Dokumentation.
 

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -77,6 +77,11 @@
         const getCategory = (artifactName = "") => {
           const name = artifactName.toLowerCase();
 
+          // V2 (APEX) bundles use a JSON data source (readable api_name fields,
+          // no SQL). Grouped separately from the V1 (BASE) reports.
+          if (name.includes("-json-sample")) {
+            return "APEX · V2 (JSON-Datenquelle)";
+          }
           if (name.includes("sticker")) return "Sticker";
           if (name.includes("trace-forward") || name.includes("trace-backward")) {
             return "Trace";
@@ -107,6 +112,7 @@
         );
 
         const categoryOrder = [
+          "APEX · V2 (JSON-Datenquelle)",
           "Sticker",
           "Trace",
           "Kalibrier-/Zertifikatsberichte",

--- a/robots.md
+++ b/robots.md
@@ -30,9 +30,16 @@ The existing bundles in this repo are the stable **V1 contract**: embedded SQL e
 
 ### Rules
 - Do **NOT** rewrite existing bundles to query the calServer V2 schema (readable column names). They stay on the V1 contract and receive bug fixes only.
-- Future **V2 bundles** will use **JSON datasources** with readable API field names (`$F{serial_number}` instead of `$F{I4202}`); the data is supplied by the calServer backend, not by SQL inside the template. Structure and packaging rules for V2 bundles will be added here when the first V2 bundle lands.
+- **V2 bundles** use **JSON datasources** with readable API field names (`$F{serial_number}` instead of `$F{I4202}`); the data is supplied by the calServer backend, not by SQL inside the template.
 - Strategy and migration path: https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md
 - JasperReports 6.20.6 (section 0.1) remains binding for all bundles until the version policy is explicitly updated.
+
+### V2 (APEX) packaging rules (MUST — now live)
+- **Naming:** a V2 bundle folder ends with `-JSON-SAMPLE` (e.g. `DAKKS-JSON-SAMPLE`); its ZIP name is the lowercased form (e.g. `dakks-json-sample`). The packaging workflows and the downloads page key off this suffix.
+- **JSON sample allowed:** V2 bundles ship a `main_reports/sample-data.json` (a JSON data-adapter fixture). The `create_zip()` allowlist matches `*-JSON-SAMPLE` and keeps `*.json` — do NOT drop the sample. (Baseline allowlist is `*.jrxml`/`*.md` only; without the `*.json` branch the sample is deleted before zipping.)
+- **Downloads page:** V2 bundles appear in their own category **"APEX · V2 (JSON-Datenquelle)"** (matched on `-json-sample` in `downloads/index.html` `getCategory()`), separate from the V1 (BASE) reports. Add a `get_last_modified` line + `README_MAP`/`TITLE_MAP` entry in `publish-downloads.yml` for each new V2 bundle.
+- **No API upload / no release (for now):** V2 bundles are **downloads-page only**. Do NOT add `/api/report/<uuid>` upload steps or `release-reports.yml` entries for them unless that policy is explicitly changed.
+- Structure (`main_reports/` + `subreports/`) and the 6.20.6 pin apply unchanged.
 
 ---
 


### PR DESCRIPTION
## Zusammenfassung

Bisher hingen die V2-Bundles (`DAKKS-JSON-SAMPLE`, `INVENTORY-JSON-SAMPLE`) an **keinem** Workflow — sie wurden weder gepackt noch auf der Downloads-Seite angezeigt. Dieser PR verdrahtet sie ins Packaging und auf die gh-pages-Downloads-Seite, getrennt in einer eigenen Kategorie **„APEX · V2 (JSON-Datenquelle)"** (APEX = interner Codename für V2).

## Änderungen

- **`package-reports.yml`**: `upload-artifact`-Steps + `create_zip` für beide V2-Bundles. Die `create_zip()`-Allowlist matcht jetzt `*-JSON-SAMPLE` und behält `*.json` — sonst würde die mitgelieferte `main_reports/sample-data.json` (JSON-Data-Adapter-Fixture) vor dem Zippen gelöscht.
- **`publish-downloads.yml`**: `get_last_modified`-Zeilen + `README_MAP`/`TITLE_MAP`-Einträge (Titel „… (APEX · V2)").
- **`downloads/index.html`**: neue Kategorie in `getCategory()` (Match auf `-json-sample`) + an erster Stelle von `categoryOrder`.
- **`robots.md`**: verbindliche V2-(APEX)-Packaging-Sektion (Namenskonvention `*-JSON-SAMPLE`, `*.json`-Allowlist, downloads-only, **kein** API-Upload/Release).
- **`README.md`**: V2/APEX-Downloads-Kategorie beschrieben; veraltete `gh-pages`-Notiz auf `actions/deploy-pages` korrigiert.

## Verifikation
- Beide Workflows als YAML valide (`yaml.safe_load`).
- Allowlist-Logik lokal simuliert: `sample-data.json` bleibt erhalten, Fremddateien werden entfernt.
- `scripts/check_jasper_version.sh` grün (keine JRXML berührt).
- Der reale Pages-Deploy läuft erst nach Merge (Trigger `workflow_run` auf „Package Reports").

## Hinweis
Merge triggert `package-reports.yml` (kein Path-Filter) → danach `publish-downloads.yml`. Die V2-Bundles erscheinen dann in der neuen Kategorie. Kein API-Upload/Release für V2 (bewusst).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_