### PR TITLE
feat(apex): REPAIR + LOCATION JSON-Bundles (Reparatur-/Leihbericht)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -222,6 +222,20 @@ jobs:
             DELIVERY-JSON-SAMPLE/subreports
           if-no-files-found: error
 
+      - name: Upload REPAIR-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: REPAIR-JSON-SAMPLE
+          path: REPAIR-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
+      - name: Upload LOCATION-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: LOCATION-JSON-SAMPLE
+          path: LOCATION-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
       - name: List files before zipping (Debug)
         run: |
           echo "📂 Inhalt von DAKKS-SAMPLE:"
@@ -349,6 +363,8 @@ jobs:
           create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
           create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
           create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
+          create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"
+          create_zip "LOCATION-JSON-SAMPLE" "location-json-sample"
 
 
       - name: Upload report ZIPs as artifact

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -107,6 +107,8 @@ jobs:
           get_last_modified "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
           get_last_modified "ORDER-JSON-SAMPLE" "order-json-sample"
           get_last_modified "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
+          get_last_modified "REPAIR-JSON-SAMPLE" "repair-json-sample"
+          get_last_modified "LOCATION-JSON-SAMPLE" "location-json-sample"
 
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
@@ -183,6 +185,8 @@ jobs:
               "sticker-cal-inv-zebra-json-sample":  "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md",
               "order-json-sample":                  "ORDER-JSON-SAMPLE/README.md",
               "delivery-json-sample":               "DELIVERY-JSON-SAMPLE/README.md",
+              "repair-json-sample":                 "REPAIR-JSON-SAMPLE/README.md",
+              "location-json-sample":               "LOCATION-JSON-SAMPLE/README.md",
           }
 
           SCHEMA_MAP = {
@@ -207,6 +211,8 @@ jobs:
               "sticker-cal-inv-zebra-json-sample":  "Zebra Inventar-/Kalibrier-Sticker (APEX · V2)",
               "order-json-sample":                  "Auftragsbeleg (APEX · V2)",
               "delivery-json-sample":               "Lieferschein (APEX · V2)",
+              "repair-json-sample":                 "Reparaturbericht (APEX · V2)",
+              "location-json-sample":               "Standort-/Leihbericht (APEX · V2)",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -1,0 +1,73 @@
+# LOCATION-JSON-SAMPLE — Standort-/Leihbericht (V2 / APEX)
+
+Standort-/Leihbericht als **V2-Bundle** im Sinne von
+[ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md):
+gefüllt aus dem Report-Data-Contract `location-report` (JSON) mit lesbaren
+API-Feldnamen statt aus eingebettetem SQL gegen V1-Codespalten.
+
+Sechste Bundle-Familie; das Layout folgt dem V1-Leihschein
+(`httpdocs/reports/locations/Location/main_reports/Location.jrxml`): Kunden- und
+Lieferadresse mit Kontakten, Leihdaten (Leihdatum/-zeit, Rückgabedatum, Status),
+Prüfmittel-Grid und Standortblock (`location_1..5`) mit Signaturzeilen.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/location-json-sample.jrxml` | Hauptbericht: Kopf mit Kunde-/Lieferadresse + Kontakten, Leihdaten-Block, Prüfmittel-Grid, Standortblock (`location_1..5`), Signaturzeilen (Entleiher/Ausgabe), Seiten-Footer |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `location-report` **v1.0**) |
+| `main_reports/location-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
+
+## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
+
+Dieses Bundle ist **datenquellenlos**: Der Bericht enthält **kein** eingebettetes
+SQL und **keine** Beispieldaten im Template selbst. Er rendert nur dann Inhalt,
+wenn ihm eine **JSON-Datenquelle** übergeben wird. Wird er ohne Datenquelle
+ausgeführt — z. B. „Preview" in Jaspersoft Studio ohne konfigurierten
+Data-Adapter, oder Generierung in der Live-Umgebung **ohne** die Report-Variable
+`data_contract` — bleibt die Seite leer. Das ist **kein** Template-Fehler,
+sondern die fehlende Datenanbindung. Abhilfe:
+
+- **Vorschau ohne Backend (Jaspersoft Studio):** Das Bundle bringt den Adapter
+  `location-json-sample_adapter.xml` mit und referenziert ihn über die
+  Report-Property `com.jaspersoft.studio.data.defadapter`. „Open → Preview"
+  füllt den Bericht direkt aus `sample-data.json`. Falls die Studio-Version den
+  Default-Adapter nicht automatisch zieht, den Adapter im Vorschau-Dropdown
+  einmalig auswählen.
+- **Live-Umgebung (calServer V2):** Auf dem Report-Setting die report-scoped
+  Variable `data_contract = location-report` setzen — dann liefert das Backend
+  (`LocationReportDataBuilder`) den JSON-Datensatz an den Runner. Ohne diese
+  Variable läuft der klassische JDBC-Pfad, der hier mangels `<queryString>`
+  keine Daten hat.
+
+## Datenanbindung
+
+- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
+- Der Runner füllt den Hauptbericht mit einer `JsonDataSource`
+  (`dataSourceType=json`, `dataJson`); der Bericht ist genau ein Datensatz
+  (Wurzelobjekt).
+- Das Rückgabedatum ist ein konfiguriertes Custom Field und wird unter seinem
+  `api_name` gebunden: `location.custom_fields.rental_end`.
+- Die Lieferadresse (`delivery_customer`) fällt **serverseitig** auf den
+  Kunden zurück, wenn kein eigener Lieferkunde hinterlegt ist — das Template
+  braucht keine Fallback-Logik.
+- Den Datensatz erzeugt das calServer-V2-Backend (`LocationReportDataBuilder`).
+
+Aktivierung in calServer: dem Report-Setting (grid_name `location`, Ordner
+`locations`) eine Report-Variable `data_contract = location-report` zuweisen
+(Details siehe V2-Doku „V2-Berichte mit JSON-Datenquelle").
+
+## Contract `location-report` (v1.0)
+
+| Block | Felder |
+|-------|--------|
+| `meta` | `contract`, `schema_version`, `generated_at`, `locale` |
+| `location` | `location_1..5`, `location_date`, `location_time`, `is_active`, `status`, `custom_fields{}` (inkl. `rental_end`, wenn konfiguriert) |
+| `device` | `asset_number`, `serial_number`, `description`, `manufacturer`, `model`, `type_code`, `next_calibration_date`, `custom_fields{}` (`{}` wenn kein Gerät verknüpft) |
+| `customer` | `name`, `customer_number`, `street`, `zip`, `city`, `country`, `custom_fields{}` |
+| `customer_contact` | `name`, `street`, `zip`, `city`, `email`, `phone` (`{}` wenn kein Kontakt verknüpft) |
+| `delivery_customer` | wie `customer`; serverseitiger Fallback auf `customer` |
+| `delivery_contact` | wie `customer_contact` |
+
+> **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
+> verbindlich (siehe `robots.md`).

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 location/loan report (ADR-009, contract "location-report" v1.0). Filled from
+  a JSON data source — NO SQL. Layout follows the V1 Location.jrxml loan sheet:
+  customer / delivery-customer address blocks with contacts, loan-data block
+  (Leihdatum/-zeit, Rückgabedatum aus location.custom_fields.rental_end, Status),
+  device grid and a location block (location_1..5). The delivery block always
+  carries printable values — the server falls back to the owning customer, so no
+  branching is needed here. All labels are staticText (no report-level $V{} → no
+  null-in-title risk). See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="location-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="e8eef700-0500-4e80-af70-000000000500">
+	<property name="com.jaspersoft.studio.data.defadapter" value="location-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<style name="SectionTitle" fontSize="10" isBold="true"/>
+	<style name="Small" fontSize="8"/>
+	<field name="location_1" class="java.lang.String"><fieldDescription><![CDATA[location.location_1]]></fieldDescription></field>
+	<field name="location_2" class="java.lang.String"><fieldDescription><![CDATA[location.location_2]]></fieldDescription></field>
+	<field name="location_3" class="java.lang.String"><fieldDescription><![CDATA[location.location_3]]></fieldDescription></field>
+	<field name="location_4" class="java.lang.String"><fieldDescription><![CDATA[location.location_4]]></fieldDescription></field>
+	<field name="location_5" class="java.lang.String"><fieldDescription><![CDATA[location.location_5]]></fieldDescription></field>
+	<field name="location_date" class="java.lang.String"><fieldDescription><![CDATA[location.location_date]]></fieldDescription></field>
+	<field name="location_time" class="java.lang.String"><fieldDescription><![CDATA[location.location_time]]></fieldDescription></field>
+	<field name="location_status" class="java.lang.String"><fieldDescription><![CDATA[location.status]]></fieldDescription></field>
+	<field name="rental_end" class="java.lang.String"><fieldDescription><![CDATA[location.custom_fields.rental_end]]></fieldDescription></field>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[device.serial_number]]></fieldDescription></field>
+	<field name="device_description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[device.manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[device.model]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription></field>
+	<field name="customer_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<field name="customer_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
+	<field name="customer_street" class="java.lang.String"><fieldDescription><![CDATA[customer.street]]></fieldDescription></field>
+	<field name="customer_zip" class="java.lang.String"><fieldDescription><![CDATA[customer.zip]]></fieldDescription></field>
+	<field name="customer_city" class="java.lang.String"><fieldDescription><![CDATA[customer.city]]></fieldDescription></field>
+	<field name="contact_name" class="java.lang.String"><fieldDescription><![CDATA[customer_contact.name]]></fieldDescription></field>
+	<field name="contact_email" class="java.lang.String"><fieldDescription><![CDATA[customer_contact.email]]></fieldDescription></field>
+	<field name="contact_phone" class="java.lang.String"><fieldDescription><![CDATA[customer_contact.phone]]></fieldDescription></field>
+	<field name="delivery_name" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.name]]></fieldDescription></field>
+	<field name="delivery_street" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.street]]></fieldDescription></field>
+	<field name="delivery_zip" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.zip]]></fieldDescription></field>
+	<field name="delivery_city" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.city]]></fieldDescription></field>
+	<field name="delivery_contact_name" class="java.lang.String"><fieldDescription><![CDATA[delivery_contact.name]]></fieldDescription></field>
+	<field name="delivery_contact_email" class="java.lang.String"><fieldDescription><![CDATA[delivery_contact.email]]></fieldDescription></field>
+	<field name="delivery_contact_phone" class="java.lang.String"><fieldDescription><![CDATA[delivery_contact.phone]]></fieldDescription></field>
+	<title>
+		<band height="240">
+			<textField>
+				<reportElement x="0" y="0" width="561" height="22"/>
+				<textElement textAlignment="Center"><font size="15" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA["Standort- / Leihbericht"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="24" width="561" height="14"/>
+				<textElement textAlignment="Center"><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($F{asset_number} == null ? "" : $F{asset_number}) + "  ·  " + ($F{device_description} == null ? "" : $F{device_description})]]></textFieldExpression>
+			</textField>
+			<line><reportElement x="0" y="44" width="561" height="1"/></line>
+			<staticText><reportElement style="SectionTitle" x="0" y="52" width="270" height="14"/><text><![CDATA[Kunde]]></text></staticText>
+			<textField>
+				<reportElement style="Value" x="0" y="70" width="270" height="13"/>
+				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{customer_number} == null || $F{customer_number}.isEmpty()) ? "" : ("  (" + $F{customer_number} + ")"))]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="0" y="84" width="270" height="13"/><textFieldExpression><![CDATA[$F{customer_street}]]></textFieldExpression></textField>
+			<textField>
+				<reportElement style="Value" x="0" y="98" width="270" height="13"/>
+				<textFieldExpression><![CDATA[($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})]]></textFieldExpression>
+			</textField>
+			<staticText><reportElement style="Label" x="0" y="116" width="60" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="60" y="116" width="210" height="12"/><textFieldExpression><![CDATA[$F{contact_name}]]></textFieldExpression></textField>
+			<textField>
+				<reportElement style="Small" x="60" y="129" width="210" height="12"/>
+				<textFieldExpression><![CDATA[($F{contact_email} == null ? "" : $F{contact_email}) + (($F{contact_phone} == null || $F{contact_phone}.isEmpty()) ? "" : ("  ·  " + $F{contact_phone}))]]></textFieldExpression>
+			</textField>
+			<staticText><reportElement style="SectionTitle" x="291" y="52" width="270" height="14"/><text><![CDATA[Lieferadresse]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="291" y="70" width="270" height="13"/><textFieldExpression><![CDATA[$F{delivery_name}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="291" y="84" width="270" height="13"/><textFieldExpression><![CDATA[$F{delivery_street}]]></textFieldExpression></textField>
+			<textField>
+				<reportElement style="Value" x="291" y="98" width="270" height="13"/>
+				<textFieldExpression><![CDATA[($F{delivery_zip} == null ? "" : $F{delivery_zip}) + " " + ($F{delivery_city} == null ? "" : $F{delivery_city})]]></textFieldExpression>
+			</textField>
+			<staticText><reportElement style="Label" x="291" y="116" width="60" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="351" y="116" width="210" height="12"/><textFieldExpression><![CDATA[$F{delivery_contact_name}]]></textFieldExpression></textField>
+			<textField>
+				<reportElement style="Small" x="351" y="129" width="210" height="12"/>
+				<textFieldExpression><![CDATA[($F{delivery_contact_email} == null ? "" : $F{delivery_contact_email}) + (($F{delivery_contact_phone} == null || $F{delivery_contact_phone}.isEmpty()) ? "" : ("  ·  " + $F{delivery_contact_phone}))]]></textFieldExpression>
+			</textField>
+			<line><reportElement x="0" y="150" width="561" height="1"/></line>
+			<staticText><reportElement style="SectionTitle" x="0" y="158" width="561" height="14"/><text><![CDATA[Leihdaten]]></text></staticText>
+			<staticText><reportElement style="Label" x="0" y="176" width="130" height="13"/><text><![CDATA[Leihdatum / -zeit]]></text></staticText>
+			<textField>
+				<reportElement style="Value" x="130" y="176" width="150" height="13"/>
+				<textFieldExpression><![CDATA[($F{location_date} == null ? "" : $F{location_date}) + (($F{location_time} == null || $F{location_time}.isEmpty()) ? "" : (" " + $F{location_time}))]]></textFieldExpression>
+			</textField>
+			<staticText><reportElement style="Label" x="290" y="176" width="120" height="13"/><text><![CDATA[Rückgabedatum]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="176" width="151" height="13"/><textFieldExpression><![CDATA[$F{rental_end}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="192" width="130" height="13"/><text><![CDATA[Verleih-Status]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="192" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_status}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="192" width="120" height="13"/><text><![CDATA[Nächste Kalibrierung]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="192" width="151" height="13"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+		</band>
+	</title>
+	<detail>
+		<band height="230">
+			<staticText><reportElement style="SectionTitle" x="0" y="0" width="561" height="14"/><text><![CDATA[Prüfmittel]]></text></staticText>
+			<staticText><reportElement style="Label" x="0" y="18" width="100" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="100" y="18" width="110" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="210" y="18" width="150" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<staticText><reportElement style="Label" x="360" y="18" width="201" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<line><reportElement x="0" y="32" width="561" height="1"/></line>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="0" y="36" width="100" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="100" y="36" width="110" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<textField>
+				<reportElement style="Small" x="210" y="36" width="150" height="13"/>
+				<textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="360" y="36" width="201" height="13"/><textFieldExpression><![CDATA[$F{device_description}]]></textFieldExpression></textField>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="0" y="62" width="561" height="14"/><text><![CDATA[Standort]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="0" y="80" width="130" height="13"/><text><![CDATA[Standort 1]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="80" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_1}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" positionType="Float" x="290" y="80" width="120" height="13"/><text><![CDATA[Standort 4]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="410" y="80" width="151" height="13"/><textFieldExpression><![CDATA[$F{location_4}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" positionType="Float" x="0" y="96" width="130" height="13"/><text><![CDATA[Standort 2]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="96" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_2}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" positionType="Float" x="290" y="96" width="120" height="13"/><text><![CDATA[Standort 5]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="410" y="96" width="151" height="13"/><textFieldExpression><![CDATA[$F{location_5}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" positionType="Float" x="0" y="112" width="130" height="13"/><text><![CDATA[Standort 3]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="112" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_3}]]></textFieldExpression></textField>
+			<line><reportElement positionType="Float" x="0" y="180" width="220" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="0" y="182" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift Entleiher]]></text></staticText>
+			<line><reportElement positionType="Float" x="341" y="180" width="220" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="341" y="182" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift Ausgabe]]></text></staticText>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="24">
+			<line><reportElement x="0" y="0" width="561" height="1"/></line>
+			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Standort- / Leihbericht · calServer V2]]></text></staticText>
+			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample_adapter.xml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample_adapter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the location/loan V2 sample.
+
+  Bundled so the report previews out-of-the-box: opening
+  location-json-sample.jrxml and hitting "Preview" fills it from the sibling
+  sample-data.json (contract location-report v1.0) via this adapter,
+  referenced by the report property com.jaspersoft.studio.data.defadapter.
+
+  This is an AUTHORING/PREVIEW aid only. It is a Studio-namespaced property and
+  is inert in the report-runner: at runtime the calServer V2 backend supplies
+  the JSON datasource itself (see README → "Datenanbindung"). If your Studio
+  version does not auto-apply it, pick this adapter manually in the preview
+  data-adapter dropdown.
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Location JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/LOCATION-JSON-SAMPLE/main_reports/sample-data.json
+++ b/LOCATION-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,61 @@
+{
+  "meta": {
+    "contract": "location-report",
+    "schema_version": "1.0",
+    "generated_at": "2026-07-16T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "location": {
+    "location_1": "Gebäude A",
+    "location_2": "Raum 101",
+    "location_3": "Regal 3",
+    "location_4": "OG2",
+    "location_5": "L-42",
+    "location_date": "2026-07-01",
+    "location_time": "08:00:00",
+    "is_active": 1,
+    "status": "verliehen",
+    "custom_fields": { "rental_end": "2026-09-30" }
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "next_calibration_date": "2027-06-30",
+    "custom_fields": {}
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE",
+    "custom_fields": {}
+  },
+  "customer_contact": {
+    "name": "Erika Musterfrau",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "email": "erika@muster.example",
+    "phone": "+49 30 1234500"
+  },
+  "delivery_customer": {
+    "name": "Muster GmbH — Werk 2",
+    "customer_number": "K-1001",
+    "street": "Wareneingang, Tor 3",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE",
+    "custom_fields": {}
+  },
+  "delivery_contact": {
+    "name": "Hans Beispiel",
+    "email": "hans@muster.example",
+    "phone": "+49 30 1234501"
+  }
+}

--- a/REPAIR-JSON-SAMPLE/README.md
+++ b/REPAIR-JSON-SAMPLE/README.md
@@ -1,0 +1,68 @@
+# REPAIR-JSON-SAMPLE — Reparaturbericht (V2 / APEX)
+
+Reparaturbericht als **V2-Bundle** im Sinne von
+[ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md):
+gefüllt aus dem Report-Data-Contract `repair-report` (JSON) mit lesbaren
+API-Feldnamen statt aus eingebettetem SQL gegen V1-Codespalten.
+
+Fünfte Bundle-Familie (nach Kalibrierschein, Geräte-Datenblatt,
+Auftrag/Lieferschein). V1 liefert keinen eingebauten Reparatur-JRXML mit —
+dieses Layout ist bewusst neu entworfen: Prüfmittel-Stammdatengrid,
+Fehlerbeschreibung, Reparaturaktion, Datum/Status und Signaturzeilen.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/repair-json-sample.jrxml` | Hauptbericht: Kopf mit Prüfmittel-Grid (Inventar-/Serien-Nr., Hersteller/Typ, nächste Kalibrierung, Kunde), Reparaturdatum + Status, Abschnitte Fehlerbeschreibung (`repair.description`) und Reparaturaktion (`repair.notes`), Signaturzeilen, Seiten-Footer |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `repair-report` **v1.0**) |
+| `main_reports/repair-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
+
+## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
+
+Dieses Bundle ist **datenquellenlos**: Der Bericht enthält **kein** eingebettetes
+SQL und **keine** Beispieldaten im Template selbst. Er rendert nur dann Inhalt,
+wenn ihm eine **JSON-Datenquelle** übergeben wird. Wird er ohne Datenquelle
+ausgeführt — z. B. „Preview" in Jaspersoft Studio ohne konfigurierten
+Data-Adapter, oder Generierung in der Live-Umgebung **ohne** die Report-Variable
+`data_contract` — bleibt die Seite leer. Das ist **kein** Template-Fehler,
+sondern die fehlende Datenanbindung. Abhilfe:
+
+- **Vorschau ohne Backend (Jaspersoft Studio):** Das Bundle bringt den Adapter
+  `repair-json-sample_adapter.xml` mit und referenziert ihn über die
+  Report-Property `com.jaspersoft.studio.data.defadapter`. „Open → Preview"
+  füllt den Bericht direkt aus `sample-data.json`. Falls die Studio-Version den
+  Default-Adapter nicht automatisch zieht, den Adapter im Vorschau-Dropdown
+  einmalig auswählen.
+- **Live-Umgebung (calServer V2):** Auf dem Report-Setting die report-scoped
+  Variable `data_contract = repair-report` setzen — dann liefert das Backend
+  (`RepairReportDataBuilder`) den JSON-Datensatz an den Runner. Ohne diese
+  Variable läuft der klassische JDBC-Pfad, der hier mangels `<queryString>`
+  keine Daten hat.
+
+## Datenanbindung
+
+- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
+- Der Runner füllt den Hauptbericht mit einer `JsonDataSource`
+  (`dataSourceType=json`, `dataJson`); der Bericht ist genau ein Datensatz
+  (Wurzelobjekt).
+- Custom Fields (z. B. Techniker, Kosten, Ersatzteile) stehen unter ihrem
+  `api_name` im Objekt `repair.custom_fields` bereit, sobald sie in calServer
+  als Felder der Reparatur-Tabelle konfiguriert sind.
+- Den Datensatz erzeugt das calServer-V2-Backend (`RepairReportDataBuilder`).
+
+Aktivierung in calServer: dem Report-Setting (grid_name `repair`, Ordner
+`repairs`) eine Report-Variable `data_contract = repair-report` zuweisen
+(Details siehe V2-Doku „V2-Berichte mit JSON-Datenquelle").
+
+## Contract `repair-report` (v1.0)
+
+| Block | Felder |
+|-------|--------|
+| `meta` | `contract`, `schema_version`, `generated_at`, `locale` |
+| `repair` | `description`, `notes`, `repair_date`, `repair_time`, `status_code`, `status`, `custom_fields{}` |
+| `device` | `asset_number`, `serial_number`, `description`, `manufacturer`, `model`, `type_code`, `next_calibration_date`, `custom_fields{}` (`{}` wenn kein Gerät verknüpft) |
+| `customer` | `name`, `customer_number`, `street`, `zip`, `city`, `custom_fields{}` (`{}` wenn kein Kunde verknüpft) |
+
+> **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
+> verbindlich (siehe `robots.md`).

--- a/REPAIR-JSON-SAMPLE/main_reports/repair-json-sample.jrxml
+++ b/REPAIR-JSON-SAMPLE/main_reports/repair-json-sample.jrxml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 repair report (ADR-009, contract "repair-report" v1.0). Filled from a JSON
+  data source — NO SQL. V1 ships no repair JRXML, so this is a greenfield layout:
+  device master-data grid, fault description, repair action, date/time/status and
+  a signature line. All labels are staticText (no report-level $V{} → no
+  null-in-title risk). See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="repair-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="e8eef700-0400-4e80-af70-000000000400">
+	<property name="com.jaspersoft.studio.data.defadapter" value="repair-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<style name="SectionTitle" fontSize="10" isBold="true"/>
+	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[repair.description]]></fieldDescription></field>
+	<field name="notes" class="java.lang.String"><fieldDescription><![CDATA[repair.notes]]></fieldDescription></field>
+	<field name="repair_date" class="java.lang.String"><fieldDescription><![CDATA[repair.repair_date]]></fieldDescription></field>
+	<field name="repair_time" class="java.lang.String"><fieldDescription><![CDATA[repair.repair_time]]></fieldDescription></field>
+	<field name="repair_status" class="java.lang.String"><fieldDescription><![CDATA[repair.status]]></fieldDescription></field>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[device.serial_number]]></fieldDescription></field>
+	<field name="device_description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[device.manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[device.model]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription></field>
+	<field name="customer_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<field name="customer_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
+	<field name="customer_city" class="java.lang.String"><fieldDescription><![CDATA[customer.city]]></fieldDescription></field>
+	<title>
+		<band height="170">
+			<textField>
+				<reportElement x="0" y="0" width="561" height="22"/>
+				<textElement textAlignment="Center"><font size="15" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA["Reparaturbericht"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="0" y="24" width="561" height="14"/>
+				<textElement textAlignment="Center"><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($F{asset_number} == null ? "" : $F{asset_number}) + "  ·  " + ($F{device_description} == null ? "" : $F{device_description})]]></textFieldExpression>
+			</textField>
+			<line><reportElement x="0" y="44" width="561" height="1"/></line>
+			<staticText><reportElement style="SectionTitle" x="0" y="52" width="561" height="14"/><text><![CDATA[Prüfmittel]]></text></staticText>
+			<staticText><reportElement style="Label" x="0" y="70" width="130" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="70" width="150" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="70" width="120" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="70" width="151" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="86" width="130" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="86" width="150" height="13"/><textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="86" width="120" height="13"/><text><![CDATA[Nächste Kalibrierung]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="86" width="151" height="13"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="102" width="130" height="13"/><text><![CDATA[Kunde]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="102" width="431" height="13"/><textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{customer_number} == null || $F{customer_number}.isEmpty()) ? "" : ("  (" + $F{customer_number} + ")")) + (($F{customer_city} == null || $F{customer_city}.isEmpty()) ? "" : (", " + $F{customer_city}))]]></textFieldExpression></textField>
+			<line><reportElement x="0" y="124" width="561" height="1"/></line>
+			<staticText><reportElement style="Label" x="0" y="132" width="130" height="13"/><text><![CDATA[Reparaturdatum]]></text></staticText>
+			<textField><reportElement style="Value" x="130" y="132" width="150" height="13"/><textFieldExpression><![CDATA[($F{repair_date} == null ? "" : $F{repair_date}) + (($F{repair_time} == null || $F{repair_time}.isEmpty()) ? "" : (" " + $F{repair_time}))]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="290" y="132" width="120" height="13"/><text><![CDATA[Status]]></text></staticText>
+			<textField><reportElement style="Value" x="410" y="132" width="151" height="13"/><textFieldExpression><![CDATA[$F{repair_status}]]></textFieldExpression></textField>
+		</band>
+	</title>
+	<detail>
+		<band height="180">
+			<staticText><reportElement style="SectionTitle" x="0" y="0" width="561" height="14"/><text><![CDATA[Fehlerbeschreibung]]></text></staticText>
+			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="18" width="561" height="14"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="0" y="48" width="561" height="14"/><text><![CDATA[Reparaturaktion]]></text></staticText>
+			<textField textAdjust="StretchHeight"><reportElement style="Value" positionType="Float" x="0" y="66" width="561" height="14"/><textFieldExpression><![CDATA[$F{notes}]]></textFieldExpression></textField>
+			<line><reportElement positionType="Float" x="0" y="130" width="220" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="0" y="132" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift Techniker]]></text></staticText>
+			<line><reportElement positionType="Float" x="341" y="130" width="220" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="341" y="132" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift Freigabe]]></text></staticText>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="24">
+			<line><reportElement x="0" y="0" width="561" height="1"/></line>
+			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Reparaturbericht · calServer V2]]></text></staticText>
+			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/REPAIR-JSON-SAMPLE/main_reports/repair-json-sample_adapter.xml
+++ b/REPAIR-JSON-SAMPLE/main_reports/repair-json-sample_adapter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the repair V2 sample.
+
+  Bundled so the report previews out-of-the-box: opening
+  repair-json-sample.jrxml and hitting "Preview" fills it from the sibling
+  sample-data.json (contract repair-report v1.0) via this adapter,
+  referenced by the report property com.jaspersoft.studio.data.defadapter.
+
+  This is an AUTHORING/PREVIEW aid only. It is a Studio-namespaced property and
+  is inert in the report-runner: at runtime the calServer V2 backend supplies
+  the JSON datasource itself (see README → "Datenanbindung"). If your Studio
+  version does not auto-apply it, pick this adapter manually in the preview
+  data-adapter dropdown.
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Repair JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/REPAIR-JSON-SAMPLE/main_reports/sample-data.json
+++ b/REPAIR-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,35 @@
+{
+  "meta": {
+    "contract": "repair-report",
+    "schema_version": "1.0",
+    "generated_at": "2026-07-16T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "repair": {
+    "description": "Display zeigt keine Anzeige, Gerät startet nicht",
+    "notes": "Displayeinheit getauscht, Firmware aktualisiert, Funktionstest bestanden",
+    "repair_date": "2026-07-10",
+    "repair_time": "09:30:00",
+    "status_code": "A",
+    "status": "erledigt",
+    "custom_fields": { "technician": "Max Mustermann", "total_cost": "245.00" }
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "next_calibration_date": "2027-06-30",
+    "custom_fields": {}
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "custom_fields": {}
+  }
+}


### PR DESCRIPTION
## Zusammenfassung

Bundles für die **letzten zwei Familien** der V2-JSON-Strategie ([ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md)) — Gegenstück zum Backend-PR calhelp/calServer-yii#2869 (Contracts `repair-report` / `location-report`). Damit ist keine Report-Familie mehr JDBC-only.

### REPAIR-JSON-SAMPLE — Reparaturbericht (Contract `repair-report` v1.0)

- V1 liefert keinen eingebauten Reparatur-JRXML mit → bewusst neu entworfenes Layout: Prüfmittel-Stammdatengrid (Inventar-/Serien-Nr., Hersteller/Typ, nächste Kalibrierung, Kunde), Reparaturdatum + Status, Abschnitte **Fehlerbeschreibung** (`repair.description`) und **Reparaturaktion** (`repair.notes`), Signaturzeilen (Techniker/Freigabe).

### LOCATION-JSON-SAMPLE — Standort-/Leihbericht (Contract `location-report` v1.0)

- Layout nach dem V1-Leihschein (`httpdocs/reports/locations/Location/main_reports/Location.jrxml`): Kunden- und Lieferadresse mit Kontakten, Leihdaten-Block (Leihdatum/-zeit, **Rückgabedatum aus `location.custom_fields.rental_end`**, Status), Prüfmittel-Grid, Standortblock (`location_1..5`), Signaturzeilen (Entleiher/Ausgabe).
- Die Lieferadresse fällt **serverseitig** auf den Kunden zurück — das Template braucht keine Fallback-Logik (anders als die V1-`$V{}`-Kaskaden).

### Härtungsregeln (aus dem Blank-Page-Fix) eingehalten

- Kein SQL, kein `REPORT_CONNECTION` — reiner `JsonDataSource`-Fill über `<fieldDescription>`-JSON-Pfade.
- Labels ausschließlich `staticText`, keine report-level `$V{}` ohne `initialValueExpression` → kein Null-im-Titel-Risiko.
- Studio-Data-Adapter (`*_adapter.xml`) über die runner-inerte Property `com.jaspersoft.studio.data.defadapter` → Vorschau in Jaspersoft Studio ist turnkey.
- README je Bundle mit Abschnitt „⚠️ Warum ein leeres/weißes Blatt erscheinen kann".
- JasperReports **6.20.6** (Version-Check grün).

### Packaging/Publishing

- `package-reports.yml`: upload-artifact + `create_zip` für beide Bundles (die `*-JSON-SAMPLE`-Allowlist nimmt `sample-data.json` + Adapter-XML bereits mit).
- `publish-downloads.yml`: `get_last_modified` + `README_MAP`/`TITLE_MAP` („Reparaturbericht (APEX · V2)" / „Standort-/Leihbericht (APEX · V2)"); die Downloads-Seite kategorisiert `-json-sample`-Namen automatisch unter „APEX · V2 (JSON-Datenquelle)".

## Verifikation

- Beide Bundles über den report-runner (JR 6.20.6) aus ihrer `sample-data.json` gerendert: Text- und PDF-Export enthalten alle Blockinhalte (Gerät, Kunde/Lieferkunde, Kontakte, Leihdaten inkl. `rental_end`, Standort 1–5, Fehlerbeschreibung/Reparaturaktion), **0× „null"** im Render.
- `xmllint` (JRXML + Adapter), JSON- und YAML-Validierung, `scripts/check_jasper_version.sh` — alles grün.

## Aktivierung in calServer (nach Merge von calhelp/calServer-yii#2869)

Report-Setting (grid_name `repair` bzw. `location`) anlegen, Bundle-ZIP hochladen, report-scoped Variable `data_contract = repair-report` bzw. `location-report` setzen. Ohne die Variable bleibt der klassische JDBC-Pfad aktiv.


---
_Generated by [Claude Code](https://claude.ai/code/session_017JynS9tysbXitgFsK3EWkh)_