### PR TITLE
feat(apex): Phase C — Kalibrierkontrollblatt + DAkkS-Aufkleber + Zebra-QR-Sticker (V2 JSON-Bundles)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -174,6 +174,36 @@ jobs:
             INVENTORY-JSON-SAMPLE/subreports
           if-no-files-found: error
 
+      - name: Upload KALIBRIERKONTROLLBLATT-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: KALIBRIERKONTROLLBLATT-JSON-SAMPLE
+          path: |
+            KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports
+            KALIBRIERKONTROLLBLATT-JSON-SAMPLE/subreports
+          if-no-files-found: error
+
+      - name: Upload STICKER-DAKKS-12MM-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STICKER-DAKKS-12MM-JSON-SAMPLE
+          path: STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
+      - name: Upload STICKER-DAKKS-18MM-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STICKER-DAKKS-18MM-JSON-SAMPLE
+          path: STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
+      - name: Upload STICKER-CAL-INV-ZEBRA-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STICKER-CAL-INV-ZEBRA-JSON-SAMPLE
+          path: STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
       - name: List files before zipping (Debug)
         run: |
           echo "📂 Inhalt von DAKKS-SAMPLE:"
@@ -295,6 +325,10 @@ jobs:
           # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL)
           create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"
           create_zip "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
+          create_zip "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
+          create_zip "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
+          create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
+          create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
 
 
       - name: Upload report ZIPs as artifact

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -101,6 +101,10 @@ jobs:
           get_last_modified "STICKERS/Sticker_Vorlage" "sticker-vorlage"
           get_last_modified "DAKKS-JSON-SAMPLE" "dakks-json-sample"
           get_last_modified "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
+          get_last_modified "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
+          get_last_modified "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
+          get_last_modified "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
+          get_last_modified "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
 
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
@@ -171,6 +175,10 @@ jobs:
               "trace-backward":    "TRACE-BACKWARD/main_reports/README.md",
               "dakks-json-sample":     "DAKKS-JSON-SAMPLE/README.md",
               "inventory-json-sample": "INVENTORY-JSON-SAMPLE/README.md",
+              "kalibrierkontrollblatt-json-sample": "KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md",
+              "sticker-dakks-12mm-json-sample":     "STICKER-DAKKS-12MM-JSON-SAMPLE/README.md",
+              "sticker-dakks-18mm-json-sample":     "STICKER-DAKKS-18MM-JSON-SAMPLE/README.md",
+              "sticker-cal-inv-zebra-json-sample":  "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md",
           }
 
           SCHEMA_MAP = {
@@ -189,6 +197,10 @@ jobs:
               "trace-backward":         "Trace-Backward (Rückführungskette)",
               "dakks-json-sample":      "DAkkS-Kalibrierschein (APEX · V2)",
               "inventory-json-sample":  "Geräte-Datenblatt (APEX · V2)",
+              "kalibrierkontrollblatt-json-sample": "Kalibrierkontrollblatt (APEX · V2)",
+              "sticker-dakks-12mm-json-sample":     "DAkkS-Aufkleber 12 mm (APEX · V2)",
+              "sticker-dakks-18mm-json-sample":     "DAkkS-Aufkleber 18 mm (APEX · V2)",
+              "sticker-cal-inv-zebra-json-sample":  "Zebra Inventar-/Kalibrier-Sticker (APEX · V2)",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md
@@ -1,0 +1,44 @@
+# KALIBRIERKONTROLLBLATT-JSON-SAMPLE — Kalibrierkontrollblatt (V2 / APEX)
+
+V2-Nachbildung des **Kalibrierkontrollblatts** (Phase C der
+JasperReports-V2-Strategie). Im Gegensatz zum V1-Bundle `KALIBRIERKONTROLLBLATT`
+(eingebettetes SQL über JDBC, Codespalten wie `I4206`, `C2301`) wird dieses Bundle
+aus einem **JSON-Datensatz mit lesbaren API-Feldnamen** gefüllt — es enthält **kein
+SQL** und ist unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/kalibrierkontrollblatt-json-sample.jrxml` | Hauptbericht: Prüfmittel-Stammdatengrid (Inventar-/Serien-Nr., Hersteller/Typ, Kostenstelle, Kalibrierintervall, strukturierter Standort, letzte/nächste Kalibrierung) + Kundenblock; alle Labels als `staticText` |
+| `subreports/calibration-history.jrxml` | Kalibrierhistorie; `calibrations`-Array via `subDataSource("calibrations")` (Datum/nächste Fälligkeit/Zertifikat-Nr./Bearbeiter) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `inventory-datasheet` **v1.1**) |
+| `main_reports/kalibrierkontrollblatt-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Contract `inventory-datasheet` (v1.1)
+
+Wurzelobjekt mit `meta`, `device`, `customer`, `calibrations[]`. Neu in v1.1 (für die
+layouttreue Nachbildung genutzt): `device.active_location` (strukturierter Standort
+`location_1..3`), `device.cost_center` und `device.last_calibration_date`. Dataset-Builder:
+Laravel `InventoryReportDataBuilder`. Feldreferenz siehe `sample-data.json`.
+
+## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
+
+Datenquellenlos: der Bericht rendert nur mit übergebener **JSON-Datenquelle**. Ohne sie
+(Studio-Preview ohne Adapter, oder Live-Generierung ohne die Report-Variable
+`data_contract`) bleibt die Seite leer bzw. bricht auf `subDataSource(...)` ab — kein
+Template-Fehler, sondern fehlende Datenanbindung. Abhilfe:
+
+- **Vorschau (Jaspersoft Studio):** Der mitgelieferte Adapter
+  `kalibrierkontrollblatt-json-sample_adapter.xml` (Default über
+  `com.jaspersoft.studio.data.defadapter`) füllt die Vorschau aus `sample-data.json` —
+  „Open → Preview" genügt.
+- **Live (calServer V2):** Auf dem Report-Setting die Variable
+  `data_contract = inventory-datasheet` setzen; das Backend liefert den Datensatz.
+
+## Autoren-Hinweise
+
+- JasperReports-Version **6.20.6** bleibt verbindlich (siehe `robots.md`).
+- Labels als `staticText` halten — `$V{}`-Variablen in `title`/`columnHeader` ohne
+  `initialValueExpression` würden vor dem ersten Record `null` drucken.
+- Subreport-Teilmengen über `subDataSource("<array>")`.

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/kalibrierkontrollblatt-json-sample.jrxml
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/kalibrierkontrollblatt-json-sample.jrxml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 Kalibrierkontrollblatt (ADR-009, contract "inventory-datasheet" v1.1). Filled
+  from a JSON data source — NO SQL, NO V1 code columns. Rebuilds the V1
+  KALIBRIERKONTROLLBLATT layout against readable api_name fields: device master-data
+  grid (incl. structured active_location + cost_center) plus the full calibration
+  history via subDataSource("calibrations"). All labels are staticText, so there is
+  no report-level $V{} variable that could evaluate to null in the title band.
+  See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="kalibrierkontrollblatt-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="c3c9e2f0-0200-4c30-9e20-000000000201">
+	<!-- Studio-only: preview fills from sample-data.json via the bundled adapter.
+	     Ignored by the report-runner, which is handed the JSON datasource by the
+	     calServer V2 backend at runtime (see README). -->
+	<property name="com.jaspersoft.studio.data.defadapter" value="kalibrierkontrollblatt-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<style name="SectionTitle" fontSize="10" isBold="true"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[device.serial_number]]></fieldDescription></field>
+	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[device.manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[device.model]]></fieldDescription></field>
+	<field name="type_code" class="java.lang.String"><fieldDescription><![CDATA[device.type_code]]></fieldDescription></field>
+	<field name="accuracy_class" class="java.lang.String"><fieldDescription><![CDATA[device.accuracy_class]]></fieldDescription></field>
+	<field name="cost_center" class="java.lang.String"><fieldDescription><![CDATA[device.cost_center]]></fieldDescription></field>
+	<field name="calibration_interval" class="java.lang.String"><fieldDescription><![CDATA[device.calibration_interval]]></fieldDescription></field>
+	<field name="last_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.last_calibration_date]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription></field>
+	<field name="loc_building" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_1]]></fieldDescription></field>
+	<field name="loc_room" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_2]]></fieldDescription></field>
+	<field name="loc_object" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_3]]></fieldDescription></field>
+	<field name="customer_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<field name="customer_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
+	<field name="customer_city" class="java.lang.String"><fieldDescription><![CDATA[customer.city]]></fieldDescription></field>
+	<title>
+		<band height="214">
+			<textField>
+				<reportElement x="0" y="0" width="561" height="22"/>
+				<textElement textAlignment="Center"><font size="15" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA["Kalibrierkontrollblatt"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="24" width="561" height="14"/>
+				<textElement textAlignment="Center"><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($F{asset_number} == null ? "" : $F{asset_number}) + "  ·  " + ($F{description} == null ? "" : $F{description})]]></textFieldExpression>
+			</textField>
+			<line><reportElement x="0" y="44" width="561" height="1"/></line>
+			<!-- Prüfmittel-Stammdaten -->
+			<staticText><reportElement style="SectionTitle" x="0" y="52" width="561" height="14"/><text><![CDATA[Prüfmittel]]></text></staticText>
+			<staticText><reportElement style="Label" x="0" y="70" width="130" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="70" width="150" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="70" width="120" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="70" width="151" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="86" width="130" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="86" width="150" height="13"/><textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="86" width="120" height="13"/><text><![CDATA[Typ / Genauigkeit]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="86" width="151" height="13"/><textFieldExpression><![CDATA[($F{type_code} == null ? "" : $F{type_code}) + "  Kl. " + ($F{accuracy_class} == null ? "" : $F{accuracy_class})]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="102" width="130" height="13"/><text><![CDATA[Kostenstelle]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="102" width="150" height="13"/><textFieldExpression><![CDATA[$F{cost_center}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="102" width="120" height="13"/><text><![CDATA[Kalibrierintervall (Mon.)]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="102" width="151" height="13"/><textFieldExpression><![CDATA[$F{calibration_interval}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="118" width="130" height="13"/><text><![CDATA[Standort (Gebäude/Raum)]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="118" width="150" height="13"/><textFieldExpression><![CDATA[($F{loc_building} == null ? "" : $F{loc_building}) + (($F{loc_room} == null || $F{loc_room}.isEmpty()) ? "" : (" / " + $F{loc_room}))]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="118" width="120" height="13"/><text><![CDATA[Objekt / Ebene]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="118" width="151" height="13"/><textFieldExpression><![CDATA[$F{loc_object}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="134" width="130" height="13"/><text><![CDATA[Letzte Kalibrierung]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="134" width="150" height="13"/><textFieldExpression><![CDATA[$F{last_calibration_date}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="134" width="120" height="13"/><text><![CDATA[Nächste Kalibrierung]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="134" width="151" height="13"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<line><reportElement x="0" y="156" width="561" height="1"/></line>
+			<!-- Kunde -->
+			<staticText><reportElement style="SectionTitle" x="0" y="164" width="561" height="14"/><text><![CDATA[Kunde]]></text></staticText>
+			<staticText><reportElement style="Label" x="0" y="182" width="130" height="13"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="182" width="150" height="13"/><textFieldExpression><![CDATA[$F{customer_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="182" width="120" height="13"/><text><![CDATA[Kunde / Ort]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="182" width="151" height="13"/><textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{customer_city} == null || $F{customer_city}.isEmpty()) ? "" : (", " + $F{customer_city}))]]></textFieldExpression></textField>
+		</band>
+	</title>
+	<detail>
+		<band height="30">
+			<staticText><reportElement style="SectionTitle" x="0" y="4" width="561" height="14"/><text><![CDATA[Kalibrierhistorie]]></text></staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="20" width="561" height="10" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("calibrations")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/calibration-history.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="24">
+			<line><reportElement x="0" y="0" width="561" height="1"/></line>
+			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Kalibrierkontrollblatt · calServer V2]]></text></staticText>
+			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/kalibrierkontrollblatt-json-sample_adapter.xml
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/kalibrierkontrollblatt-json-sample_adapter.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 Kalibrierkontrollblatt sample.
+
+  Bundled so the report previews out-of-the-box: opening the main JRXML and
+  hitting "Preview" fills it from the sibling sample-data.json (contract
+  inventory-datasheet v1.1) via this adapter, referenced by the report property
+  com.jaspersoft.studio.data.defadapter.
+
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Kalibrierkontrollblatt JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/sample-data.json
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,43 @@
+{
+  "meta": {
+    "contract": "inventory-datasheet",
+    "schema_version": "1.1",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "accuracy_class": "0.05",
+    "location": "Labor 1",
+    "active_location": {
+      "location_1": "Gebäude A",
+      "location_2": "Raum 101",
+      "location_3": "Regal 3",
+      "custom_fields": {}
+    },
+    "cost_center": "K-42",
+    "status": 1,
+    "calibration_interval": 12,
+    "last_calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30",
+    "custom_fields": { "customer_tag": "KND-DMM-7" }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "custom_fields": {}
+  },
+  "calibrations": [
+    { "calibration_date": "2026-06-30", "next_calibration_date": "2027-06-30", "certificate_number": "DAkkS-K-2026-0042", "technician": "Erika Musterfrau" },
+    { "calibration_date": "2025-06-28", "next_calibration_date": "2026-06-28", "certificate_number": "DAkkS-K-2025-0031", "technician": "Erika Musterfrau" },
+    { "calibration_date": "2024-06-25", "next_calibration_date": "2025-06-25", "certificate_number": "DAkkS-K-2024-0022", "technician": "Max Mustermann" }
+  ]
+}

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/subreports/calibration-history.jrxml
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/subreports/calibration-history.jrxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 calibration-history subreport (contract inventory-datasheet v1.1): fed the
+  "calibrations" array via subDataSource("calibrations"). Static German column
+  headers (no $V{} variable → no null-in-header risk).
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="calibration-history" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="c3c9e2f0-0201-4c31-9e21-000000000202">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="calibration_date" class="java.lang.String"><fieldDescription><![CDATA[calibration_date]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
+	<field name="certificate_number" class="java.lang.String"><fieldDescription><![CDATA[certificate_number]]></fieldDescription></field>
+	<field name="technician" class="java.lang.String"><fieldDescription><![CDATA[technician]]></fieldDescription></field>
+	<columnHeader>
+		<band height="16">
+			<staticText><reportElement x="0" y="0" width="120" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[Kalibrierdatum]]></text></staticText>
+			<staticText><reportElement x="120" y="0" width="120" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[Nächste Fälligkeit]]></text></staticText>
+			<staticText><reportElement x="240" y="0" width="200" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[Zertifikat-Nr.]]></text></staticText>
+			<staticText><reportElement x="440" y="0" width="121" height="15"/><textElement><font isBold="true"/></textElement><text><![CDATA[Bearbeiter]]></text></staticText>
+			<line><reportElement x="0" y="15" width="561" height="1"/></line>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="14">
+			<textField><reportElement x="0" y="0" width="120" height="13"/><textFieldExpression><![CDATA[$F{calibration_date}]]></textFieldExpression></textField>
+			<textField><reportElement x="120" y="0" width="120" height="13"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<textField><reportElement x="240" y="0" width="200" height="13"/><textFieldExpression><![CDATA[$F{certificate_number}]]></textFieldExpression></textField>
+			<textField><reportElement x="440" y="0" width="121" height="13"/><textFieldExpression><![CDATA[$F{technician}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md
@@ -1,0 +1,30 @@
+# STICKER-CAL-INV-ZEBRA-JSON-SAMPLE — Zebra Inventar-/Kalibrier-Sticker (V2 / APEX)
+
+V2-Nachbildung des kombinierten **Inventar-/Kalibrier-Stickers** für den
+Zebra ZD621 30×15 mm @203 dpi (240×120 px), Phase C. Gefüllt aus einem
+**JSON-Datensatz** (Contract `inventory-datasheet` v1.1) statt aus SQL —
+DB-agnostisch, keine V1-Codespalten.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/cal-inv-zebra-json-sample.jrxml` | Label 240×120 px: **QR aus `device.asset_number`** (links) + Infospalte rechts (Inventar-Nr., OE-Bezeichnung, Kostenstelle, Standort, letzte + nächste Kalibrierung) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `inventory-datasheet` v1.1) |
+| `main_reports/cal-inv-zebra-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Felder
+
+`device.asset_number` (QR + Text), `device.cost_center`, `device.active_location.location_1/2`,
+`device.last_calibration_date`, `device.next_calibration_date`, `customer.name`
+(OE-Bezeichnung/Gruppe). Dataset-Builder: Laravel `InventoryReportDataBuilder`.
+
+> Der QR wird runner-seitig aus dem Feldwert gerendert (`<jr:QRCode>`, ZXing) — kein
+> vorgeneriertes Bild, kein `Barcode`-Model, DB-agnostisch.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle rendert der Sticker leer. Vorschau: mitgelieferter Adapter
+(Default über `com.jaspersoft.studio.data.defadapter`) → „Open → Preview". Live
+(calServer V2): Report-Setting-Variable `data_contract = inventory-datasheet`.
+JasperReports **6.20.6** verbindlich. Keine `$V{}`-Variablen (nur `staticText`/`$F{}`).

--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/cal-inv-zebra-json-sample.jrxml
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/cal-inv-zebra-json-sample.jrxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 combined inventory + calibration sticker for Zebra ZD621 30x15 mm @203dpi
+  (240x120 px), ADR-009 contract "inventory-datasheet" v1.1. Filled from a JSON
+  data source — NO SQL. QR from device.asset_number (renders runner-side from the
+  field string, DB-agnostic). Right column: inventory no., org unit (customer.name),
+  cost centre, structured location, last + next calibration. No report-level
+  variables. See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="cal-inv-zebra-json-sample" pageWidth="240" pageHeight="120" columnWidth="240" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenNoDataType="AllSectionsNoDetail" uuid="c5cbf400-0220-4c50-9e40-000000000220">
+	<property name="com.jaspersoft.studio.data.defadapter" value="cal-inv-zebra-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="6"/>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<field name="cost_center" class="java.lang.String"><fieldDescription><![CDATA[device.cost_center]]></fieldDescription></field>
+	<field name="last_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.last_calibration_date]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription></field>
+	<field name="loc_building" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_1]]></fieldDescription></field>
+	<field name="loc_room" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_2]]></fieldDescription></field>
+	<field name="org_unit" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<detail>
+		<band height="120">
+			<!-- QR of the inventory/asset number -->
+			<componentElement>
+				<reportElement x="6" y="20" width="80" height="80"/>
+				<jr:QRCode>
+					<jr:codeExpression><![CDATA[$F{asset_number} == null ? "" : $F{asset_number}]]></jr:codeExpression>
+				</jr:QRCode>
+			</componentElement>
+			<staticText><reportElement x="6" y="102" width="80" height="10"/><textElement textAlignment="Center"><font size="6"/></textElement><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<!-- Right info column -->
+			<textField><reportElement x="94" y="6" width="140" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField><reportElement x="94" y="20" width="140" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[$F{org_unit}]]></textFieldExpression></textField>
+			<textField><reportElement x="94" y="32" width="140" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA["Kostenstelle: " + ($F{cost_center} == null ? "" : $F{cost_center})]]></textFieldExpression></textField>
+			<textField><reportElement x="94" y="44" width="140" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA["Ort: " + ($F{loc_building} == null ? "" : $F{loc_building}) + (($F{loc_room} == null || $F{loc_room}.isEmpty()) ? "" : (" / " + $F{loc_room}))]]></textFieldExpression></textField>
+			<line><reportElement x="94" y="58" width="140" height="1"/></line>
+			<staticText><reportElement x="94" y="62" width="70" height="10"/><textElement><font size="6"/></textElement><text><![CDATA[Kalibriert:]]></text></staticText>
+			<textField><reportElement x="164" y="62" width="70" height="10"/><textElement textAlignment="Right"><font size="6" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{last_calibration_date}]]></textFieldExpression></textField>
+			<staticText><reportElement x="94" y="76" width="70" height="10"/><textElement><font size="6"/></textElement><text><![CDATA[Nächste Kal.:]]></text></staticText>
+			<textField><reportElement x="164" y="76" width="70" height="12"/><textElement textAlignment="Right"><font size="8" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/cal-inv-zebra-json-sample_adapter.xml
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/cal-inv-zebra-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 Zebra cal+inv sticker sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Zebra Cal+Inv Sticker JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,41 @@
+{
+  "meta": {
+    "contract": "inventory-datasheet",
+    "schema_version": "1.1",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "accuracy_class": "0.05",
+    "location": "Labor 1",
+    "active_location": {
+      "location_1": "Gebäude A",
+      "location_2": "Raum 101",
+      "location_3": "Regal 3",
+      "custom_fields": {}
+    },
+    "cost_center": "K-42",
+    "status": 1,
+    "calibration_interval": 12,
+    "last_calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30",
+    "custom_fields": { "customer_tag": "KND-DMM-7" }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "custom_fields": {}
+  },
+  "calibrations": [
+    { "calibration_date": "2026-06-30", "next_calibration_date": "2027-06-30", "certificate_number": "DAkkS-K-2026-0042", "technician": "Erika Musterfrau" }
+  ]
+}

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/README.md
@@ -1,0 +1,25 @@
+# STICKER-DAKKS-12MM-JSON-SAMPLE — DAkkS-Aufkleber 12 mm (V2 / APEX)
+
+V2-Nachbildung des **DAkkS-Kalibrieraufklebers 12 mm** (Phase C). Micro-Label
+34×47 pt (≈ 12×16,6 mm), gefüllt aus einem **JSON-Datensatz** (Contract
+`calibration-certificate` v1.1) statt aus SQL — DB-agnostisch, kein V1-Codespalten.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/dakks-aufkleber-12mm-json-sample.jrxml` | Micro-Label: Rahmen (Line-Art), „DAkkS", Akkreditierungs-Markennummer, Kalibrierdatum. Kein QR, keine Variablen |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.1, minimal) |
+| `main_reports/dakks-aufkleber-12mm-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Felder
+
+`accreditation.mark_number_1` (+ `mark_number_2`), `calibration.calibration_date`.
+Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle rendert das Label leer. Vorschau: mitgelieferter Adapter
+(Default über `com.jaspersoft.studio.data.defadapter`) → „Open → Preview". Live
+(calServer V2): Report-Setting-Variable `data_contract = calibration-certificate`.
+JasperReports **6.20.6** verbindlich.

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/dakks-aufkleber-12mm-json-sample.jrxml
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/dakks-aufkleber-12mm-json-sample.jrxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 DAkkS calibration label 12 mm (ADR-009, contract "calibration-certificate"
+  v1.1). Filled from a JSON data source — NO SQL. Reproduces the V1
+  DAKKS-Aufkleber_12mm micro-label (34x47 pt ≈ 12x16.6 mm) against readable
+  api_name fields: accreditation.mark_number_1/_2 + calibration.calibration_date.
+  No QR, no report-level variables. See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-12mm-json-sample" pageWidth="34" pageHeight="47" columnWidth="34" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0210-4c40-9e30-000000000210">
+	<property name="com.jaspersoft.studio.data.defadapter" value="dakks-aufkleber-12mm-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="4"/>
+	<field name="mark_number_1" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_1]]></fieldDescription></field>
+	<field name="mark_number_2" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_2]]></fieldDescription></field>
+	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
+	<detail>
+		<band height="47">
+			<line><reportElement x="1" y="1" width="32" height="1"/></line>
+			<line><reportElement x="1" y="46" width="32" height="1"/></line>
+			<line><reportElement x="1" y="1" width="1" height="45"/></line>
+			<line><reportElement x="33" y="1" width="1" height="45"/></line>
+			<staticText><reportElement x="2" y="3" width="30" height="6"/><textElement textAlignment="Center"><font size="5" isBold="true"/></textElement><text><![CDATA[DAkkS]]></text></staticText>
+			<textField><reportElement x="2" y="11" width="30" height="12"/><textElement textAlignment="Center"><font size="4"/></textElement><textFieldExpression><![CDATA[$F{mark_number_1}]]></textFieldExpression></textField>
+			<staticText><reportElement x="2" y="26" width="30" height="6"/><textElement textAlignment="Center"><font size="4"/></textElement><text><![CDATA[Kalibriert:]]></text></staticText>
+			<textField><reportElement x="2" y="33" width="30" height="8"/><textElement textAlignment="Center"><font size="5" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/dakks-aufkleber-12mm-json-sample_adapter.xml
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/dakks-aufkleber-12mm-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 DAkkS 12 mm label sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>DAkkS Aufkleber 12mm JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "contract": "calibration-certificate",
+    "schema_version": "1.1",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE",
+    "certificate_number": "DAkkS-K-2026-0042"
+  },
+  "accreditation": {
+    "mark_number_1": "D-K-12345-01-00",
+    "mark_number_2": "Deutsche Akkreditierungsstelle",
+    "calibration_mark": "DAkkS-K-12345"
+  },
+  "calibration": {
+    "calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30"
+  },
+  "device": {
+    "asset_number": "INV-9001"
+  }
+}

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/README.md
@@ -1,0 +1,25 @@
+# STICKER-DAKKS-18MM-JSON-SAMPLE — DAkkS-Aufkleber 18 mm (V2 / APEX)
+
+V2-Nachbildung des **DAkkS-Kalibrieraufklebers 18 mm** (Phase C). Label 51×70 pt
+Landscape (≈ 18×24,7 mm), gefüllt aus einem **JSON-Datensatz** (Contract
+`calibration-certificate` v1.1) statt aus SQL — DB-agnostisch, keine V1-Codespalten.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/dakks-aufkleber-18mm-json-sample.jrxml` | Label: Rahmen (Line-Art), „DAkkS", Akkreditierungs-Markennummer, Kalibrier- + nächstes Datum. Kein QR, keine Variablen |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.1, minimal) |
+| `main_reports/dakks-aufkleber-18mm-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Felder
+
+`accreditation.mark_number_1` (+ `mark_number_2`), `calibration.calibration_date`,
+`calibration.next_calibration_date`. Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle rendert das Label leer. Vorschau: mitgelieferter Adapter
+(Default über `com.jaspersoft.studio.data.defadapter`) → „Open → Preview". Live
+(calServer V2): Report-Setting-Variable `data_contract = calibration-certificate`.
+JasperReports **6.20.6** verbindlich.

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/dakks-aufkleber-18mm-json-sample.jrxml
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/dakks-aufkleber-18mm-json-sample.jrxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 DAkkS calibration label 18 mm (ADR-009, contract "calibration-certificate"
+  v1.1). Filled from a JSON data source — NO SQL. Reproduces the V1
+  DAKKS-Aufkleber_18mm label (51x70 pt Landscape ≈ 18x24.7 mm) against readable
+  api_name fields: accreditation.mark_number_1/_2 + calibration.calibration_date
+  (+ next). No QR, no report-level variables. See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-18mm-json-sample" pageWidth="51" pageHeight="70" orientation="Landscape" columnWidth="51" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0211-4c41-9e31-000000000211">
+	<property name="com.jaspersoft.studio.data.defadapter" value="dakks-aufkleber-18mm-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="5"/>
+	<field name="mark_number_1" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_1]]></fieldDescription></field>
+	<field name="mark_number_2" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_2]]></fieldDescription></field>
+	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
+	<field name="next_cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription></field>
+	<detail>
+		<band height="51">
+			<line><reportElement x="1" y="1" width="68" height="1"/></line>
+			<line><reportElement x="1" y="50" width="68" height="1"/></line>
+			<line><reportElement x="1" y="1" width="1" height="49"/></line>
+			<line><reportElement x="69" y="1" width="1" height="49"/></line>
+			<staticText><reportElement x="3" y="3" width="64" height="9"/><textElement textAlignment="Center"><font size="8" isBold="true"/></textElement><text><![CDATA[DAkkS]]></text></staticText>
+			<textField><reportElement x="3" y="13" width="64" height="8"/><textElement textAlignment="Center"><font size="5"/></textElement><textFieldExpression><![CDATA[$F{mark_number_1}]]></textFieldExpression></textField>
+			<staticText><reportElement x="3" y="24" width="30" height="7"/><textElement><font size="5"/></textElement><text><![CDATA[Kalibriert:]]></text></staticText>
+			<textField><reportElement x="33" y="24" width="34" height="7"/><textElement textAlignment="Right"><font size="6" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression></textField>
+			<staticText><reportElement x="3" y="33" width="30" height="7"/><textElement><font size="5"/></textElement><text><![CDATA[Nächste:]]></text></staticText>
+			<textField><reportElement x="33" y="33" width="34" height="7"/><textElement textAlignment="Right"><font size="6"/></textElement><textFieldExpression><![CDATA[$F{next_cal_date}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/dakks-aufkleber-18mm-json-sample_adapter.xml
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/dakks-aufkleber-18mm-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 DAkkS 18 mm label sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>DAkkS Aufkleber 18mm JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "contract": "calibration-certificate",
+    "schema_version": "1.1",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE",
+    "certificate_number": "DAkkS-K-2026-0042"
+  },
+  "accreditation": {
+    "mark_number_1": "D-K-12345-01-00",
+    "mark_number_2": "Deutsche Akkreditierungsstelle",
+    "calibration_mark": "DAkkS-K-12345"
+  },
+  "calibration": {
+    "calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30"
+  },
+  "device": {
+    "asset_number": "INV-9001"
+  }
+}


### PR DESCRIPTION
## Kontext

Phase C der V2-Reports-Strategie: vier weitere **layouttreue V2-Bundles** mit JSON-Datenquelle (kein SQL, DB-agnostisch), als „APEX · V2" auf der Downloads-Seite. Jedes Bundle wurde über den `report-runner` (JSON-Fill, JasperReports 6.20.6) **inhaltlich gerendert-verifiziert** — echte Feldwerte, 0× „null".

Setzt den yii-seitigen Contract-Ausbau [`inventory-datasheet` → v1.1 (calServer-yii#2855)](https://github.com/calhelp/calServer-yii/pull/2855) für die Sticker-Felder voraus.

## Neue Bundles

| Bundle | Contract | Inhalt |
|--------|----------|--------|
| `KALIBRIERKONTROLLBLATT-JSON-SAMPLE` | `inventory-datasheet` v1.1 | A4-Prüfmittelgrid + Kalibrierhistorie via `subDataSource("calibrations")`; nutzt v1.1-Felder `device.cost_center`, `device.active_location` (Gebäude/Raum, Objekt/Ebene), `device.last_calibration_date` |
| `STICKER-DAKKS-12MM-JSON-SAMPLE` | `calibration-certificate` v1.1 | Micro-Label 34×47 pt aus `accreditation.mark_number_1/_2` + `calibration.calibration_date` |
| `STICKER-DAKKS-18MM-JSON-SAMPLE` | `calibration-certificate` v1.1 | Label 51×70 pt Landscape, dito + nächstes Datum |
| `STICKER-CAL-INV-ZEBRA-JSON-SAMPLE` | `inventory-datasheet` v1.1 | Zebra ZD621 30×15 mm @203dpi (240×120 px), **QR aus `device.asset_number`** (`<jr:QRCode>`, ZXing, runner-seitig) + Kostenstelle/Standort/Kalibrierdaten |

## Härtung (aus dem DAkkS-Blank-Bug übernommen)

- **Keine `$V{}`-Variablen in report-level Bändern** — alle Labels `staticText`/`$F{}` (der `null`-in-Header-Fehlerklasse wird per Konstruktion vorgebeugt).
- Jedes Bundle mit mitgeliefertem **Jaspersoft-Studio-JSON-Data-Adapter** (`*_adapter.xml`, `com.jaspersoft.studio.data.defadapter` — Studio-only, im Runner inert) + README-Abschnitt „leeres Blatt = fehlende Datenquelle".

## Packaging

- `package-reports.yml`: `upload-artifact` + `create_zip` je Bundle (Allowlist deckt `*.json`/`*.xml` bereits ab).
- `publish-downloads.yml`: `get_last_modified` + `README_MAP` + `TITLE_MAP`.
- `downloads/index.html`: unverändert — `getCategory()` ordnet die `-json-sample`-Namen automatisch der APEX·V2-Sektion zu (Match auf `-json-sample` **vor** `sticker`).

## Verifikation

- Runner-Render aller vier Bundles: je 1 Seite, echte Werte, 0× „null" (das 12-mm-Micro-Label füllt ebenfalls sauber; nur der Text-Exporter überläuft bei 34×47 pt — PDF-Export bestätigt den Inhalt).
- `scripts/check_jasper_version.sh` grün (alle 6.20.6); `xmllint` well-formed; JSON valide; YAML-Syntax beider Workflows geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_