### PR TITLE
fix(dakks-json-sample): leeres Blatt beheben — isDe-Init + Studio-JSON-Adapter

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -216,8 +216,9 @@ jobs:
               allowed_patterns+=('*.xsd' '*.json')
             elif [[ "$sample" == *-JSON-SAMPLE ]]; then
               # V2 (APEX) bundles ship a JSON data-adapter sample (sample-data.json)
-              # next to the JRXML — keep *.json in the ZIP.
-              allowed_patterns+=('*.json')
+              # plus a Jaspersoft Studio data-adapter (*.xml) so the report
+              # previews out-of-the-box — keep both in the ZIP.
+              allowed_patterns+=('*.json' '*.xml')
             fi
 
             rm -rf "${stage_dir}"

--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -17,7 +17,31 @@ unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
 | `main_reports/dakks-json-sample.jrxml` | Hauptbericht: Labor-Kopf, zweisprachiges Objekt-Stammdatengrid, Kalibrierzeichen-Box (Line-Art), QR aus `device.asset_number`, Abschnittskörper (Verfahren, Messbedingungen), Signatur-/Freigabebereich, Seiten-Footer |
 | `subreports/results.jrxml` | Messergebnis-Tabelle; `results`-Array via `subDataSource("results")` — mit SI-Wert+Präfix+Einheit-Konkatenation und per-Zeile `accred`-„*"-Symbol |
 | `subreports/standards.jrxml` | Verwendete Normale; `standards`-Array via `subDataSource("standards")` — inkl. nächster Kalibrierung + Zertifikat-Nr. |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` **v1.1**) — als JSON-Data-Adapter in Jaspersoft Studio verwenden |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` **v1.1**) |
+| `main_reports/dakks-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
+
+## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
+
+Dieses Bundle ist **datenquellenlos**: Der Bericht enthält **kein** eingebettetes
+SQL und **keine** Beispieldaten im Template selbst. Er rendert nur dann Inhalt,
+wenn ihm eine **JSON-Datenquelle** übergeben wird. Wird er ohne Datenquelle
+ausgeführt — z. B. „Preview" in Jaspersoft Studio ohne konfigurierten
+Data-Adapter, oder Generierung in der Live-Umgebung **ohne** die Report-Variable
+`data_contract` — bleibt die Seite leer bzw. der Lauf bricht auf dem
+Subreport-`subDataSource(...)`-Aufruf ab. Das ist **kein** Template-Fehler,
+sondern die fehlende Datenanbindung. Abhilfe:
+
+- **Vorschau ohne Backend (Jaspersoft Studio):** Das Bundle bringt den Adapter
+  `dakks-json-sample_adapter.xml` mit und referenziert ihn über die
+  Report-Property `com.jaspersoft.studio.data.defadapter`. „Open → Preview"
+  füllt den Schein direkt aus `sample-data.json`. Falls die Studio-Version den
+  Default-Adapter nicht automatisch zieht, den Adapter im Vorschau-Dropdown
+  einmalig auswählen.
+- **Live-Umgebung (calServer V2):** Auf dem Report-Setting die report-scoped
+  Variable `data_contract = calibration-certificate` setzen — dann liefert das
+  Backend (`CalibrationReportDataBuilder`) den JSON-Datensatz an den Runner.
+  Ohne diese Variable läuft der klassische JDBC-Pfad, der hier mangels
+  `<queryString>` keine Daten hat.
 
 ## Datenanbindung
 
@@ -46,8 +70,9 @@ siehe `sample-data.json`.
 
 ## Autoren-Hinweise (Jaspersoft Studio)
 
-1. In Studio einen **JSON-Data-Adapter** anlegen und auf `sample-data.json`
-   zeigen lassen.
+1. Der mitgelieferte **JSON-Data-Adapter** (`dakks-json-sample_adapter.xml`)
+   zeigt bereits auf `sample-data.json` und ist als Default-Adapter hinterlegt —
+   „Preview" genügt. (Alternativ selbst einen JSON-Data-Adapter anlegen.)
 2. Felder über ihren JSON-Pfad (`<fieldDescription>`) binden, nicht über SQL.
 3. Für wiederkehrende Listen (Ergebnisse, Normale) ein Subreport mit
    `subDataSource("<array>")` als Datenquelle verwenden.

--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
@@ -10,6 +10,10 @@
   Bilingual labels switch on $P{Sprache}. See main_reports/sample-data.json.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="b1a7c0de-0100-4a10-9c10-000000000010">
+	<!-- Studio-only: preview fills from sample-data.json via the bundled adapter.
+	     Ignored by the report-runner, which is handed the JSON datasource by the
+	     calServer V2 backend at runtime (see README). -->
+	<property name="com.jaspersoft.studio.data.defadapter" value="dakks-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Value" fontSize="9"/>
@@ -46,7 +50,11 @@
 	<field name="text_traceability" class="java.lang.String"><fieldDescription><![CDATA[texts.traceability]]></fieldDescription></field>
 	<field name="text_uncertainty" class="java.lang.String"><fieldDescription><![CDATA[texts.uncertainty]]></fieldDescription></field>
 	<field name="text_conformity" class="java.lang.String"><fieldDescription><![CDATA[texts.conformity_legend]]></fieldDescription></field>
-	<variable name="isDe" class="java.lang.Boolean"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression></variable>
+	<!-- Language flag. Needs an initialValueExpression: the title band (and any
+	     other report-level band) is evaluated before the first detail record, so
+	     without an initial value $V{isDe} would be null there and the bilingual
+	     ternaries in the title would render "null". -->
+	<variable name="isDe" class="java.lang.Boolean" calculation="Nothing"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression><initialValueExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></initialValueExpression></variable>
 	<title>
 		<band height="300">
 			<textField>

--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample_adapter.xml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample_adapter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the DAkkS V2 sample.
+
+  Bundled so the report previews out-of-the-box: opening
+  dakks-json-sample.jrxml and hitting "Preview" fills it from the sibling
+  sample-data.json (contract calibration-certificate v1.1) via this adapter,
+  referenced by the report property com.jaspersoft.studio.data.defadapter.
+
+  This is an AUTHORING/PREVIEW aid only. It is a Studio-namespaced property and
+  is inert in the report-runner: at runtime the calServer V2 backend supplies
+  the JSON datasource itself (see README → "Datenanbindung"). If your Studio
+  version does not auto-apply it, pick this adapter manually in the preview
+  data-adapter dropdown.
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>DAkkS JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/DAKKS-JSON-SAMPLE/subreports/results.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/results.jrxml
@@ -28,7 +28,10 @@
 	<field name="exp_uncert" class="java.lang.String"><fieldDescription><![CDATA[exp_uncert]]></fieldDescription></field>
 	<field name="exp_uncert_p" class="java.lang.String"><fieldDescription><![CDATA[exp_uncert_p]]></fieldDescription></field>
 	<field name="exp_uncert_u" class="java.lang.String"><fieldDescription><![CDATA[exp_uncert_u]]></fieldDescription></field>
-	<variable name="isDe" class="java.lang.Boolean"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression></variable>
+	<!-- initialValueExpression required: the columnHeader band prints before the
+	     first detail record, so without it $V{isDe} would be null there and the
+	     bilingual header labels would render "null". -->
+	<variable name="isDe" class="java.lang.Boolean" calculation="Nothing"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression><initialValueExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></initialValueExpression></variable>
 	<variable name="Nominal" class="java.lang.String"><variableExpression><![CDATA[($F{fixq}==null?"":$F{fixq}) + ($F{fixq_p}==null||$F{fixq_p}.isEmpty()?"":(" "+$F{fixq_p})) + ($F{fixq_u}==null?"":$F{fixq_u})]]></variableExpression></variable>
 	<variable name="Measured" class="java.lang.String"><variableExpression><![CDATA[($F{varq}==null?"":$F{varq}) + ($F{varq_p}==null||$F{varq_p}.isEmpty()?"":(" "+$F{varq_p})) + ($F{varq_u}==null?"":$F{varq_u})]]></variableExpression></variable>
 	<variable name="Lower" class="java.lang.String"><variableExpression><![CDATA[($F{lower_limit}==null?"":$F{lower_limit}) + ($F{lower_limit_p}==null||$F{lower_limit_p}.isEmpty()?"":(" "+$F{lower_limit_p})) + ($F{lower_limit_u}==null?"":$F{lower_limit_u})]]></variableExpression></variable>

--- a/DAKKS-JSON-SAMPLE/subreports/standards.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/standards.jrxml
@@ -13,7 +13,10 @@
 	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[model]]></fieldDescription></field>
 	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
 	<field name="certificate_number" class="java.lang.String"><fieldDescription><![CDATA[certificate_number]]></fieldDescription></field>
-	<variable name="isDe" class="java.lang.Boolean"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression></variable>
+	<!-- initialValueExpression required: the columnHeader band prints before the
+	     first detail record, so without it $V{isDe} would be null there and the
+	     bilingual header labels would render "null". -->
+	<variable name="isDe" class="java.lang.Boolean" calculation="Nothing"><variableExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></variableExpression><initialValueExpression><![CDATA[$P{Sprache} == null || $P{Sprache}.equals("Deutsch")]]></initialValueExpression></variable>
 	<columnHeader>
 		<band height="15">
 			<staticText><reportElement x="0" y="0" width="70" height="14"/><textElement><font isBold="true"/></textElement><text><![CDATA[Inv.-Nr.]]></text></staticText>


### PR DESCRIPTION
## Problem

Der layouttreue V2-DAkkS-Schein (`DAKKS-JSON-SAMPLE`) rendert als **komplett weißes Blatt** bzw. zeigt in den Kopfzeilen `null`. Gemeldet aus der Praxis: „ein komplett weißes Blatt anstatt der bekannte DAkkS-Sample-Jasper".

## Ursachenanalyse (per report-runner reproduziert, JasperReports 6.20.6, JSON-Fill-Pfad)

Ein Wegwerf-Render über den `report-runner` (Fill aus `sample-data.json`, PDF/Text-Export) hat zwei Ursachen belegt:

1. **`$V{isDe}` in report-level Bändern = `null`.** Die Variable wurde im `title`-Band des Hauptberichts und im `columnHeader`-Band beider Subreports **vor dem ersten Detail-Record** ausgewertet. Ohne Initialwert war sie dort `null`, sodass die zweisprachigen Ternaries den String `"null"` druckten — betroffen: Titel „Kalibrierschein", „Kalibrierschein-Nr.", sowie die Spaltenüberschriften „Prüfpunkt/Sollwert/Istwert/…" (results) und „Beschreibung/Hersteller/…" (standards). Gezählt: 9× `"null"`.
2. **Datenquellenlose Vorschau.** Das Bundle enthält bewusst **kein** eingebettetes SQL und **keine** Template-Daten. Wird es ohne JSON-Datenquelle ausgeführt (Studio-Preview ohne Adapter, oder Live-Generierung ohne die Report-Variable `data_contract`), bleibt die Seite leer bzw. der Lauf bricht auf `subDataSource(...)` ab — kein Template-Fehler, sondern fehlende Datenanbindung.

## Fix

- **`initialValueExpression`** an der `isDe`-Variable in allen drei Templates (`main_reports/dakks-json-sample.jrxml`, `subreports/results.jrxml`, `subreports/standards.jrxml`).
- **Turnkey-Vorschau:** Neuer Jaspersoft-Studio-JSON-Data-Adapter `main_reports/dakks-json-sample_adapter.xml` auf `sample-data.json`, referenziert über die Report-Property `com.jaspersoft.studio.data.defadapter`. Diese Property ist **Studio-only** und im report-runner **inert** — dort liefert das V2-Backend (`CalibrationReportDataBuilder`) die JSON-Datenquelle. (Die runtime-Property `net.sf.jasperreports.data.adapter` wurde bewusst **nicht** gesetzt: sie greift laut Test auch bei explizit übergebener Datenquelle und wäre produktionsunsicher.)
- **Packaging:** `*.xml` in die Allowlist der `*-JSON-SAMPLE`-Bundles aufgenommen, damit der Adapter im ZIP mitgeliefert wird.
- **README:** Neuer Abschnitt „⚠️ Warum ein leeres/weißes Blatt erscheinen kann" mit den zwei Anbindungswegen (Studio-Adapter bzw. Report-Variable `data_contract=calibration-certificate`).

## Verifikation

- Render über `report-runner` → **2 Seiten**, vollständiger Inhalt: Labor-Kopf, zweisprachiges Objektgrid, Kalibrierzeichen-Box, Verfahren/Messbedingungen, Normale- und Ergebnis-Subreport mit korrekten Überschriften + SI-Präfix-Konkatenation („2.0 mV", „50 µV") + accred-„*", Signaturbereich, Seiten-Footer. **0× `"null"`.**
- `scripts/check_jasper_version.sh` grün (alle JRXML 6.20.6).
- `xmllint` well-formed für alle geänderten Templates + Adapter.
- report-runner-Suite (im yii-Repo) weiterhin grün.

## Änderungen

| Datei | Änderung |
|-------|----------|
| `DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml` | `isDe` initialValueExpression; Studio-defadapter-Property |
| `DAKKS-JSON-SAMPLE/subreports/results.jrxml` | `isDe` initialValueExpression |
| `DAKKS-JSON-SAMPLE/subreports/standards.jrxml` | `isDe` initialValueExpression |
| `DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample_adapter.xml` | **neu** — Studio-JSON-Data-Adapter auf `sample-data.json` |
| `.github/workflows/package-reports.yml` | `*.xml` in Allowlist der JSON-Bundles |
| `DAKKS-JSON-SAMPLE/README.md` | Abschnitt „leeres Blatt"; Adapter-Hinweise |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_