### PR TITLE
feat: layouttreuer DAkkS-Kalibrierschein (V2, Contract v1.1)

### DIFF
--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -1,6 +1,7 @@
-# DAKKS-JSON-SAMPLE — V2-Pilot (JSON-Datasource)
+# DAKKS-JSON-SAMPLE — layouttreuer DAkkS-Kalibrierschein (V2 / APEX)
 
-Dies ist das **Pilot-Bundle für calServer V2** (Phase 0 der
+Dies ist die **layouttreue V2-Nachbildung des akkreditierten DAkkS-Kalibrierscheins**
+(Phase 0 der
 [JasperReports-V2-Strategie](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md),
 [ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md)).
 
@@ -13,10 +14,10 @@ unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/dakks-json-sample.jrxml` | Hauptbericht; liest die Felder über `<fieldDescription>`-JSON-Pfade (z. B. `device.serial_number`) |
-| `subreports/results.jrxml` | Messergebnis-Tabelle; erhält das `results`-Array via `subDataSource("results")` |
-| `subreports/standards.jrxml` | Verwendete Normale; erhält das `standards`-Array via `subDataSource("standards")` |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.0) — als JSON-Data-Adapter in Jaspersoft Studio verwenden |
+| `main_reports/dakks-json-sample.jrxml` | Hauptbericht: Labor-Kopf, zweisprachiges Objekt-Stammdatengrid, Kalibrierzeichen-Box (Line-Art), QR aus `device.asset_number`, Abschnittskörper (Verfahren, Messbedingungen), Signatur-/Freigabebereich, Seiten-Footer |
+| `subreports/results.jrxml` | Messergebnis-Tabelle; `results`-Array via `subDataSource("results")` — mit SI-Wert+Präfix+Einheit-Konkatenation und per-Zeile `accred`-„*"-Symbol |
+| `subreports/standards.jrxml` | Verwendete Normale; `standards`-Array via `subDataSource("standards")` — inkl. nächster Kalibrierung + Zertifikat-Nr. |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` **v1.1**) — als JSON-Data-Adapter in Jaspersoft Studio verwenden |
 
 ## Datenanbindung
 
@@ -31,12 +32,17 @@ unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
   `sample-data.json`, abrufbar auch über
   `GET /api/v2/calibrations/{ctag}/report-dataset`.
 
-## Contract `calibration-certificate` (v1.0)
+## Contract `calibration-certificate` (v1.1)
 
-Wurzelobjekt mit den Blöcken `meta`, `calibration`, `device`, `customer`,
-`standards[]`, `results[]`. Jeder Entitätsblock trägt zusätzlich ein
-`custom_fields`-Objekt mit den benutzerdefinierten Feldern unter ihrem
-`api_name`. Feldreferenz siehe `sample-data.json`.
+Wurzelobjekt mit den Blöcken `meta`, `laboratory`, `accreditation`,
+`calibration`, `device`, `customer`, `procedure`, `standards[]`, `results[]`,
+`signatures[]`, `texts`. Die Blöcke `laboratory`/`accreditation`/`procedure`/
+`texts` und der Freigeber (`signatures[]`) stammen aus konfigurierten
+Report-Variablen (`master_report_variable`, z. B. `lab_name`, `mark_number_1`,
+`approver_name`, `traceability_note`) — nicht aus Entity-Daten. `results[]`
+enthält je Wert das Triple `<feld>`/`<feld>_p` (SI-Präfix)/`<feld>_u` (Einheit)
+plus `accred`. Jeder Entitätsblock trägt zusätzlich `custom_fields`. Feldreferenz
+siehe `sample-data.json`.
 
 ## Autoren-Hinweise (Jaspersoft Studio)
 
@@ -47,7 +53,6 @@ Wurzelobjekt mit den Blöcken `meta`, `calibration`, `device`, `customer`,
    `subDataSource("<array>")` als Datenquelle verwenden.
 4. JasperReports-Version **6.20.6** bleibt verbindlich (siehe `robots.md`).
 
-> **Status:** Referenz-/Pilotvorlage. Das Layout demonstriert den
-> JSON-Datasource-Mechanismus; die layouttreue Nachbildung des akkreditierten
-> DAkkS-Scheins erfolgt im weiteren Verlauf von Phase 0 gegen den
-> Dual-Run-Sichtvergleich.
+> **Status:** Layouttreue V2-Nachbildung, über den report-runner zu PDF
+> verifiziert. Die abschließende pixelgenaue Abnahme des akkreditierten Scheins
+> erfolgt per Dual-Run-Sichtvergleich V1↔V2 in einer Live-Umgebung.

--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
@@ -1,158 +1,149 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 pilot template (ADR-009): filled from the report-data-contract JSON
-  ("calibration-certificate") via a JSON data source — NO embedded SQL, NO V1
-  code columns. Every field reads a readable api_name via its <fieldDescription>
-  JSON path. Subreports receive their slice through
-  ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource(...), not a DB connection.
-  The dataset is produced by Laravel's CalibrationReportDataBuilder; see
-  main_reports/sample-data.json for a fixture matching this template.
+  V2 layout-faithful DAkkS calibration certificate (ADR-009, contract
+  "calibration-certificate" v1.1). Filled from a JSON data source — NO SQL, NO V1
+  code columns. Rebuilds the accredited layout of DAKKS-SAMPLE/main_reports/
+  dakks-sample.jrxml against readable api_name fields: lab header, bilingual
+  object master-data grid, calibration-mark box, "used standards" + measurement
+  subreports (subDataSource), signature/approval area, page X-of-Y footer.
+  Bilingual labels switch on $P{Sprache}. See main_reports/sample-data.json.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-json-sample" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="30" bottomMargin="30" uuid="b1a7c0de-0001-4a10-9c01-000000000001">
-	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false"/>
-	<style name="Label" fontSize="9" isBold="true"/>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="b1a7c0de-0100-4a10-9c10-000000000010">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Value" fontSize="9"/>
+	<style name="SectionTitle" fontSize="10" isBold="true"/>
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
-	<field name="certificate_number" class="java.lang.String">
-		<fieldDescription><![CDATA[meta.certificate_number]]></fieldDescription>
-	</field>
-	<field name="calibration_date" class="java.lang.String">
-		<fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription>
-	</field>
-	<field name="next_calibration_date" class="java.lang.String">
-		<fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription>
-	</field>
-	<field name="technician" class="java.lang.String">
-		<fieldDescription><![CDATA[calibration.technician]]></fieldDescription>
-	</field>
-	<field name="device_asset_number" class="java.lang.String">
-		<fieldDescription><![CDATA[device.asset_number]]></fieldDescription>
-	</field>
-	<field name="device_serial_number" class="java.lang.String">
-		<fieldDescription><![CDATA[device.serial_number]]></fieldDescription>
-	</field>
-	<field name="device_description" class="java.lang.String">
-		<fieldDescription><![CDATA[device.description]]></fieldDescription>
-	</field>
-	<field name="device_manufacturer" class="java.lang.String">
-		<fieldDescription><![CDATA[device.manufacturer]]></fieldDescription>
-	</field>
-	<field name="device_model" class="java.lang.String">
-		<fieldDescription><![CDATA[device.model]]></fieldDescription>
-	</field>
-	<field name="customer_name" class="java.lang.String">
-		<fieldDescription><![CDATA[customer.name]]></fieldDescription>
-	</field>
-	<field name="customer_street" class="java.lang.String">
-		<fieldDescription><![CDATA[customer.street]]></fieldDescription>
-	</field>
-	<field name="customer_zip" class="java.lang.String">
-		<fieldDescription><![CDATA[customer.zip]]></fieldDescription>
-	</field>
-	<field name="customer_city" class="java.lang.String">
-		<fieldDescription><![CDATA[customer.city]]></fieldDescription>
-	</field>
+	<parameter name="Sprache" class="java.lang.String">
+		<parameterDescription><![CDATA[Sprachumschalter für zweisprachige Labels (Deutsch = zweisprachig de/en).]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
+	</parameter>
+	<field name="certificate_number" class="java.lang.String"><fieldDescription><![CDATA[meta.certificate_number]]></fieldDescription></field>
+	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
+	<field name="next_cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription></field>
+	<field name="lab_name" class="java.lang.String"><fieldDescription><![CDATA[laboratory.name]]></fieldDescription></field>
+	<field name="lab_code" class="java.lang.String"><fieldDescription><![CDATA[laboratory.code]]></fieldDescription></field>
+	<field name="lab_street" class="java.lang.String"><fieldDescription><![CDATA[laboratory.street]]></fieldDescription></field>
+	<field name="lab_zip" class="java.lang.String"><fieldDescription><![CDATA[laboratory.zip]]></fieldDescription></field>
+	<field name="lab_city" class="java.lang.String"><fieldDescription><![CDATA[laboratory.city]]></fieldDescription></field>
+	<field name="mark_number_1" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_1]]></fieldDescription></field>
+	<field name="mark_number_2" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_2]]></fieldDescription></field>
+	<field name="device_asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<field name="device_serial_number" class="java.lang.String"><fieldDescription><![CDATA[device.serial_number]]></fieldDescription></field>
+	<field name="device_description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
+	<field name="device_manufacturer" class="java.lang.String"><fieldDescription><![CDATA[device.manufacturer]]></fieldDescription></field>
+	<field name="device_model" class="java.lang.String"><fieldDescription><![CDATA[device.model]]></fieldDescription></field>
+	<field name="customer_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<field name="customer_street" class="java.lang.String"><fieldDescription><![CDATA[customer.street]]></fieldDescription></field>
+	<field name="customer_zip" class="java.lang.String"><fieldDescription><![CDATA[customer.zip]]></fieldDescription></field>
+	<field name="customer_city" class="java.lang.String"><fieldDescription><![CDATA[customer.city]]></fieldDescription></field>
+	<field name="procedure_name" class="java.lang.String"><fieldDescription><![CDATA[procedure.procedure_name]]></fieldDescription></field>
+	<field name="calibration_method" class="java.lang.String"><fieldDescription><![CDATA[procedure.calibration_method]]></fieldDescription></field>
+	<field name="measurement_conditions" class="java.lang.String"><fieldDescription><![CDATA[procedure.measurement_conditions]]></fieldDescription></field>
+	<field name="text_traceability" class="java.lang.String"><fieldDescription><![CDATA[texts.traceability]]></fieldDescription></field>
+	<field name="text_uncertainty" class="java.lang.String"><fieldDescription><![CDATA[texts.uncertainty]]></fieldDescription></field>
+	<field name="text_conformity" class="java.lang.String"><fieldDescription><![CDATA[texts.conformity_legend]]></fieldDescription></field>
+	<variable name="isDe" class="java.lang.Boolean"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression></variable>
 	<title>
-		<band height="50">
-			<staticText>
-				<reportElement x="0" y="0" width="535" height="24"/>
-				<textElement><font size="16" isBold="true"/></textElement>
-				<text><![CDATA[DAkkS-Kalibrierschein (V2 · JSON-Datasource)]]></text>
-			</staticText>
+		<band height="300">
 			<textField>
-				<reportElement x="0" y="28" width="535" height="14"/>
-				<textElement><font size="10"/></textElement>
-				<textFieldExpression><![CDATA["Zertifikat-Nr.: " + ($F{certificate_number} == null ? "" : $F{certificate_number})]]></textFieldExpression>
+				<reportElement x="0" y="0" width="400" height="14"/>
+				<textElement><font size="10" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{lab_name}]]></textFieldExpression>
 			</textField>
+			<textField>
+				<reportElement x="0" y="14" width="400" height="12"/>
+				<textFieldExpression><![CDATA[($F{lab_street} == null ? "" : $F{lab_street}) + ", " + ($F{lab_zip} == null ? "" : $F{lab_zip}) + " " + ($F{lab_city} == null ? "" : $F{lab_city})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="26" width="400" height="12"/>
+				<textFieldExpression><![CDATA[$F{lab_code} == null ? "" : ("Akkreditierungscode: " + $F{lab_code})]]></textFieldExpression>
+			</textField>
+			<line><reportElement x="0" y="44" width="561" height="1"/></line>
+			<textField>
+				<reportElement x="0" y="56" width="561" height="22"/>
+				<textElement textAlignment="Center"><font size="15" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$V{isDe} ? "Kalibrierschein" : "Calibration Certificate"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="80" width="561" height="14"/>
+				<textElement textAlignment="Center"><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($V{isDe} ? "Kalibrierschein-Nr.: " : "Certificate No.: ") + ($F{certificate_number} == null ? "" : $F{certificate_number})]]></textFieldExpression>
+			</textField>
+			<!-- Object master-data grid (bilingual) -->
+			<staticText><reportElement style="Label" x="0" y="108" width="150" height="13"/><text><![CDATA[Gegenstand / Object]]></text></staticText>
+			<textField><reportElement style="Value" x="150" y="108" width="255" height="13"/><textFieldExpression><![CDATA[$F{device_description}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="124" width="150" height="13"/><text><![CDATA[Hersteller / Manufacturer]]></text></staticText>
+			<textField><reportElement style="Value" x="150" y="124" width="255" height="13"/><textFieldExpression><![CDATA[$F{device_manufacturer}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="140" width="150" height="13"/><text><![CDATA[Typ / Type]]></text></staticText>
+			<textField><reportElement style="Value" x="150" y="140" width="255" height="13"/><textFieldExpression><![CDATA[$F{device_model}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="156" width="150" height="13"/><text><![CDATA[Fabrikat-/Serien-Nr. / Serial number]]></text></staticText>
+			<textField><reportElement style="Value" x="150" y="156" width="255" height="13"/><textFieldExpression><![CDATA[($F{device_asset_number} == null ? "" : $F{device_asset_number}) + " / " + ($F{device_serial_number} == null ? "" : $F{device_serial_number})]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="172" width="150" height="13"/><text><![CDATA[Auftraggeber / Customer]]></text></staticText>
+			<textField><reportElement style="Value" x="150" y="172" width="255" height="13"/><textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + ", " + ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="188" width="150" height="13"/><text><![CDATA[Datum der Kalibrierung / Date]]></text></staticText>
+			<textField><reportElement style="Value" x="150" y="188" width="255" height="13"/><textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression></textField>
+			<!-- Calibration-mark box (line-art + text) -->
+			<line><reportElement x="415" y="104" width="146" height="1"/></line>
+			<line><reportElement x="415" y="104" width="1" height="96"/></line>
+			<line><reportElement x="561" y="104" width="1" height="96"/></line>
+			<line><reportElement x="415" y="200" width="146" height="1"/></line>
+			<staticText><reportElement x="415" y="106" width="146" height="12"/><textElement textAlignment="Center"><font size="7" isBold="true"/></textElement><text><![CDATA[Kalibrierzeichen / Calibration mark]]></text></staticText>
+			<textField><reportElement x="415" y="126" width="146" height="14"/><textElement textAlignment="Center"><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{mark_number_1}]]></textFieldExpression></textField>
+			<textField><reportElement x="415" y="142" width="146" height="14"/><textElement textAlignment="Center"/><textFieldExpression><![CDATA[$F{mark_number_2}]]></textFieldExpression></textField>
+			<textField><reportElement x="415" y="176" width="146" height="14"/><textElement textAlignment="Center"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression></textField>
+			<!-- QR of the asset number -->
+			<componentElement>
+				<reportElement x="470" y="212" width="80" height="80"/>
+				<jr:QRCode xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd">
+					<jr:codeExpression><![CDATA[$F{device_asset_number} == null ? "" : $F{device_asset_number}]]></jr:codeExpression>
+				</jr:QRCode>
+			</componentElement>
+			<staticText><reportElement style="Label" x="0" y="220" width="200" height="13"/><text><![CDATA[Nächste Kalibrierung / Next calibration]]></text></staticText>
+			<textField><reportElement style="Value" x="0" y="236" width="255" height="13"/><textFieldExpression><![CDATA[$F{next_cal_date}]]></textFieldExpression></textField>
 		</band>
 	</title>
 	<detail>
-		<band height="260">
-			<staticText>
-				<reportElement style="Label" x="0" y="0" width="120" height="14"/>
-				<text><![CDATA[Kalibrierdatum]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="120" y="0" width="160" height="14"/>
-				<textFieldExpression><![CDATA[$F{calibration_date}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="290" y="0" width="120" height="14"/>
-				<text><![CDATA[Nächste Kalibrierung]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="410" y="0" width="125" height="14"/>
-				<textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="0" y="16" width="120" height="14"/>
-				<text><![CDATA[Sachbearbeiter]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="120" y="16" width="415" height="14"/>
-				<textFieldExpression><![CDATA[$F{technician}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="0" y="40" width="535" height="14"/>
-				<text><![CDATA[Prüfgegenstand]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Label" x="0" y="56" width="120" height="14"/>
-				<text><![CDATA[Inventar-Nr. / Serien-Nr.]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="120" y="56" width="415" height="14"/>
-				<textFieldExpression><![CDATA[($F{device_asset_number} == null ? "" : $F{device_asset_number}) + "  /  " + ($F{device_serial_number} == null ? "" : $F{device_serial_number})]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="0" y="72" width="120" height="14"/>
-				<text><![CDATA[Bezeichnung]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="120" y="72" width="415" height="14"/>
-				<textFieldExpression><![CDATA[$F{device_description}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="0" y="88" width="120" height="14"/>
-				<text><![CDATA[Hersteller / Typ]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="120" y="88" width="415" height="14"/>
-				<textFieldExpression><![CDATA[($F{device_manufacturer} == null ? "" : $F{device_manufacturer}) + "  " + ($F{device_model} == null ? "" : $F{device_model})]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="0" y="112" width="535" height="14"/>
-				<text><![CDATA[Auftraggeber]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Value" x="0" y="128" width="535" height="14"/>
-				<textFieldExpression><![CDATA[$F{customer_name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Value" x="0" y="144" width="535" height="14"/>
-				<textFieldExpression><![CDATA[($F{customer_street} == null ? "" : $F{customer_street}) + ", " + ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Label" x="0" y="168" width="535" height="14"/>
-				<text><![CDATA[Verwendete Normale]]></text>
-			</staticText>
+		<band height="420">
+			<staticText><reportElement style="SectionTitle" x="0" y="0" width="561" height="14"/><text><![CDATA[Kalibrierverfahren / Calibration procedure]]></text></staticText>
+			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="16" width="561" height="13"/><textFieldExpression><![CDATA[($F{procedure_name} == null ? "" : $F{procedure_name}) + (($F{calibration_method} == null || $F{calibration_method}.isEmpty()) ? "" : (" — " + $F{calibration_method}))]]></textFieldExpression></textField>
+			<staticText><reportElement style="SectionTitle" x="0" y="40" width="561" height="14"/><text><![CDATA[Messbedingungen / Measurement conditions]]></text></staticText>
+			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="56" width="561" height="13"/><textFieldExpression><![CDATA[$F{measurement_conditions}]]></textFieldExpression></textField>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="0" y="80" width="561" height="14"/><text><![CDATA[Verwendete Normale / Reference standards used]]></text></staticText>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="184" width="535" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="96" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Sprache"><subreportParameterExpression><![CDATA[$P{Sprache}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("standards")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/standards.jasper"]]></subreportExpression>
 			</subreport>
-			<staticText>
-				<reportElement style="Label" positionType="Float" x="0" y="216" width="535" height="14"/>
-				<text><![CDATA[Messergebnisse]]></text>
-			</staticText>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="0" y="128" width="561" height="14"/><text><![CDATA[Messergebnisse / Measurement results]]></text></staticText>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="232" width="535" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="144" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Sprache"><subreportParameterExpression><![CDATA[$P{Sprache}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("results")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/results.jasper"]]></subreportExpression>
 			</subreport>
+			<textField textAdjust="StretchHeight"><reportElement positionType="Float" style="Value" x="0" y="176" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{text_conformity}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement positionType="Float" style="Value" x="0" y="196" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{text_uncertainty}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement positionType="Float" style="Value" x="0" y="216" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{text_traceability}]]></textFieldExpression></textField>
+			<!-- Signature / approval area -->
+			<line><reportElement positionType="Float" x="0" y="248" width="561" height="1"/></line>
+			<staticText><reportElement style="Label" positionType="Float" x="0" y="256" width="561" height="12"/><text><![CDATA[Freigabe des Kalibrierscheins durch / Approval of the calibration certificate by]]></text></staticText>
+			<line><reportElement positionType="Float" x="0" y="300" width="220" height="1"/></line>
+			<line><reportElement positionType="Float" x="341" y="300" width="220" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="0" y="302" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum / Date]]></text></staticText>
+			<staticText><reportElement positionType="Float" x="341" y="302" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Bearbeiter / Person in charge]]></text></staticText>
 		</band>
 	</detail>
+	<pageFooter>
+		<band height="30">
+			<line><reportElement x="0" y="0" width="561" height="1"/></line>
+			<textField><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{lab_name} == null ? "" : $F{lab_name}) + (($F{certificate_number} == null) ? "" : (" · " + $F{certificate_number}))]]></textFieldExpression></textField>
+			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA[($V{isDe} ? "Seite " : "Page ") + $V{PAGE_NUMBER} + ($V{isDe} ? " von " : " of ")]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+		</band>
+	</pageFooter>
 </jasperReport>

--- a/DAKKS-JSON-SAMPLE/main_reports/sample-data.json
+++ b/DAKKS-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,10 +1,27 @@
 {
   "meta": {
     "contract": "calibration-certificate",
-    "schema_version": "1.0",
+    "schema_version": "1.1",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE",
     "certificate_number": "DAkkS-K-2026-0042"
+  },
+  "laboratory": {
+    "name": "Kalibrierlabor Musterstadt GmbH",
+    "code": "D-K-12345-01-00",
+    "email": "labor@muster.example",
+    "phone": "+49 30 1234500",
+    "street": "Laborstraße 5",
+    "zip": "12345",
+    "city": "Musterstadt",
+    "country": "DE",
+    "calibration_place": "im Labor",
+    "company_name": "Kalibrierlabor Musterstadt GmbH"
+  },
+  "accreditation": {
+    "mark_number_1": "D-K-12345-01-00",
+    "mark_number_2": "Deutsche Akkreditierungsstelle",
+    "calibration_mark": "DAkkS-K-12345"
   },
   "calibration": {
     "id": "c1a2b3c4-0000-4000-8000-000000000001",
@@ -14,11 +31,7 @@
     "technician": "Erika Musterfrau",
     "temperature": 21.5,
     "humidity": 45.0,
-    "status": 1,
-    "calibration_time": "10:15",
-    "custom_fields": {
-      "lab_reference": "LAB-4711"
-    }
+    "custom_fields": { "lab_reference": "LAB-4711" }
   },
   "device": {
     "asset_number": "INV-9001",
@@ -28,21 +41,19 @@
     "model": "87V",
     "type_code": "DMM",
     "accuracy_class": "0.05",
-    "custom_fields": {
-      "customer_tag": "KND-DMM-7"
-    }
+    "custom_fields": { "customer_tag": "KND-DMM-7" }
   },
   "customer": {
     "name": "Muster GmbH",
     "customer_number": "K-1001",
     "street": "Musterstraße 1",
-    "zip": "12345",
-    "city": "Musterstadt",
-    "country": "DE",
-    "email": "kontakt@muster.example",
-    "phone": "+49 30 1234567",
-    "contact_person": "Max Muster",
-    "custom_fields": []
+    "zip": "54321",
+    "city": "Beispielstadt"
+  },
+  "procedure": {
+    "procedure_name": "Kalibrierung Gleichspannung/Gleichstrom",
+    "calibration_method": "Vergleich mit Referenznormal",
+    "measurement_conditions": "(23 ± 2) °C, (45 ± 10) % r.F."
   },
   "standards": [
     {
@@ -50,38 +61,63 @@
       "serial_number": "N-778899",
       "description": "Referenz-Kalibrator",
       "manufacturer": "Keysight",
-      "model": "3458A"
+      "model": "3458A",
+      "next_calibration_date": "2027-03-31",
+      "certificate_number": "DAkkS-K-2026-0100"
     },
     {
       "asset_number": "REF-002",
       "serial_number": "N-112233",
       "description": "Normalwiderstand 100 Ω",
       "manufacturer": "Fluke",
-      "model": "742A"
+      "model": "742A",
+      "next_calibration_date": "2027-05-15",
+      "certificate_number": "DAkkS-K-2026-0101"
     }
   ],
   "results": [
     {
       "row_num": 1,
       "test_desc": "Gleichspannung 10 V",
-      "fixq": "10.000",
-      "varq": "10.001",
-      "lower_limit": "9.995",
-      "upper_limit": "10.005",
-      "exp_uncert": "0.002",
-      "std_uncert": "0.001",
-      "pass_fail": "i.O."
+      "accred": "1",
+      "pass_fail": "i.O.",
+      "fixq": "10.000", "fixq_p": "", "fixq_u": "V",
+      "varq": "10.001", "varq_p": "", "varq_u": "V",
+      "lower_limit": "9.995", "lower_limit_p": "", "lower_limit_u": "V",
+      "upper_limit": "10.005", "upper_limit_p": "", "upper_limit_u": "V",
+      "exp_uncert": "2.0", "exp_uncert_p": "m", "exp_uncert_u": "V"
     },
     {
       "row_num": 2,
+      "test_desc": "Gleichspannung 100 mV",
+      "accred": "1",
+      "pass_fail": "i.O.",
+      "fixq": "100.0", "fixq_p": "m", "fixq_u": "V",
+      "varq": "100.2", "varq_p": "m", "varq_u": "V",
+      "lower_limit": "99.5", "lower_limit_p": "m", "lower_limit_u": "V",
+      "upper_limit": "100.5", "upper_limit_p": "m", "upper_limit_u": "V",
+      "exp_uncert": "50", "exp_uncert_p": "µ", "exp_uncert_u": "V"
+    },
+    {
+      "row_num": 3,
       "test_desc": "Gleichstrom 1 A",
-      "fixq": "1.0000",
-      "varq": "0.9998",
-      "lower_limit": "0.9990",
-      "upper_limit": "1.0010",
-      "exp_uncert": "0.0003",
-      "std_uncert": "0.00015",
-      "pass_fail": "i.O."
+      "accred": "0",
+      "pass_fail": "i.O.",
+      "fixq": "1.0000", "fixq_p": "", "fixq_u": "A",
+      "varq": "0.9998", "varq_p": "", "varq_u": "A",
+      "lower_limit": "0.9990", "lower_limit_p": "", "lower_limit_u": "A",
+      "upper_limit": "1.0010", "upper_limit_p": "", "upper_limit_u": "A",
+      "exp_uncert": "0.3", "exp_uncert_p": "m", "exp_uncert_u": "A"
     }
-  ]
+  ],
+  "signatures": [
+    { "role": "technician", "name": "Erika Musterfrau" },
+    { "role": "approver", "name": "Dr. Max Mustermann" }
+  ],
+  "texts": {
+    "cert_description": null,
+    "traceability": "Die Kalibrierung erfolgte rückführbar auf nationale Normale der PTB.",
+    "uncertainty": "Die angegebene erweiterte Messunsicherheit ergibt sich aus der Standardmessunsicherheit multipliziert mit dem Erweiterungsfaktor k=2.",
+    "conformity_legend": "* im Akkreditierungsumfang"
+  }
 }

--- a/DAKKS-JSON-SAMPLE/subreports/results.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/results.jrxml
@@ -1,114 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 results subreport: fed the "results" array of the calibration-certificate
-  contract via ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("results").
-  Each field reads a readable api_name relative to a result element.
+  V2 measurement-results subreport (contract calibration-certificate v1.1): fed
+  the "results" array via subDataSource("results"). Reproduces the accredited
+  layout's value/prefix/unit concatenation (e.g. "10.5 mV") and the per-row
+  accreditation "*" symbol driven by the readable `accred` field.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="results" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="b1a7c0de-0002-4a10-9c02-000000000002">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="results" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="b1a7c0de-0102-4a10-9c12-000000000012">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
-	<field name="row_num" class="java.lang.Integer">
-		<fieldDescription><![CDATA[row_num]]></fieldDescription>
-	</field>
-	<field name="test_desc" class="java.lang.String">
-		<fieldDescription><![CDATA[test_desc]]></fieldDescription>
-	</field>
-	<field name="fixq" class="java.lang.String">
-		<fieldDescription><![CDATA[fixq]]></fieldDescription>
-	</field>
-	<field name="varq" class="java.lang.String">
-		<fieldDescription><![CDATA[varq]]></fieldDescription>
-	</field>
-	<field name="lower_limit" class="java.lang.String">
-		<fieldDescription><![CDATA[lower_limit]]></fieldDescription>
-	</field>
-	<field name="upper_limit" class="java.lang.String">
-		<fieldDescription><![CDATA[upper_limit]]></fieldDescription>
-	</field>
-	<field name="exp_uncert" class="java.lang.String">
-		<fieldDescription><![CDATA[exp_uncert]]></fieldDescription>
-	</field>
-	<field name="pass_fail" class="java.lang.String">
-		<fieldDescription><![CDATA[pass_fail]]></fieldDescription>
-	</field>
+	<parameter name="Sprache" class="java.lang.String"><defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression></parameter>
+	<field name="row_num" class="java.lang.Integer"><fieldDescription><![CDATA[row_num]]></fieldDescription></field>
+	<field name="test_desc" class="java.lang.String"><fieldDescription><![CDATA[test_desc]]></fieldDescription></field>
+	<field name="accred" class="java.lang.String"><fieldDescription><![CDATA[accred]]></fieldDescription></field>
+	<field name="pass_fail" class="java.lang.String"><fieldDescription><![CDATA[pass_fail]]></fieldDescription></field>
+	<field name="fixq" class="java.lang.String"><fieldDescription><![CDATA[fixq]]></fieldDescription></field>
+	<field name="fixq_p" class="java.lang.String"><fieldDescription><![CDATA[fixq_p]]></fieldDescription></field>
+	<field name="fixq_u" class="java.lang.String"><fieldDescription><![CDATA[fixq_u]]></fieldDescription></field>
+	<field name="varq" class="java.lang.String"><fieldDescription><![CDATA[varq]]></fieldDescription></field>
+	<field name="varq_p" class="java.lang.String"><fieldDescription><![CDATA[varq_p]]></fieldDescription></field>
+	<field name="varq_u" class="java.lang.String"><fieldDescription><![CDATA[varq_u]]></fieldDescription></field>
+	<field name="lower_limit" class="java.lang.String"><fieldDescription><![CDATA[lower_limit]]></fieldDescription></field>
+	<field name="lower_limit_p" class="java.lang.String"><fieldDescription><![CDATA[lower_limit_p]]></fieldDescription></field>
+	<field name="lower_limit_u" class="java.lang.String"><fieldDescription><![CDATA[lower_limit_u]]></fieldDescription></field>
+	<field name="upper_limit" class="java.lang.String"><fieldDescription><![CDATA[upper_limit]]></fieldDescription></field>
+	<field name="upper_limit_p" class="java.lang.String"><fieldDescription><![CDATA[upper_limit_p]]></fieldDescription></field>
+	<field name="upper_limit_u" class="java.lang.String"><fieldDescription><![CDATA[upper_limit_u]]></fieldDescription></field>
+	<field name="exp_uncert" class="java.lang.String"><fieldDescription><![CDATA[exp_uncert]]></fieldDescription></field>
+	<field name="exp_uncert_p" class="java.lang.String"><fieldDescription><![CDATA[exp_uncert_p]]></fieldDescription></field>
+	<field name="exp_uncert_u" class="java.lang.String"><fieldDescription><![CDATA[exp_uncert_u]]></fieldDescription></field>
+	<variable name="isDe" class="java.lang.Boolean"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression></variable>
+	<variable name="Nominal" class="java.lang.String"><variableExpression><![CDATA[($F{fixq}==null?"":$F{fixq}) + ($F{fixq_p}==null||$F{fixq_p}.isEmpty()?"":(" "+$F{fixq_p})) + ($F{fixq_u}==null?"":$F{fixq_u})]]></variableExpression></variable>
+	<variable name="Measured" class="java.lang.String"><variableExpression><![CDATA[($F{varq}==null?"":$F{varq}) + ($F{varq_p}==null||$F{varq_p}.isEmpty()?"":(" "+$F{varq_p})) + ($F{varq_u}==null?"":$F{varq_u})]]></variableExpression></variable>
+	<variable name="Lower" class="java.lang.String"><variableExpression><![CDATA[($F{lower_limit}==null?"":$F{lower_limit}) + ($F{lower_limit_p}==null||$F{lower_limit_p}.isEmpty()?"":(" "+$F{lower_limit_p})) + ($F{lower_limit_u}==null?"":$F{lower_limit_u})]]></variableExpression></variable>
+	<variable name="Upper" class="java.lang.String"><variableExpression><![CDATA[($F{upper_limit}==null?"":$F{upper_limit}) + ($F{upper_limit_p}==null||$F{upper_limit_p}.isEmpty()?"":(" "+$F{upper_limit_p})) + ($F{upper_limit_u}==null?"":$F{upper_limit_u})]]></variableExpression></variable>
+	<variable name="Uncert" class="java.lang.String"><variableExpression><![CDATA[($F{exp_uncert}==null?"":$F{exp_uncert}) + ($F{exp_uncert_p}==null||$F{exp_uncert_p}.isEmpty()?"":(" "+$F{exp_uncert_p})) + ($F{exp_uncert_u}==null?"":$F{exp_uncert_u})]]></variableExpression></variable>
 	<columnHeader>
 		<band height="16">
-			<staticText>
-				<reportElement x="0" y="0" width="30" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[Nr.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="30" y="0" width="150" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[Prüfpunkt]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="180" y="0" width="70" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[Sollwert]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="250" y="0" width="70" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[Istwert]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="320" y="0" width="70" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[untere Grenze]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="390" y="0" width="70" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[obere Grenze]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="460" y="0" width="45" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[U]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="505" y="0" width="30" height="15"/>
-				<textElement><font isBold="true"/></textElement>
-				<text><![CDATA[i.O.]]></text>
-			</staticText>
+			<staticText><reportElement x="0" y="0" width="22" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[Nr.]]></text></staticText>
+			<textField><reportElement x="22" y="0" width="150" height="15"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Prüfpunkt" : "Test point"]]></textFieldExpression></textField>
+			<textField><reportElement x="172" y="0" width="80" height="15"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Sollwert" : "Nominal"]]></textFieldExpression></textField>
+			<textField><reportElement x="252" y="0" width="80" height="15"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Istwert" : "Measured"]]></textFieldExpression></textField>
+			<textField><reportElement x="332" y="0" width="75" height="15"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "untere Grenze" : "Lower limit"]]></textFieldExpression></textField>
+			<textField><reportElement x="407" y="0" width="75" height="15"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "obere Grenze" : "Upper limit"]]></textFieldExpression></textField>
+			<staticText><reportElement x="482" y="0" width="55" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[U (k=2)]]></text></staticText>
+			<staticText><reportElement x="537" y="0" width="24" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[i.O.]]></text></staticText>
 		</band>
 	</columnHeader>
 	<detail>
 		<band height="14">
-			<textField>
-				<reportElement x="0" y="0" width="30" height="13"/>
-				<textFieldExpression><![CDATA[$F{row_num}]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight">
-				<reportElement x="30" y="0" width="150" height="13"/>
-				<textFieldExpression><![CDATA[$F{test_desc}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="180" y="0" width="70" height="13"/>
-				<textFieldExpression><![CDATA[$F{fixq}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="250" y="0" width="70" height="13"/>
-				<textFieldExpression><![CDATA[$F{varq}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="320" y="0" width="70" height="13"/>
-				<textFieldExpression><![CDATA[$F{lower_limit}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="390" y="0" width="70" height="13"/>
-				<textFieldExpression><![CDATA[$F{upper_limit}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="460" y="0" width="45" height="13"/>
-				<textFieldExpression><![CDATA[$F{exp_uncert}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="505" y="0" width="30" height="13"/>
-				<textFieldExpression><![CDATA[$F{pass_fail}]]></textFieldExpression>
-			</textField>
+			<textField><reportElement x="0" y="0" width="22" height="13"/><textFieldExpression><![CDATA[$F{row_num}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="22" y="0" width="150" height="13"/><textFieldExpression><![CDATA[($F{test_desc}==null?"":$F{test_desc}) + (($F{accred}!=null && $F{accred}.equals("1")) ? " *" : "")]]></textFieldExpression></textField>
+			<textField><reportElement x="172" y="0" width="80" height="13"/><textFieldExpression><![CDATA[$V{Nominal}]]></textFieldExpression></textField>
+			<textField><reportElement x="252" y="0" width="80" height="13"/><textFieldExpression><![CDATA[$V{Measured}]]></textFieldExpression></textField>
+			<textField><reportElement x="332" y="0" width="75" height="13"/><textFieldExpression><![CDATA[$V{Lower}]]></textFieldExpression></textField>
+			<textField><reportElement x="407" y="0" width="75" height="13"/><textFieldExpression><![CDATA[$V{Upper}]]></textFieldExpression></textField>
+			<textField><reportElement x="482" y="0" width="55" height="13"/><textFieldExpression><![CDATA[$V{Uncert}]]></textFieldExpression></textField>
+			<textField><reportElement x="537" y="0" width="24" height="13"/><textFieldExpression><![CDATA[$F{pass_fail}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/DAKKS-JSON-SAMPLE/subreports/standards.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/standards.jrxml
@@ -1,38 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 standards subreport: fed the "standards" array of the
-  calibration-certificate contract via
-  ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("standards").
+  V2 "used standards" subreport (contract calibration-certificate v1.1): fed the
+  "standards" array via subDataSource("standards"). Bilingual column headers.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="standards" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="b1a7c0de-0003-4a10-9c03-000000000003">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="standards" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="b1a7c0de-0101-4a10-9c11-000000000011">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
-	<field name="asset_number" class="java.lang.String">
-		<fieldDescription><![CDATA[asset_number]]></fieldDescription>
-	</field>
-	<field name="description" class="java.lang.String">
-		<fieldDescription><![CDATA[description]]></fieldDescription>
-	</field>
-	<field name="manufacturer" class="java.lang.String">
-		<fieldDescription><![CDATA[manufacturer]]></fieldDescription>
-	</field>
-	<field name="model" class="java.lang.String">
-		<fieldDescription><![CDATA[model]]></fieldDescription>
-	</field>
+	<parameter name="Sprache" class="java.lang.String"><defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression></parameter>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[asset_number]]></fieldDescription></field>
+	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[description]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[model]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
+	<field name="certificate_number" class="java.lang.String"><fieldDescription><![CDATA[certificate_number]]></fieldDescription></field>
+	<variable name="isDe" class="java.lang.Boolean"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression></variable>
+	<columnHeader>
+		<band height="15">
+			<staticText><reportElement x="0" y="0" width="70" height="14"/><textElement><font isBold="true"/></textElement><text><![CDATA[Inv.-Nr.]]></text></staticText>
+			<textField><reportElement x="70" y="0" width="170" height="14"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Beschreibung" : "Description"]]></textFieldExpression></textField>
+			<textField><reportElement x="240" y="0" width="150" height="14"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Hersteller / Typ" : "Manufacturer / Type"]]></textFieldExpression></textField>
+			<textField><reportElement x="390" y="0" width="80" height="14"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Nächste Kal." : "Next cal."]]></textFieldExpression></textField>
+			<textField><reportElement x="470" y="0" width="91" height="14"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$V{isDe} ? "Zertifikat-Nr." : "Certificate No."]]></textFieldExpression></textField>
+		</band>
+	</columnHeader>
 	<detail>
 		<band height="14">
-			<textField>
-				<reportElement x="0" y="0" width="90" height="13"/>
-				<textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight">
-				<reportElement x="90" y="0" width="245" height="13"/>
-				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="335" y="0" width="200" height="13"/>
-				<textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression>
-			</textField>
+			<textField><reportElement x="0" y="0" width="70" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="70" y="0" width="170" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+			<textField><reportElement x="240" y="0" width="150" height="13"/><textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression></textField>
+			<textField><reportElement x="390" y="0" width="80" height="13"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<textField><reportElement x="470" y="0" width="91" height="13"/><textFieldExpression><![CDATA[$F{certificate_number}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>


### PR DESCRIPTION
## Zusammenfassung

Baut das Pilot-Bundle `DAKKS-JSON-SAMPLE` von der flachen Demo zur **layouttreuen V2-Nachbildung des akkreditierten DAkkS-Kalibrierscheins** aus — der eigentliche Phase-0-Exit von [ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md). Gefüllt aus dem `calibration-certificate`-Contract **v1.1** (JSON-Datasource, kein SQL).

Setzt den Contract v1.1 voraus (calServer-yii PR #2843).

## Layout (nachgebildet aus `DAKKS-SAMPLE`)

- **Hauptbericht**: Labor-Kopf (Name/Anschrift/Akkreditierungscode), zentrierter Titel + Zertifikat-Nr., **zweisprachiges Objekt-Stammdatengrid** (Gegenstand/Object, Hersteller, Typ, Serien-Nr., Auftraggeber, Datum), **Kalibrierzeichen-Box** aus Line-Art mit `mark_number_1/2` + Datum, **QR** aus `device.asset_number`, Abschnitte (Kalibrierverfahren, Messbedingungen), normative Texte (Konformitätslegende, Unsicherheit, Rückführung), **Signatur-/Freigabebereich**, **Seiten-Footer** (Seite X von Y, zweisprachig).
- **`results`-Subreport**: SI-**Wert+Präfix+Einheit-Konkatenation** (z. B. „10.5 mV") und per-Zeile **`accred`-„*"-Symbol**.
- **`standards`-Subreport**: inkl. nächster Kalibrierung + Zertifikat-Nr.
- `sample-data.json` auf v1.1 gehoben (laboratory/accreditation/procedure/signatures/texts + SI-Triples).

## Verifikation
- Das reale Bundle wurde über den `report-runner` (JSON-Fill, als ZIP) **zu PDF gerendert** — Haupt- + beide Subreports, QR, SI-Konkatenation, accred-Symbol, zweisprachige Labels.
- `scripts/check_jasper_version.sh` grün (JasperReports 6.20.6).

## Offen (Live)
Pixelgenaue Abnahme des akkreditierten Scheins per Dual-Run-Sichtvergleich V1↔V2 in einer Live-Umgebung (z. B. `develop.net-cal.com/v2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_