### PR TITLE
feat(parameters): Parameter-Katalog-Manifest für V2-JSON-Bundles (Pilot: DAKKS-JSON-SAMPLE)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -163,6 +163,7 @@ jobs:
           path: |
             DAKKS-JSON-SAMPLE/main_reports
             DAKKS-JSON-SAMPLE/subreports
+            DAKKS-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
       - name: Upload INVENTORY-JSON-SAMPLE as artifact
@@ -304,6 +305,12 @@ jobs:
               cp "${sample}/README.md" "${stage_dir}/README.md"
             fi
 
+            # Parameter-Manifest an der Bundle-Wurzel mitnehmen (nur V2-JSON-
+            # Bundles pflegen eins; calServer liest daraus den Parameter-Katalog).
+            if [ -f "${sample}/parameters.json" ]; then
+              cp "${sample}/parameters.json" "${stage_dir}/parameters.json"
+            fi
+
             # Nicht erlaubte Dateien entfernen, damit nur die gewünschten Typen
             # (JRXML, Markdown und ggf. Properties/XSD/JSON) enthalten bleiben.
             local allowed_conditions=()
@@ -328,6 +335,7 @@ jobs:
             [ -d main_reports ] && zip_targets+=(main_reports)
             [ -d subreports ] && zip_targets+=(subreports)
             [ -f README.md ] && zip_targets+=(README.md)
+            [ -f parameters.json ] && zip_targets+=(parameters.json)
             if [ "${#zip_targets[@]}" -eq 0 ]; then
               echo "❌ No report content found for ${sample}" >&2
               popd >/dev/null

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -137,6 +137,12 @@ jobs:
           cp pages/index.html "${SITE_DIR}/index.html"
           touch "${SITE_DIR}/.nojekyll"
 
+          # JSON-Schemata (z. B. report-parameters.schema.json) mit veröffentlichen,
+          # damit die $schema-URLs der Bundle-Manifeste auflösbar sind.
+          if [ -d schema ]; then
+            cp -R schema "${SITE_DIR}/schema"
+          fi
+
           : > "${METADATA_FILE}"
           shopt -s nullglob
 

--- a/.github/workflows/validate-reports.yml
+++ b/.github/workflows/validate-reports.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-reports.yml
+++ b/.github/workflows/validate-reports.yml
@@ -1,0 +1,30 @@
+---
+name: Validate Reports
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check JasperReports version comments
+        run: bash scripts/check_jasper_version.sh
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install jsonschema
+        run: pip install jsonschema
+
+      # Parameter-Manifeste (parameters.json) gibt es NUR in V2-JSON-Bundles
+      # (kein eingebettetes SQL). Der Check validiert gegen
+      # schema/report-parameters.schema.json und das jeweilige Haupt-JRXML.
+      - name: Check parameter manifests
+        run: python3 scripts/check_parameters_manifest.py

--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -19,6 +19,7 @@ unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL).
 | `subreports/standards.jrxml` | Verwendete Normale; `standards`-Array via `subDataSource("standards")` — inkl. nächster Kalibrierung + Zertifikat-Nr. |
 | `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` **v1.1**) |
 | `main_reports/dakks-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
+| `parameters.json` | **Parameter-Manifest**: beschreibt die konfigurierbaren Parameter des Hauptberichts (Label de/en, Beschreibung, Rolle, Eingabetyp, Default) für den calServer-Parameter-Katalog (siehe unten) |
 
 ## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
 
@@ -67,6 +68,28 @@ Report-Variablen (`master_report_variable`, z. B. `lab_name`, `mark_number_1`,
 enthält je Wert das Triple `<feld>`/`<feld>_p` (SI-Präfix)/`<feld>_u` (Einheit)
 plus `accred`. Jeder Entitätsblock trägt zusätzlich `custom_fields`. Feldreferenz
 siehe `sample-data.json`.
+
+## Parameter-Katalog (`parameters.json`)
+
+Dieses Bundle ist der **Pilotbericht für das Parameter-Manifest**: Die Datei
+`parameters.json` an der Bundle-Wurzel beschreibt die konfigurierbaren
+Parameter des Haupt-JRXML maschinenlesbar (Format:
+[`schema/report-parameters.schema.json`](../schema/report-parameters.schema.json)).
+calServer V2 liest sie direkt aus dem hochgeladenen ZIP und bietet die
+Parameter im Dialog „Berichtsvariable erstellen" mit Beschreibung, Typ und
+Standardwert zur Auswahl an — statt eines leeren Freitextfelds.
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `Sprache` | variable (global) | `Deutsch` = zweisprachige Beschriftung de/en, sonst rein englisch |
+| `Company_footer` | variable (type) | zusätzliche Fußzeile am unteren Seitenrand (leer = keine) |
+| `Show_next_calibration` | variable (report) | `false` blendet den Block „Nächste Kalibrierung" aus (Rekalibrier-Empfehlung nur auf Kundenwunsch, DIN EN ISO/IEC 17025) |
+| `Reportpath` | system | wird von calServer automatisch gesetzt (Subreport-Auflösung) |
+
+Die vorgeschlagenen Variablennamen sind `lcfirst` der Parameternamen
+(`Company_footer` → Berichtsvariable `company_footer`); die Auflösung zur
+Laufzeit läuft über `$P{ucfirst(variable_name)}`. Gilt **nur für
+V2-JSON-Bundles** — klassische JDBC-Bundles tragen kein Manifest.
 
 ## Autoren-Hinweise (Jaspersoft Studio)
 

--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
@@ -25,6 +25,14 @@
 		<parameterDescription><![CDATA[Sprachumschalter für zweisprachige Labels (Deutsch = zweisprachig de/en).]]></parameterDescription>
 		<defaultValueExpression><![CDATA["Deutsch"]]></defaultValueExpression>
 	</parameter>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Fußzeilentext am unteren Rand jeder Seite, z. B. Laborname und Akkreditierungshinweis. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Show_next_calibration" class="java.lang.String">
+		<parameterDescription><![CDATA["true"/"false": Block „Nächste Kalibrierung / Next calibration" auf dem Deckblatt anzeigen (Rekalibrier-Empfehlung nur auf Kundenwunsch, DAkkS).]]></parameterDescription>
+		<defaultValueExpression><![CDATA["true"]]></defaultValueExpression>
+	</parameter>
 	<field name="certificate_number" class="java.lang.String"><fieldDescription><![CDATA[meta.certificate_number]]></fieldDescription></field>
 	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
 	<field name="next_cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription></field>
@@ -110,8 +118,8 @@
 					<jr:codeExpression><![CDATA[$F{device_asset_number} == null ? "" : $F{device_asset_number}]]></jr:codeExpression>
 				</jr:QRCode>
 			</componentElement>
-			<staticText><reportElement style="Label" x="0" y="220" width="200" height="13"/><text><![CDATA[Nächste Kalibrierung / Next calibration]]></text></staticText>
-			<textField><reportElement style="Value" x="0" y="236" width="255" height="13"/><textFieldExpression><![CDATA[$F{next_cal_date}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="0" y="220" width="200" height="13"><printWhenExpression><![CDATA[!"false".equalsIgnoreCase($P{Show_next_calibration})]]></printWhenExpression></reportElement><text><![CDATA[Nächste Kalibrierung / Next calibration]]></text></staticText>
+			<textField><reportElement style="Value" x="0" y="236" width="255" height="13"><printWhenExpression><![CDATA[!"false".equalsIgnoreCase($P{Show_next_calibration})]]></printWhenExpression></reportElement><textFieldExpression><![CDATA[$F{next_cal_date}]]></textFieldExpression></textField>
 		</band>
 	</title>
 	<detail>
@@ -150,6 +158,7 @@
 		<band height="30">
 			<line><reportElement x="0" y="0" width="561" height="1"/></line>
 			<textField><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{lab_name} == null ? "" : $F{lab_name}) + (($F{certificate_number} == null) ? "" : (" · " + $F{certificate_number}))]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="0" y="16" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA[($V{isDe} ? "Seite " : "Page ") + $V{PAGE_NUMBER} + ($V{isDe} ? " von " : " of ")]]></textFieldExpression></textField>
 			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
 		</band>

--- a/DAKKS-JSON-SAMPLE/parameters.json
+++ b/DAKKS-JSON-SAMPLE/parameters.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Sprache",
+      "label": {
+        "de": "Sprache des Kalibrierscheins",
+        "en": "Certificate language"
+      },
+      "description": {
+        "de": "Steuert die Beschriftungen des Kalibrierscheins. „Deutsch“ rendert Titel, Seitenzählung und Abschnittsköpfe zweisprachig Deutsch/Englisch (DAkkS-üblich); jeder andere Wert schaltet auf rein englische Beschriftung um.",
+        "en": "Controls the certificate captions. \"Deutsch\" renders title, page numbering and section headers bilingually in German/English (customary for DAkkS certificates); any other value switches to English-only captions."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "select",
+      "options": [
+        { "value": "Deutsch", "label": { "de": "Deutsch (zweisprachig de/en)", "en": "German (bilingual de/en)" } },
+        { "value": "English", "label": { "de": "Englisch", "en": "English" } }
+      ],
+      "default": "Deutsch",
+      "required": false,
+      "group": "Allgemein",
+      "order": 10
+    },
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Freier Text am unteren Rand jeder Seite, unterhalb von Laborname und Kalibrierschein-Nummer — üblicherweise Firmenname mit Akkreditierungshinweis des Kalibrierlaboratoriums. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Free text at the bottom of every page, below the laboratory name and certificate number — typically the company name with the calibration laboratory's accreditation notice. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "order": 20,
+      "example": "Musterfirma GmbH · Kalibrierlaboratorium D-K-15208-01-00"
+    },
+    {
+      "name": "Show_next_calibration",
+      "label": {
+        "de": "Nächste Kalibrierung anzeigen",
+        "en": "Show next calibration date"
+      },
+      "description": {
+        "de": "Blendet den Block „Nächste Kalibrierung / Next calibration“ auf dem Deckblatt ein oder aus. Nach DIN EN ISO/IEC 17025 ist das Rekalibrierdatum eine Empfehlung, die nur auf Kundenwunsch auf dem Kalibrierschein erscheint — „false“ erzeugt den Schein ohne diese Empfehlung.",
+        "en": "Shows or hides the \"Nächste Kalibrierung / Next calibration\" block on the cover page. Under DIN EN ISO/IEC 17025 the recalibration date is a recommendation printed on the certificate only at the customer's request — \"false\" produces the certificate without it."
+      },
+      "role": "variable",
+      "scope": "report",
+      "input": "boolean",
+      "default": "true",
+      "required": false,
+      "group": "Inhalt",
+      "order": 30
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt und darf nicht als Berichtsvariable konfiguriert werden.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer and must not be configured as a report variable."
+      },
+      "role": "system"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -91,11 +91,16 @@ downloads/
 pages/
 └── index.html          # Projekt-Landing-Page für GitHub Pages
 
+schema/
+└── report-parameters.schema.json  # JSON-Schema für parameters.json (V2-JSON-Bundles)
+
 scripts/
-├── check_jasper_version.sh  # Prüft JRXML-Versionen auf 6.20.6
-├── dakks_upload_sample.bat  # Beispielskript für den automatisierten Report-Upload
-├── dcc_upload_sample.bat    # Upload-Beispiel für DCC-Reports
-└── dcc_xml_writer.py        # Hilfsskript zum Erzeugen von DCC-XML
+├── check_jasper_version.sh         # Prüft JRXML-Versionen auf 6.20.6
+├── check_parameters_manifest.py    # CI-Validator für parameters.json-Manifeste
+├── generate_parameters_manifest.py # Erzeugt ein parameters.json-Gerüst aus dem Haupt-JRXML
+├── dakks_upload_sample.bat         # Beispielskript für den automatisierten Report-Upload
+├── dcc_upload_sample.bat           # Upload-Beispiel für DCC-Reports
+└── dcc_xml_writer.py               # Hilfsskript zum Erzeugen von DCC-XML
 ````
 
 **Hinweis:** Die Beispiele sind bewusst generisch gehalten. Sie können direkt als Grundlage für eigene Anpassungen verwendet werden.
@@ -145,8 +150,40 @@ Nutze Versionierung für Reports, um bei Fehlern jederzeit auf eine frühere Var
 Im Ordner `scripts` findest du neben dem Batch-Skript `dakks_upload_sample.bat` weitere Hilfen:
 
 - `check_jasper_version.sh` prüft alle JRXML-Dateien auf die erwartete JasperReports-Version 6.20.6.
+- `check_parameters_manifest.py` validiert `parameters.json`-Manifeste gegen das Schema und das Haupt-JRXML (läuft auch als CI-Check, siehe unten).
+- `generate_parameters_manifest.py` erzeugt ein `parameters.json`-Gerüst aus den `<parameter>`-Deklarationen eines Haupt-JRXML.
 - `dcc_upload_sample.bat` zeigt einen Upload-Workflow für DCC-Reports.
 - `dcc_xml_writer.py` unterstützt bei der Erzeugung von DCC-XML.
+
+### Parameter beschreiben (`parameters.json`, nur V2-JSON-Bundles)
+
+V2-JSON-Bundles (Bundles **ohne eingebettetes SQL**, die der report-runner aus
+einem JSON-Datensatz füllt — erkennbar am Suffix `-JSON-SAMPLE`) können ihre
+konfigurierbaren Parameter in einem **Manifest `parameters.json`** an der
+Bundle-Wurzel beschreiben (gleiche Ebene wie die README). calServer V2 liest
+das Manifest direkt aus dem hochgeladenen ZIP und bietet die Parameter beim
+Anlegen von Berichtsvariablen mit Label, Beschreibung, Typ und Standardwert
+zur Auswahl an. Referenzbeispiel: [`DAKKS-JSON-SAMPLE/parameters.json`](DAKKS-JSON-SAMPLE/parameters.json).
+
+**Wichtig:** Klassische V1/JDBC-Bundles (mit eingebettetem SQL) bekommen
+**kein** Manifest — calServer ignoriert es dort, und der CI-Check bricht mit
+einem Fehler ab.
+
+Workflow für Berichtsentwickler:
+
+1. Parameter wie gewohnt im JRXML deklarieren. Namen konfigurierbarer
+   Parameter **mit Großbuchstaben beginnen** (`Company_footer`, nicht
+   `company_footer`) — calServer injiziert Berichtsvariablen als
+   `$P{ucfirst(variable_name)}`, kleingeschriebene Parameternamen sind von
+   Variablen nicht erreichbar.
+2. Gerüst erzeugen: `python3 scripts/generate_parameters_manifest.py MEIN-BUNDLE -o MEIN-BUNDLE/parameters.json`
+3. Labels und Beschreibungen (deutsch **und** englisch), Rollen
+   (`variable`/`prompt`/`system`), Scope-Empfehlungen und Eingabetypen
+   ergänzen — Format siehe [`schema/report-parameters.schema.json`](schema/report-parameters.schema.json).
+4. Lokal prüfen: `python3 scripts/check_parameters_manifest.py MEIN-BUNDLE`
+   — derselbe Check läuft in jedem Pull Request (Workflow „Validate Reports“).
+
+Der Paket-Build nimmt das Manifest automatisch in das Bundle-ZIP auf.
 
 ### Vorbereitung:
 

--- a/schema/report-parameters.schema.json
+++ b/schema/report-parameters.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "title": "calServer Report-Parameter-Manifest",
+  "description": "Maschinenlesbarer Parameter-Katalog eines V2-JSON-Report-Bundles (parameters.json an der Bundle-Wurzel). Gilt NUR fuer Bundles ohne eingebettetes SQL, die der report-runner aus einem JSON-Datensatz fuellt (ADR-009); klassische V1/JDBC-Bundles tragen kein Manifest.",
+  "type": "object",
+  "required": ["version", "parameters"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "version": {
+      "description": "Format-Kennung des Manifests. Erweiterungen bleiben abwaertskompatibel innerhalb derselben Version.",
+      "const": 1
+    },
+    "parameters": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/parameter" }
+    }
+  },
+  "definitions": {
+    "localizedText": {
+      "description": "Anzeigetext: einfacher String oder Objekt je Sprache (de, en, ...). Aufloesung im Backend: Anfragesprache, dann de, dann en, dann erste vorhandene.",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": { "pattern": "^[a-z]{2}(-[A-Z]{2})?$" },
+          "additionalProperties": { "type": "string" }
+        }
+      ]
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["name", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Exakter JRXML-Parametername ($P{...}); muss im Haupt-JRXML deklariert sein. Fuer role=variable mit Grossbuchstaben beginnen (ucfirst-Injektion durch calServer).",
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "label": { "$ref": "#/definitions/localizedText" },
+        "description": { "$ref": "#/definitions/localizedText" },
+        "role": {
+          "description": "variable = Admin-Konfiguration (Berichtsvariable), prompt = Nutzerabfrage beim Generieren, system = wird automatisch versorgt und nie angeboten.",
+          "type": "string",
+          "enum": ["variable", "prompt", "system"],
+          "default": "variable"
+        },
+        "scope": {
+          "description": "Empfohlener Geltungsbereich der Berichtsvariable (nur Vorauswahl im Dialog).",
+          "type": "string",
+          "enum": ["report", "type", "global"],
+          "default": "report"
+        },
+        "input": {
+          "description": "UI-Eingabetyp im Variablen-Dialog.",
+          "type": "string",
+          "enum": ["text", "textarea", "select", "boolean", "number", "date", "color", "image"],
+          "default": "text"
+        },
+        "options": {
+          "description": "Erlaubte Werte, nur bei input=select.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "required": ["value"],
+                "additionalProperties": false,
+                "properties": {
+                  "value": { "type": "string" },
+                  "label": { "$ref": "#/definitions/localizedText" }
+                }
+              }
+            ]
+          }
+        },
+        "default": {
+          "description": "Standardwert als String (befuellt das content-Feld der Berichtsvariable vor).",
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "group": {
+          "description": "Gruppierung in Auswahllisten (z. B. \"Layout\", \"Labor-Identitaet\").",
+          "type": "string"
+        },
+        "order": {
+          "description": "Sortierung innerhalb der Gruppe (aufsteigend).",
+          "type": "integer"
+        },
+        "example": {
+          "description": "Beispielwert als Platzhaltertext im Eingabefeld.",
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "input": { "const": "select" } }, "required": ["input"] },
+          "then": { "required": ["options"] },
+          "else": { "not": { "required": ["options"] } }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/check_parameters_manifest.py
+++ b/scripts/check_parameters_manifest.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""CI-Validator für parameters.json-Manifeste (analog check_jasper_version.sh).
+
+Prüft jedes im Repository gefundene Parameter-Manifest (Bundle-Wurzel oder
+main_reports/) gegen das JSON-Schema und das zugehörige Haupt-JRXML:
+
+Fehler (Exit 1):
+  - Manifest nicht parsebar oder verletzt schema/report-parameters.schema.json
+  - Manifest-Parameter, der im Haupt-JRXML nicht deklariert ist
+  - Manifest in einem Bundle MIT eingebettetem SQL (<queryString>) —
+    Manifeste sind nur für V2-JSON-Bundles vorgesehen
+  - options bei einem input ≠ select bzw. input=select ohne options
+  - doppelte Parameternamen
+
+Warnung (kein Exit-Fehler):
+  - role=variable mit kleingeschriebenem Anfangsbuchstaben (von der
+    calServer-Variablenauflösung per ucfirst nicht erreichbar)
+
+Aufruf: python3 scripts/check_parameters_manifest.py [BUNDLE_DIR ...]
+Ohne Argumente wird das gesamte Repository durchsucht.
+Nutzt das Paket `jsonschema`, falls installiert (CI); ohne läuft eine
+strukturelle Minimalprüfung.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "schema" / "report-parameters.schema.json"
+
+VALID_ROLES = {"variable", "prompt", "system"}
+VALID_SCOPES = {"report", "type", "global"}
+VALID_INPUTS = {"text", "textarea", "select", "boolean", "number", "date", "color", "image"}
+
+errors: list[str] = []
+warnings: list[str] = []
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def find_manifests(targets: list[Path]) -> list[Path]:
+    manifests: list[Path] = []
+    for target in targets:
+        for path in sorted(target.rglob("parameters.json")):
+            if any(part in {".git", "schema", "downloads", "pages", "staging", "zip_output"} for part in path.parts):
+                continue
+            manifests.append(path)
+    return manifests
+
+
+def bundle_dir_of(manifest: Path) -> Path:
+    # Manifest liegt an der Bundle-Wurzel (neben main_reports/) oder in main_reports/.
+    return manifest.parent.parent if manifest.parent.name == "main_reports" else manifest.parent
+
+
+def main_jrxml_of(bundle: Path) -> Path | None:
+    candidates = sorted((bundle / "main_reports").glob("*.jrxml"))
+    return candidates[0] if candidates else None
+
+
+def jrxml_facts(jrxml: Path) -> tuple[set[str], bool]:
+    root = ET.parse(jrxml).getroot()
+    declared = {
+        element.get("name", "")
+        for element in root
+        if local_name(element.tag) == "parameter" and element.get("name")
+    }
+    has_query = any(
+        (element.text or "").strip()
+        for element in root.iter()
+        if local_name(element.tag) == "queryString"
+    )
+    return declared, has_query
+
+
+def validate_against_schema(manifest_path: Path, manifest: object) -> None:
+    try:
+        import jsonschema
+    except ImportError:
+        structural_fallback(manifest_path, manifest)
+        return
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft7Validator(schema)
+    for violation in sorted(validator.iter_errors(manifest), key=lambda v: list(v.absolute_path)):
+        location = "/".join(str(part) for part in violation.absolute_path) or "<Wurzel>"
+        errors.append(f"{manifest_path}: Schema-Verstoß bei {location}: {violation.message}")
+
+
+def structural_fallback(manifest_path: Path, manifest: object) -> None:
+    if not isinstance(manifest, dict) or manifest.get("version") != 1 or not isinstance(manifest.get("parameters"), list):
+        errors.append(f"{manifest_path}: erwartet Objekt mit version=1 und parameters-Liste")
+        return
+    for index, entry in enumerate(manifest["parameters"]):
+        if not isinstance(entry, dict) or not entry.get("name") or "label" not in entry:
+            errors.append(f"{manifest_path}: parameters/{index}: name und label sind Pflicht")
+            continue
+        for field, allowed in (("role", VALID_ROLES), ("scope", VALID_SCOPES), ("input", VALID_INPUTS)):
+            if field in entry and entry[field] not in allowed:
+                errors.append(f"{manifest_path}: parameters/{index}: ungültiges {field} „{entry[field]}“")
+
+
+def check_manifest(manifest_path: Path) -> None:
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as parse_error:
+        errors.append(f"{manifest_path}: nicht parsebar: {parse_error}")
+        return
+
+    validate_against_schema(manifest_path, manifest)
+
+    bundle = bundle_dir_of(manifest_path)
+    jrxml = main_jrxml_of(bundle)
+    if jrxml is None:
+        errors.append(f"{manifest_path}: kein Haupt-JRXML unter {bundle}/main_reports/ gefunden")
+        return
+
+    declared, has_query = jrxml_facts(jrxml)
+
+    if has_query:
+        errors.append(
+            f"{manifest_path}: Bundle {bundle.name} enthält eingebettetes SQL — "
+            "parameters.json ist nur für V2-JSON-Bundles erlaubt (calServer ignoriert es sonst)."
+        )
+
+    entries = manifest.get("parameters", []) if isinstance(manifest, dict) else []
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if name in seen:
+            errors.append(f"{manifest_path}: Parameter „{name}“ ist doppelt deklariert")
+        seen.add(name)
+
+        if name not in declared:
+            errors.append(
+                f"{manifest_path}: Parameter „{name}“ ist im Haupt-JRXML ({jrxml.name}) nicht deklariert"
+            )
+
+        role = entry.get("role", "variable")
+        if role == "variable" and name[0].islower():
+            warnings.append(
+                f"{manifest_path}: Parameter „{name}“ (role=variable) beginnt kleingeschrieben — "
+                "von der calServer-Variablenauflösung (ucfirst) nicht erreichbar."
+            )
+
+        input_type = entry.get("input", "text")
+        if "options" in entry and input_type != "select":
+            errors.append(f"{manifest_path}: Parameter „{name}“: options sind nur bei input=select erlaubt")
+        if input_type == "select" and "options" not in entry:
+            errors.append(f"{manifest_path}: Parameter „{name}“: input=select verlangt options")
+
+
+def main() -> None:
+    targets = [Path(argument) for argument in sys.argv[1:]] or [REPO_ROOT]
+    manifests = find_manifests(targets)
+
+    for manifest_path in manifests:
+        check_manifest(manifest_path)
+
+    for message in warnings:
+        print(f"⚠️  {message}")
+    for message in errors:
+        print(f"❌ {message}", file=sys.stderr)
+
+    if errors:
+        sys.exit(1)
+    print(f"✅ {len(manifests)} Parameter-Manifest(e) geprüft, keine Fehler")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_parameters_manifest.py
+++ b/scripts/generate_parameters_manifest.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Erzeugt ein parameters.json-Manifest-Gerüst aus dem Haupt-JRXML eines Bundles.
+
+Nur für V2-JSON-Bundles (kein eingebettetes SQL, ADR-009): das Manifest
+beschreibt die konfigurierbaren Parameter des Haupt-JRXML für den
+calServer-Parameter-Katalog. Der Berichtsentwickler ergänzt anschließend
+Labels (de/en), Beschreibungen, Rollen und Scope-Empfehlungen — das Skript
+liefert nur das Gerüst:
+
+  Name          aus dem name-Attribut der <parameter>-Deklaration
+  Typ (input)   aus dem class-Attribut (Date → date, Integer → number, ...)
+  Default       aus literalem <defaultValueExpression> ("...", Zahl)
+  Beschreibung  aus <parameterDescription>
+  role/scope/…  aus optionalen calserver.*-Properties, sonst Heuristik
+
+Aufruf:
+  python3 scripts/generate_parameters_manifest.py DAKKS-JSON-SAMPLE
+  python3 scripts/generate_parameters_manifest.py pfad/zu/main.jrxml -o parameters.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+SCHEMA_URL = "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json"
+
+# Implizite JasperReports-Standardparameter — nie ins Manifest aufnehmen.
+BUILTIN_PARAMETERS = {
+    "REPORT_LOCALE", "REPORT_CONNECTION", "REPORT_MAX_COUNT", "REPORT_DATA_SOURCE",
+    "REPORT_VIRTUALIZER", "REPORT_TIME_ZONE", "REPORT_FORMAT_FACTORY",
+    "REPORT_RESOURCE_BUNDLE", "REPORT_CLASS_LOADER", "REPORT_URL_HANDLER_FACTORY",
+    "REPORT_FILE_RESOLVER", "REPORT_SCRIPTLET", "REPORT_PARAMETERS_MAP",
+    "REPORT_CONTEXT", "IS_IGNORE_PAGINATION", "FILTER", "JASPER_REPORT", "SORT_FIELDS",
+}
+
+# Von calServer automatisch versorgte Parameter — immer role=system.
+SYSTEM_PARAMETERS = {"Reportpath", "PrefixTable", "data_contract"}
+
+# Java-Klasse (letztes Segment) → Manifest-input.
+CLASS_TO_INPUT = {
+    "Date": "date", "Timestamp": "date", "LocalDate": "date", "LocalDateTime": "date",
+    "Integer": "number", "Long": "number", "Short": "number", "Double": "number",
+    "Float": "number", "BigDecimal": "number", "BigInteger": "number", "Number": "number",
+    "Boolean": "boolean",
+}
+
+VALID_ROLES = {"variable", "prompt", "system"}
+VALID_SCOPES = {"report", "type", "global"}
+VALID_INPUTS = {"text", "textarea", "select", "boolean", "number", "date", "color", "image"}
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def find_main_jrxml(target: Path) -> Path:
+    if target.is_file():
+        return target
+    candidates = sorted((target / "main_reports").glob("*.jrxml"))
+    if not candidates:
+        sys.exit(f"FEHLER: kein Haupt-JRXML unter {target}/main_reports/ gefunden")
+    if len(candidates) > 1:
+        print(
+            f"WARNUNG: mehrere JRXML unter {target}/main_reports/, verwende {candidates[0].name}",
+            file=sys.stderr,
+        )
+    return candidates[0]
+
+
+def has_embedded_query(root: ET.Element) -> bool:
+    for element in root.iter():
+        if local_name(element.tag) == "queryString":
+            return bool((element.text or "").strip())
+    return False
+
+
+def literal_default(expression: str) -> str | None:
+    expression = expression.strip()
+    match = re.search(r'"([^"]*)"', expression)
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"-?\d+(\.\d+)?", expression):
+        return expression
+    return None
+
+
+def build_entry(parameter: ET.Element) -> dict | None:
+    name = parameter.get("name", "")
+    if not name or name in BUILTIN_PARAMETERS:
+        return None
+
+    properties: dict[str, str] = {}
+    description = ""
+    default: str | None = None
+
+    for child in parameter:
+        tag = local_name(child.tag)
+        if tag == "property" and (child.get("name") or "").startswith("calserver."):
+            properties[(child.get("name") or "")[len("calserver."):]] = child.get("value") or ""
+        elif tag == "parameterDescription":
+            description = (child.text or "").strip()
+        elif tag == "defaultValueExpression":
+            default = literal_default(child.text or "")
+
+    java_class = parameter.get("class", "java.lang.String").rsplit(".", 1)[-1]
+
+    if properties.get("role") in VALID_ROLES:
+        role = properties["role"]
+    elif name in SYSTEM_PARAMETERS:
+        role = "system"
+    elif parameter.get("isForPrompting") == "true":
+        role = "prompt"
+    else:
+        role = "variable"
+
+    entry: dict = {
+        "name": name,
+        # Gerüst: Label = Parametername; der Autor ersetzt ihn durch de/en-Texte.
+        "label": properties.get("label") or {"de": name.replace("_", " "), "en": name.replace("_", " ")},
+    }
+    if description:
+        entry["description"] = {"de": description}
+    entry["role"] = role
+    if role == "variable":
+        entry["scope"] = properties.get("scope") if properties.get("scope") in VALID_SCOPES else "report"
+        entry["input"] = (
+            properties.get("input")
+            if properties.get("input") in VALID_INPUTS
+            else CLASS_TO_INPUT.get(java_class, "text")
+        )
+        if default is not None:
+            entry["default"] = default
+        entry["required"] = False
+    return entry
+
+
+def main() -> None:
+    argument_parser = argparse.ArgumentParser(description=__doc__)
+    argument_parser.add_argument("target", help="Bundle-Verzeichnis oder Pfad zu einem Haupt-JRXML")
+    argument_parser.add_argument("-o", "--output", help="Zieldatei (Default: stdout)")
+    argument_parser.add_argument("--force", action="store_true", help="vorhandene Zieldatei überschreiben")
+    arguments = argument_parser.parse_args()
+
+    jrxml_path = find_main_jrxml(Path(arguments.target))
+    root = ET.parse(jrxml_path).getroot()
+
+    if has_embedded_query(root):
+        sys.exit(
+            f"FEHLER: {jrxml_path} enthält eingebettetes SQL (<queryString>) — "
+            "parameters.json ist nur für V2-JSON-Bundles vorgesehen."
+        )
+
+    entries = []
+    for parameter in root:
+        if local_name(parameter.tag) != "parameter":
+            continue
+        entry = build_entry(parameter)
+        if entry is not None:
+            entries.append(entry)
+            if entry["role"] == "variable" and entry["name"][0].islower():
+                print(
+                    f"WARNUNG: Parameter „{entry['name']}“ (role=variable) beginnt kleingeschrieben — "
+                    "von der calServer-Variablenauflösung (ucfirst) nicht erreichbar.",
+                    file=sys.stderr,
+                )
+
+    manifest = {"$schema": SCHEMA_URL, "version": 1, "parameters": entries}
+    rendered = json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"
+
+    if arguments.output:
+        output_path = Path(arguments.output)
+        if output_path.exists() and not arguments.force:
+            sys.exit(f"FEHLER: {output_path} existiert bereits (mit --force überschreiben)")
+        output_path.write_text(rendered, encoding="utf-8")
+        print(f"{output_path} geschrieben ({len(entries)} Parameter)", file=sys.stderr)
+    else:
+        sys.stdout.write(rendered)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Zusammenfassung

Setzt **Teil A** des Konzepts „Parameter-Katalog im Report-Paket" um ([calServer-yii `docs/konzept-report-parameter-katalog.md`](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-report-parameter-katalog.md), PR calhelp/calServer-yii#2875) — **eingeschränkt auf V2-JSON-Bundles** (kein eingebettetes SQL, ADR-009). Klassische V1/JDBC-Bundles bleiben vollständig unangetastet; ein Manifest in einem SQL-Bundle ist ab jetzt ein CI-Fehler.

## Änderungen

### JSON-Schema
- `schema/report-parameters.schema.json` (Draft-07, `version: 1`): `parameters[]` mit `name`, `label`/`description` (String oder Sprachobjekt `de`/`en`), `role` (`variable`|`prompt`|`system`), `scope` (`report`|`type`|`global`), `input` (`text`|`textarea`|`select`|`boolean`|`number`|`date`|`color`|`image`), `options` (nur bei `select`, per Schema erzwungen), `default`, `required`, `group`, `order`, `example`.
- Das Schema wird über den Pages-Workflow mit veröffentlicht, damit die `$schema`-URL (`https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json`) auflösbar ist.

### Pilotbericht DAKKS-JSON-SAMPLE
- `parameters.json` als Referenz-Manifest mit deutschen **und** englischen Labels/Beschreibungen im Kalibrierschein-/DAkkS-Kontext: `Sprache` (select, global), `Company_footer` (textarea, type), `Show_next_calibration` (boolean, report — Rekalibrier-Empfehlung nur auf Kundenwunsch, DIN EN ISO/IEC 17025), `Reportpath` (system).
- Haupt-JRXML um die beiden neuen, tatsächlich genutzten Parameter ergänzt: `Company_footer` (zusätzliche Fußzeilen-Zeile, leer = unsichtbar) und `Show_next_calibration` (`printWhenExpression` am Block „Nächste Kalibrierung"). Defaults erhalten die bislang verifizierte Ausgabe unverändert.

### Authoring-Kette
- `scripts/generate_parameters_manifest.py`: erzeugt ein Manifest-Gerüst aus dem Haupt-JRXML (Name, Typ aus `class`, Default aus literalem `defaultValueExpression`, Beschreibung aus `parameterDescription`, `calserver.*`-Properties, Rollen-Heuristik). Bricht bei SQL-Bundles ab.
- `scripts/check_parameters_manifest.py` + neuer Workflow `validate-reports.yml` (läuft bei Push/PR, zusammen mit `check_jasper_version.sh`):
  - **Fehler:** Manifest verletzt Schema · Manifest-Parameter nicht im Haupt-JRXML deklariert · Manifest in Bundle **mit** eingebettetem SQL · `options` ohne `input=select` bzw. `select` ohne `options` · doppelte Namen
  - **Warnung:** `role=variable` mit kleingeschriebenem Anfangsbuchstaben (`ucfirst`-Falle)

### Packaging & Doku
- `package-reports.yml`: `parameters.json` an der Bundle-Wurzel wandert mit ins Artifact und ins Bundle-ZIP (nur dort, wo eins existiert).
- Autoren-Doku im Root-README („Parameter beschreiben — nur V2-JSON-Bundles") und im Bundle-README des Piloten.

## Tests
- `python3 scripts/check_parameters_manifest.py` → grün (inkl. `jsonschema`-Pfad und struktureller Fallback ohne Abhängigkeit)
- Negativfälle manuell verifiziert: fehlender JRXML-Parameter, `options` bei `input=text`, `select` ohne `options`, Manifest im SQL-Bundle, kleingeschriebener Variablenname (Warnung)
- `bash scripts/check_jasper_version.sh` → grün; alle Workflow-YAMLs geparst

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129fgDxrMzrxFnStyWDgHXp

---
_Generated by [Claude Code](https://claude.ai/code/session_0129fgDxrMzrxFnStyWDgHXp)_