### PR TITLE
feat(apex): Phase D — ORDER + DELIVERY (V2 JSON-Bundles, Auftrag/Lieferschein)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -204,6 +204,24 @@ jobs:
           path: STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports
           if-no-files-found: error
 
+      - name: Upload ORDER-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ORDER-JSON-SAMPLE
+          path: |
+            ORDER-JSON-SAMPLE/main_reports
+            ORDER-JSON-SAMPLE/subreports
+          if-no-files-found: error
+
+      - name: Upload DELIVERY-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: DELIVERY-JSON-SAMPLE
+          path: |
+            DELIVERY-JSON-SAMPLE/main_reports
+            DELIVERY-JSON-SAMPLE/subreports
+          if-no-files-found: error
+
       - name: List files before zipping (Debug)
         run: |
           echo "📂 Inhalt von DAKKS-SAMPLE:"
@@ -329,6 +347,8 @@ jobs:
           create_zip "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
           create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
+          create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
+          create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
 
 
       - name: Upload report ZIPs as artifact

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -105,6 +105,8 @@ jobs:
           get_last_modified "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           get_last_modified "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
           get_last_modified "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
+          get_last_modified "ORDER-JSON-SAMPLE" "order-json-sample"
+          get_last_modified "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
 
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
@@ -179,6 +181,8 @@ jobs:
               "sticker-dakks-12mm-json-sample":     "STICKER-DAKKS-12MM-JSON-SAMPLE/README.md",
               "sticker-dakks-18mm-json-sample":     "STICKER-DAKKS-18MM-JSON-SAMPLE/README.md",
               "sticker-cal-inv-zebra-json-sample":  "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md",
+              "order-json-sample":                  "ORDER-JSON-SAMPLE/README.md",
+              "delivery-json-sample":               "DELIVERY-JSON-SAMPLE/README.md",
           }
 
           SCHEMA_MAP = {
@@ -201,6 +205,8 @@ jobs:
               "sticker-dakks-12mm-json-sample":     "DAkkS-Aufkleber 12 mm (APEX · V2)",
               "sticker-dakks-18mm-json-sample":     "DAkkS-Aufkleber 18 mm (APEX · V2)",
               "sticker-cal-inv-zebra-json-sample":  "Zebra Inventar-/Kalibrier-Sticker (APEX · V2)",
+              "order-json-sample":                  "Auftragsbeleg (APEX · V2)",
+              "delivery-json-sample":               "Lieferschein (APEX · V2)",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/DELIVERY-JSON-SAMPLE/README.md
+++ b/DELIVERY-JSON-SAMPLE/README.md
@@ -1,0 +1,30 @@
+# DELIVERY-JSON-SAMPLE — Lieferschein (V2 / APEX)
+
+V2-Nachbildung des **Lieferscheins** (Phase D), schlanke Variante des
+Auftragsbelegs: Kopf + Lieferadresse + Positionen, **ohne Preise und ohne
+Steuerstatistik**. Gefüllt aus einem **JSON-Datensatz** (Contract `order-document`
+v1.0) statt aus SQL — DB-agnostisch, keine V1-Codespalten.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/delivery-json-sample.jrxml` | Hauptbericht: Briefkopf mit **Lieferadresse** (Meta-Box Liefernummer/Datum/Kunde/Kontakt), Positionstabelle (Pos/Beschreibung/Menge), Empfangs-Unterschriftszeile |
+| `subreports/positions-delivery.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` — nur Pos/Beschreibung/Menge |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.0, `document.status = "Lieferung"`) |
+| `main_reports/delivery-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Contract `order-document` (v1.0)
+
+Gleicher Contract wie `ORDER-JSON-SAMPLE`; der Lieferschein liest nur `document`,
+die serverseitig aufgelöste `delivery`-Adressrolle (Fallback → Bestell-Kunde) und
+`positions[]` (ohne Preis-/Steuerfelder). Dataset-Builder: Laravel
+`OrderDocumentDataBuilder`.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle bleibt die Seite leer bzw. bricht auf `subDataSource(...)` ab.
+Vorschau: mitgelieferter Adapter (Default über `com.jaspersoft.studio.data.defadapter`)
+→ „Open → Preview". Live (calServer V2): Report-Setting-Variable
+`data_contract = order-document`; Datensatz auch via
+`GET /api/v2/bookings/{id}/report-dataset`. JasperReports **6.20.6** verbindlich.

--- a/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
+++ b/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 delivery note (Lieferschein), ADR-009 contract "order-document" v1.0 — the
+  slim variant: header + delivery address + positions, NO prices and NO tax
+  statistics (a delivery note carries no monetary totals). Filled from a JSON data
+  source — NO SQL. Positions via subDataSource("positions"). The delivery address
+  block is resolved server-side (delivery role → falls back to the ordering
+  customer). All labels are staticText. See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="d7ddf600-0310-4d70-9f60-000000000310">
+	<property name="com.jaspersoft.studio.data.defadapter" value="delivery-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<field name="doc_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
+	<field name="doc_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
+	<field name="doc_status" class="java.lang.String"><fieldDescription><![CDATA[document.status]]></fieldDescription></field>
+	<field name="doc_comment" class="java.lang.String"><fieldDescription><![CDATA[document.comment]]></fieldDescription></field>
+	<field name="del_name" class="java.lang.String"><fieldDescription><![CDATA[delivery.name]]></fieldDescription></field>
+	<field name="del_street" class="java.lang.String"><fieldDescription><![CDATA[delivery.street]]></fieldDescription></field>
+	<field name="del_zip" class="java.lang.String"><fieldDescription><![CDATA[delivery.zip]]></fieldDescription></field>
+	<field name="del_city" class="java.lang.String"><fieldDescription><![CDATA[delivery.city]]></fieldDescription></field>
+	<field name="del_contact" class="java.lang.String"><fieldDescription><![CDATA[delivery.contact.name]]></fieldDescription></field>
+	<field name="cust_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
+	<title>
+		<band height="184">
+			<staticText><reportElement x="0" y="0" width="330" height="9"/><textElement><font size="6"/></textElement><text><![CDATA[calServer V2 · Musterfirma · Musterstraße 1 · 12345 Musterstadt]]></text></staticText>
+			<textField><reportElement x="0" y="18" width="300" height="14"/><textElement><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{del_name}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="32" width="300" height="12"/><textFieldExpression><![CDATA[$F{del_street}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="44" width="300" height="12"/><textFieldExpression><![CDATA[($F{del_zip} == null ? "" : $F{del_zip}) + " " + ($F{del_city} == null ? "" : $F{del_city})]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="18" width="80" height="12"/><text><![CDATA[Liefernummer]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="18" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="32" width="80" height="12"/><text><![CDATA[Datum]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="32" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="46" width="80" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="46" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="60" width="80" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="60" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{del_contact}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="120" width="561" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA["Lieferschein " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="144" width="561" height="14"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
+			<line><reportElement x="0" y="164" width="561" height="1"/></line>
+			<staticText><reportElement style="Label" x="0" y="168" width="40" height="14"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" x="40" y="168" width="431" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" x="471" y="168" width="90" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+		</band>
+	</title>
+	<detail>
+		<band height="30">
+			<subreport>
+				<reportElement positionType="Float" x="0" y="0" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/positions-delivery.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="46">
+			<staticText><reportElement positionType="Float" x="0" y="16" width="561" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Ware vollständig und unbeschädigt erhalten:]]></text></staticText>
+			<line><reportElement positionType="Float" x="0" y="30" width="240" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="0" y="32" width="240" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift]]></text></staticText>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample_adapter.xml
+++ b/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 delivery-note sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Delivery Note JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/DELIVERY-JSON-SAMPLE/main_reports/sample-data.json
+++ b/DELIVERY-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,62 @@
+{
+  "meta": {
+    "contract": "order-document",
+    "schema_version": "1.0",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "document": {
+    "number": "LI-2026-0042",
+    "date": "2026-07-20",
+    "status": "Lieferung",
+    "comment": "Lieferung zu Auftrag AU-2026-0042.",
+    "delivery_condition": "frei Haus",
+    "delivery_costs": 0,
+    "description": null,
+    "custom_fields": {
+      "W4109": "2026-07-20"
+    }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE"
+  },
+  "delivery": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Wareneingang, Tor 3",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE",
+    "contact": {
+      "name": "Erika Musterfrau",
+      "email": "erika@muster.example",
+      "phone": "+49 30 1234500"
+    }
+  },
+  "invoice": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE"
+  },
+  "positions": [
+    { "pos_number": 1, "name": "Digitalmultimeter Fluke 87V (INV-9001)", "article_type": "inventory", "quantity": 1, "unit": "Stk", "price": 0.0, "discount": 0.0, "tax": 0.0, "line_net": 0.0 },
+    { "pos_number": 2, "name": "Referenz-Kalibrator (REF-001)", "article_type": "inventory", "quantity": 1, "unit": "Stk", "price": 0.0, "discount": 0.0, "tax": 0.0, "line_net": 0.0 }
+  ],
+  "statistics": {
+    "tax_groups": [],
+    "net_total": 0.0,
+    "order_discount_percent": 0.0,
+    "discount_amount": 0.0,
+    "net_after_discount": 0.0,
+    "vat_total": 0.0,
+    "gross_total": 0.0
+  }
+}

--- a/DELIVERY-JSON-SAMPLE/subreports/positions-delivery.jrxml
+++ b/DELIVERY-JSON-SAMPLE/subreports/positions-delivery.jrxml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 delivery positions subreport (contract order-document v1.0): fed the
+  "positions" array via subDataSource("positions"). Delivery-note variant — only
+  position, description and quantity, no prices/tax. No $V{} variables.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0311-4d71-9f61-000000000311">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<field name="pos_number" class="java.lang.Integer"><fieldDescription><![CDATA[pos_number]]></fieldDescription></field>
+	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="quantity" class="java.lang.Double"><fieldDescription><![CDATA[quantity]]></fieldDescription></field>
+	<field name="unit" class="java.lang.String"><fieldDescription><![CDATA[unit]]></fieldDescription></field>
+	<detail>
+		<band height="15">
+			<textField><reportElement x="0" y="0" width="40" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="40" y="0" width="431" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##"><reportElement x="471" y="0" width="60" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField><reportElement x="533" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -1,0 +1,45 @@
+# ORDER-JSON-SAMPLE — Auftrag/Angebot/Rechnung (V2 / APEX)
+
+V2-Nachbildung des **Auftragsbelegs** (Phase D). Im Gegensatz zum V1-Bundle
+`ORDER-SAMPLE` (eingebettetes SQL + separater Statistics-Subreport, der die
+Steuergruppen per GROUP-BY selbst nachquert) wird dieses Bundle aus einem
+**JSON-Datensatz mit lesbaren API-Feldnamen** gefüllt — es enthält **kein SQL**
+und ist unabhängig vom DB-Backend (MySQL, PostgreSQL, MSSQL).
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/order-json-sample.jrxml` | Hauptbericht: Briefkopf (Empfängeradresse + Meta-Box Belegnummer/Datum/Kunde/Kontakt), Betreff, Positionstabelle + Statistik. Alle Labels als `staticText` |
+| `subreports/positions.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` (Pos/Beschreibung/Menge/Einzelpreis/Rabatt/Betrag/MwSt) |
+| `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.0) |
+| `main_reports/order-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Contract `order-document` (v1.0)
+
+Wurzelobjekt mit `meta`, `document` (Nummer/Datum/Status/Kommentar/Rechtstext +
+`custom_fields` für W41xx-Zusatzfelder), drei Adressrollen `customer`/`delivery`/
+`invoice` (mit `contact`-Unterobjekt, serverseitig mit V1-Fallback aufgelöst),
+`positions[]` und **serverseitig vorberechneter `statistics`** (`tax_groups[]` je
+Steuersatz + Skalare `net_total`/`discount_amount`/`net_after_discount`/`vat_total`/
+`gross_total`). **Jasper kann ein JSON-Array nicht gruppieren** — die
+Steuergruppen-Aggregation macht daher der `OrderDocumentDataBuilder` (Laravel);
+der Bericht druckt nur. Feldreferenz siehe `sample-data.json`.
+
+> **Auftragsrabatt (W4114):** Die Muster sind rabattfrei, damit die Summen
+> eindeutig sind. Die exakte V1-Rabatt-Steuer-Arithmetik bei mehreren Steuersätzen
+> ist ein Dual-Run-Abstimmungspunkt (siehe Builder-Doku).
+
+## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
+
+Datenquellenlos: rendert nur mit übergebener **JSON-Datenquelle**. Ohne sie
+(Studio-Preview ohne Adapter, oder Live-Generierung ohne `data_contract`) bleibt die
+Seite leer bzw. bricht auf `subDataSource(...)` ab. Abhilfe:
+
+- **Vorschau (Studio):** mitgelieferter Adapter (Default über
+  `com.jaspersoft.studio.data.defadapter`) → „Open → Preview".
+- **Live (calServer V2):** Report-Setting-Variable `data_contract = order-document`;
+  Datensatz auch via `GET /api/v2/bookings/{id}/report-dataset`.
+
+JasperReports **6.20.6** verbindlich.

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 order document (Auftrag/Angebot/Rechnung), ADR-009 contract "order-document"
+  v1.0. Filled from a JSON data source — NO SQL, NO V1 code columns. Positions and
+  the per-tax-rate statistics are pre-aggregated server-side (OrderDocumentDataBuilder)
+  because a JSON template cannot group an array; the template only prints them:
+  positions[] via subDataSource("positions"), statistics.tax_groups[] via
+  subDataSource("statistics.tax_groups"), and the scalar totals as root fields.
+  All labels are staticText (no report-level $V{} → no null-in-title risk).
+  See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="order-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="d6dcf500-0300-4d60-9f50-000000000300">
+	<property name="com.jaspersoft.studio.data.defadapter" value="order-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<style name="Money" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<field name="doc_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
+	<field name="doc_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
+	<field name="doc_status" class="java.lang.String"><fieldDescription><![CDATA[document.status]]></fieldDescription></field>
+	<field name="doc_comment" class="java.lang.String"><fieldDescription><![CDATA[document.comment]]></fieldDescription></field>
+	<field name="doc_description" class="java.lang.String"><fieldDescription><![CDATA[document.description]]></fieldDescription></field>
+	<field name="cust_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<field name="cust_street" class="java.lang.String"><fieldDescription><![CDATA[customer.street]]></fieldDescription></field>
+	<field name="cust_zip" class="java.lang.String"><fieldDescription><![CDATA[customer.zip]]></fieldDescription></field>
+	<field name="cust_city" class="java.lang.String"><fieldDescription><![CDATA[customer.city]]></fieldDescription></field>
+	<field name="cust_contact" class="java.lang.String"><fieldDescription><![CDATA[customer.contact.name]]></fieldDescription></field>
+	<field name="cust_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
+	<field name="net_total" class="java.lang.Double"><fieldDescription><![CDATA[statistics.net_total]]></fieldDescription></field>
+	<field name="discount_amount" class="java.lang.Double"><fieldDescription><![CDATA[statistics.discount_amount]]></fieldDescription></field>
+	<field name="net_after_discount" class="java.lang.Double"><fieldDescription><![CDATA[statistics.net_after_discount]]></fieldDescription></field>
+	<field name="vat_total" class="java.lang.Double"><fieldDescription><![CDATA[statistics.vat_total]]></fieldDescription></field>
+	<field name="gross_total" class="java.lang.Double"><fieldDescription><![CDATA[statistics.gross_total]]></fieldDescription></field>
+	<field name="order_discount_percent" class="java.lang.Double"><fieldDescription><![CDATA[statistics.order_discount_percent]]></fieldDescription></field>
+	<title>
+		<band height="200">
+			<!-- Sender line -->
+			<staticText><reportElement x="0" y="0" width="330" height="9"/><textElement><font size="6"/></textElement><text><![CDATA[calServer V2 · Musterfirma · Musterstraße 1 · 12345 Musterstadt]]></text></staticText>
+			<!-- Recipient address block -->
+			<textField><reportElement x="0" y="18" width="300" height="14"/><textElement><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{cust_name}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="32" width="300" height="12"/><textFieldExpression><![CDATA[$F{cust_street}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="44" width="300" height="12"/><textFieldExpression><![CDATA[($F{cust_zip} == null ? "" : $F{cust_zip}) + " " + ($F{cust_city} == null ? "" : $F{cust_city})]]></textFieldExpression></textField>
+			<!-- Meta box (right) -->
+			<staticText><reportElement style="Label" x="380" y="18" width="80" height="12"/><text><![CDATA[Belegnummer]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="18" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="32" width="80" height="12"/><text><![CDATA[Datum]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="32" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="46" width="80" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="46" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="60" width="80" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="60" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
+			<!-- Subject -->
+			<textField><reportElement x="0" y="120" width="561" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA[($F{doc_status} == null ? "Beleg" : $F{doc_status}) + " " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="144" width="561" height="14"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
+			<!-- Positions table header -->
+			<line><reportElement x="0" y="176" width="561" height="1"/></line>
+			<staticText><reportElement style="Label" x="0" y="180" width="28" height="14"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" x="28" y="180" width="240" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" x="268" y="180" width="60" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+			<staticText><reportElement style="Label" x="328" y="180" width="70" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Einzelpreis]]></text></staticText>
+			<staticText><reportElement style="Label" x="398" y="180" width="45" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Rabatt]]></text></staticText>
+			<staticText><reportElement style="Label" x="443" y="180" width="78" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Betrag]]></text></staticText>
+			<staticText><reportElement style="Label" x="521" y="180" width="40" height="14"/><textElement textAlignment="Right"/><text><![CDATA[MwSt]]></text></staticText>
+		</band>
+	</title>
+	<detail>
+		<band height="200">
+			<subreport>
+				<reportElement positionType="Float" x="0" y="0" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/positions.jasper"]]></subreportExpression>
+			</subreport>
+			<line><reportElement positionType="Float" x="330" y="24" width="231" height="1"/></line>
+			<!-- Totals -->
+			<staticText><reportElement style="Label" positionType="Float" x="330" y="28" width="150" height="13"/><text><![CDATA[Zwischensumme netto]]></text></staticText>
+			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="480" y="28" width="81" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{net_total}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement style="Label" positionType="Float" x="330" y="44" width="150" height="13"><printWhenExpression><![CDATA[$F{discount_amount} != null && $F{discount_amount}.doubleValue() != 0.0]]></printWhenExpression></reportElement><textFieldExpression><![CDATA["Rabatt " + ($F{order_discount_percent} == null ? "" : $F{order_discount_percent}) + " %"]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="480" y="44" width="81" height="13"><printWhenExpression><![CDATA[$F{discount_amount} != null && $F{discount_amount}.doubleValue() != 0.0]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount_amount} == null ? null : (-$F{discount_amount})]]></textFieldExpression></textField>
+			<!-- Tax groups (USt. je Steuersatz) -->
+			<subreport>
+				<reportElement positionType="Float" x="330" y="60" width="231" height="12" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("statistics.tax_groups")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/tax-groups.jasper"]]></subreportExpression>
+			</subreport>
+			<line><reportElement positionType="Float" x="330" y="84" width="231" height="1"/></line>
+			<staticText><reportElement style="Label" positionType="Float" x="330" y="88" width="150" height="14"/><textElement><font size="10" isBold="true"/></textElement><text><![CDATA[Gesamtbetrag]]></text></staticText>
+			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="470" y="88" width="91" height="14"/><textElement textAlignment="Right"><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{gross_total}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement positionType="Float" x="0" y="120" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{doc_description}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="24">
+			<line><reportElement x="0" y="0" width="561" height="1"/></line>
+			<textField><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{doc_status} == null ? "" : $F{doc_status}) + (($F{doc_number} == null) ? "" : (" · " + $F{doc_number}))]]></textFieldExpression></textField>
+			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample_adapter.xml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 order-document sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Order Document JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,70 @@
+{
+  "meta": {
+    "contract": "order-document",
+    "schema_version": "1.0",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "document": {
+    "number": "AU-2026-0042",
+    "date": "2026-07-15",
+    "status": "Auftrag",
+    "comment": "Vielen Dank für Ihren Auftrag.",
+    "delivery_condition": "frei Haus",
+    "delivery_costs": 0,
+    "description": "Es gelten unsere Allgemeinen Geschäftsbedingungen.",
+    "custom_fields": {
+      "W4104": "Ihre Bestellung 12345",
+      "W4105": "2026-07-10",
+      "W4109": "2026-07-20"
+    }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE",
+    "contact": {
+      "name": "Erika Musterfrau",
+      "street": "Musterstraße 1",
+      "zip": "54321",
+      "city": "Beispielstadt",
+      "email": "erika@muster.example",
+      "phone": "+49 30 1234500"
+    }
+  },
+  "delivery": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE"
+  },
+  "invoice": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE"
+  },
+  "positions": [
+    { "pos_number": 1, "name": "Kalibrierung Gleichspannung", "article_type": "article", "quantity": 2, "unit": "Stk", "price": 100.0, "discount": 0.0, "tax": 19.0, "line_net": 200.0 },
+    { "pos_number": 2, "name": "Versand", "article_type": "article", "quantity": 1, "unit": "Stk", "price": 50.0, "discount": 10.0, "tax": 7.0, "line_net": 45.0 }
+  ],
+  "statistics": {
+    "tax_groups": [
+      { "rate": 7.0, "net": 45.0, "vat": 3.15 },
+      { "rate": 19.0, "net": 200.0, "vat": 38.0 }
+    ],
+    "net_total": 245.0,
+    "order_discount_percent": 0.0,
+    "discount_amount": 0.0,
+    "net_after_discount": 245.0,
+    "vat_total": 41.15,
+    "gross_total": 286.15
+  }
+}

--- a/ORDER-JSON-SAMPLE/subreports/positions.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions.jrxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 order positions subreport (contract order-document v1.0): fed the "positions"
+  array via subDataSource("positions"). One row per line item; the pre-computed
+  line_net is printed as-is (no running-sum in Jasper). No $V{} variables.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0301-4d61-9f51-000000000301">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<field name="pos_number" class="java.lang.Integer"><fieldDescription><![CDATA[pos_number]]></fieldDescription></field>
+	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="quantity" class="java.lang.Double"><fieldDescription><![CDATA[quantity]]></fieldDescription></field>
+	<field name="unit" class="java.lang.String"><fieldDescription><![CDATA[unit]]></fieldDescription></field>
+	<field name="price" class="java.lang.Double"><fieldDescription><![CDATA[price]]></fieldDescription></field>
+	<field name="discount" class="java.lang.Double"><fieldDescription><![CDATA[discount]]></fieldDescription></field>
+	<field name="line_net" class="java.lang.Double"><fieldDescription><![CDATA[line_net]]></fieldDescription></field>
+	<field name="tax" class="java.lang.Double"><fieldDescription><![CDATA[tax]]></fieldDescription></field>
+	<detail>
+		<band height="15">
+			<textField><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="28" y="0" width="240" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##"><reportElement x="268" y="0" width="32" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField><reportElement x="306" y="0" width="22" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="328" y="0" width="70" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{price}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##' %'"><reportElement x="398" y="0" width="45" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="443" y="0" width="78" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{line_net}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##' %'"><reportElement x="521" y="0" width="40" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tax}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/ORDER-JSON-SAMPLE/subreports/tax-groups.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/tax-groups.jrxml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 tax-groups subreport (contract order-document v1.0): fed the
+  statistics.tax_groups array via subDataSource("statistics.tax_groups"). One row
+  per tax rate — net base + VAT amount, both pre-aggregated server-side.
+  No $V{} variables.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="tax-groups" pageWidth="231" pageHeight="842" columnWidth="231" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0302-4d62-9f52-000000000302">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="rate" class="java.lang.Double"><fieldDescription><![CDATA[rate]]></fieldDescription></field>
+	<field name="net" class="java.lang.Double"><fieldDescription><![CDATA[net]]></fieldDescription></field>
+	<field name="vat" class="java.lang.Double"><fieldDescription><![CDATA[vat]]></fieldDescription></field>
+	<detail>
+		<band height="12">
+			<staticText><reportElement x="0" y="0" width="24" height="11"/><text><![CDATA[USt.]]></text></staticText>
+			<textField pattern="#,##0.##' %'"><reportElement x="24" y="0" width="40" height="11"/><textFieldExpression><![CDATA[$F{rate}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="90" y="0" width="70" height="11"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{net}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="160" y="0" width="71" height="11"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{vat}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
## Kontext

Phase D der V2-Reports-Strategie: die Auftrags-/Lieferschein-Familie als **layouttreue V2-Bundles** mit JSON-Datenquelle (kein SQL, DB-agnostisch), als „APEX · V2" auf der Downloads-Seite. Contract + Builder + `report-dataset`-Endpoint liegen in [calServer-yii#2857](https://github.com/calhelp/calServer-yii/pull/2857).

Beide Bundles wurden über den `report-runner` (JSON-Fill, JasperReports 6.20.6) **inhaltlich gerendert-verifiziert** — die Summen sind **builder-identisch**, 0× „null".

## Neue Bundles

| Bundle | Inhalt |
|--------|--------|
| `ORDER-JSON-SAMPLE` | Auftragsbeleg: Briefkopf (Empfängeradresse + Meta-Box), Positionstabelle via `subDataSource("positions")`, Steuergruppen via `subDataSource("statistics.tax_groups")` (**verschachtelter Pfad bestätigt**), Skalar-Summen aus dem Contract (Zwischensumme netto 245,00 €, USt. 7 %/19 %, **Gesamtbetrag 286,15 €**) |
| `DELIVERY-JSON-SAMPLE` | Lieferschein (schlank): Lieferadresse aus der serverseitig aufgelösten `delivery`-Rolle, Positionen **ohne** Preise/Steuer, Empfangs-Unterschriftszeile |

Beide fahren denselben Contract `order-document` v1.0; die serverseitig vorberechnete `statistics` wird nur vom Auftrag gedruckt (Jasper kann ein JSON-Array nicht gruppieren).

## Härtung (aus dem DAkkS-Blank-Bug)

- **Keine `$V{}`-Variablen in report-level Bändern** — alle Labels `staticText`/`$F{}`.
- Prozent-Felder mit **gequotetem Literal** (`#,##0.##' %'`) statt DecimalFormat-`%` (das ×100 multipliziert hätte — im Render gefixt: 19 statt „1.900 %").
- Je Bundle mitgelieferter **Jaspersoft-Studio-JSON-Data-Adapter** (`*_adapter.xml`, Studio-only, im Runner inert) + README „leeres Blatt = fehlende Datenquelle".

## Packaging

`package-reports.yml` (`upload-artifact` + `create_zip`) und `publish-downloads.yml` (`get_last_modified` + `README_MAP` + `TITLE_MAP`) je Bundle ergänzt; `getCategory()` ordnet die `-json-sample`-Namen automatisch der APEX·V2-Sektion zu.

## Verifikation

- Runner-Render beider Bundles: je 1 Seite, echte Werte, Summen builder-identisch, 0× „null".
- `scripts/check_jasper_version.sh` grün (6.20.6); `xmllint` well-formed; JSON valide; YAML-Syntax beider Workflows geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh

---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_