### PR TITLE
feat(parameters): Parameter-Katalog für 5 weitere V2-JSON-Bundles (Company_footer)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -182,6 +182,7 @@ jobs:
           path: |
             KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports
             KALIBRIERKONTROLLBLATT-JSON-SAMPLE/subreports
+            KALIBRIERKONTROLLBLATT-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
       - name: Upload STICKER-DAKKS-12MM-JSON-SAMPLE as artifact
@@ -212,6 +213,7 @@ jobs:
           path: |
             ORDER-JSON-SAMPLE/main_reports
             ORDER-JSON-SAMPLE/subreports
+            ORDER-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
       - name: Upload DELIVERY-JSON-SAMPLE as artifact
@@ -221,20 +223,25 @@ jobs:
           path: |
             DELIVERY-JSON-SAMPLE/main_reports
             DELIVERY-JSON-SAMPLE/subreports
+            DELIVERY-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
       - name: Upload REPAIR-JSON-SAMPLE as artifact
         uses: actions/upload-artifact@v4
         with:
           name: REPAIR-JSON-SAMPLE
-          path: REPAIR-JSON-SAMPLE/main_reports
+          path: |
+            REPAIR-JSON-SAMPLE/main_reports
+            REPAIR-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
       - name: Upload LOCATION-JSON-SAMPLE as artifact
         uses: actions/upload-artifact@v4
         with:
           name: LOCATION-JSON-SAMPLE
-          path: LOCATION-JSON-SAMPLE/main_reports
+          path: |
+            LOCATION-JSON-SAMPLE/main_reports
+            LOCATION-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
       - name: List files before zipping (Debug)

--- a/DELIVERY-JSON-SAMPLE/README.md
+++ b/DELIVERY-JSON-SAMPLE/README.md
@@ -28,3 +28,18 @@ Vorschau: mitgelieferter Adapter (Default über `com.jaspersoft.studio.data.defa
 → „Open → Preview". Live (calServer V2): Report-Setting-Variable
 `data_contract = order-document`; Datensatz auch via
 `GET /api/v2/bookings/{id}/report-dataset`. JasperReports **6.20.6** verbindlich.
+
+## Parameter-Katalog (`parameters.json`)
+
+Dieses Bundle liefert ein **Parameter-Manifest** (`parameters.json` an der
+Bundle-Wurzel), damit calServer V2 die konfigurierbaren Parameter beim Anlegen
+von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
+[Konzept](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-report-parameter-katalog.md)).
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Lieferschein). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+
+Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
+und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)
+bleibt wie gehabt maßgeblich.

--- a/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
+++ b/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
@@ -16,6 +16,10 @@
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<field name="doc_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
 	<field name="doc_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
 	<field name="doc_status" class="java.lang.String"><fieldDescription><![CDATA[document.status]]></fieldDescription></field>
@@ -58,10 +62,11 @@
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="46">
+		<band height="58">
 			<staticText><reportElement positionType="Float" x="0" y="16" width="561" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Ware vollständig und unbeschädigt erhalten:]]></text></staticText>
 			<line><reportElement positionType="Float" x="0" y="30" width="240" height="1"/></line>
 			<staticText><reportElement positionType="Float" x="0" y="32" width="240" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement positionType="Float" x="0" y="46" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/DELIVERY-JSON-SAMPLE/parameters.json
+++ b/DELIVERY-JSON-SAMPLE/parameters.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite des Lieferscheins, unterhalb des Empfangs-/Unterschriftsblocks — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page of the delivery note, below the receipt/signature block — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer."
+      },
+      "role": "system"
+    }
+  ]
+}

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md
@@ -42,3 +42,18 @@ Template-Fehler, sondern fehlende Datenanbindung. Abhilfe:
 - Labels als `staticText` halten — `$V{}`-Variablen in `title`/`columnHeader` ohne
   `initialValueExpression` würden vor dem ersten Record `null` drucken.
 - Subreport-Teilmengen über `subDataSource("<array>")`.
+
+## Parameter-Katalog (`parameters.json`)
+
+Dieses Bundle liefert ein **Parameter-Manifest** (`parameters.json` an der
+Bundle-Wurzel), damit calServer V2 die konfigurierbaren Parameter beim Anlegen
+von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
+[Konzept](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-report-parameter-katalog.md)).
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Kalibrierkontrollblatt). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+
+Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
+und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)
+bleibt wie gehabt maßgeblich.

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/kalibrierkontrollblatt-json-sample.jrxml
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/main_reports/kalibrierkontrollblatt-json-sample.jrxml
@@ -21,6 +21,10 @@
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Akkreditierungshinweis. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
 	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[device.serial_number]]></fieldDescription></field>
 	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
@@ -93,11 +97,12 @@
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="24">
+		<band height="36">
 			<line><reportElement x="0" y="0" width="561" height="1"/></line>
 			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Kalibrierkontrollblatt · calServer V2]]></text></staticText>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
 			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="0" y="18" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/parameters.json
+++ b/KALIBRIERKONTROLLBLATT-JSON-SAMPLE/parameters.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite, unterhalb von Berichtsname und Seitenzählung — üblicherweise Firmenname mit Akkreditierungshinweis. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page, below the report name and page count — typically the company name with an accreditation notice. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "example": "Musterfirma GmbH · Kalibrierlaboratorium D-K-15208-01-00"
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer."
+      },
+      "role": "system"
+    }
+  ]
+}

--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -71,3 +71,18 @@ Aktivierung in calServer: dem Report-Setting (grid_name `location`, Ordner
 
 > **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
 > verbindlich (siehe `robots.md`).
+
+## Parameter-Katalog (`parameters.json`)
+
+Dieses Bundle liefert ein **Parameter-Manifest** (`parameters.json` an der
+Bundle-Wurzel), damit calServer V2 die konfigurierbaren Parameter beim Anlegen
+von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
+[Konzept](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-report-parameter-katalog.md)).
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Standort-/Leihbericht). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+
+Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
+und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)
+bleibt wie gehabt maßgeblich.

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
@@ -17,6 +17,10 @@
 	<style name="Value" fontSize="9"/>
 	<style name="SectionTitle" fontSize="10" isBold="true"/>
 	<style name="Small" fontSize="8"/>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<field name="location_1" class="java.lang.String"><fieldDescription><![CDATA[location.location_1]]></fieldDescription></field>
 	<field name="location_2" class="java.lang.String"><fieldDescription><![CDATA[location.location_2]]></fieldDescription></field>
 	<field name="location_3" class="java.lang.String"><fieldDescription><![CDATA[location.location_3]]></fieldDescription></field>
@@ -137,11 +141,12 @@
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="24">
+		<band height="36">
 			<line><reportElement x="0" y="0" width="561" height="1"/></line>
 			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Standort- / Leihbericht · calServer V2]]></text></staticText>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
 			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="0" y="18" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/LOCATION-JSON-SAMPLE/parameters.json
+++ b/LOCATION-JSON-SAMPLE/parameters.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite des Standort-/Leihberichts, unterhalb von Berichtsname und Seitenzählung — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page of the location/loan report, below the report name and page count — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
+    }
+  ]
+}

--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -43,3 +43,18 @@ Seite leer bzw. bricht auf `subDataSource(...)` ab. Abhilfe:
   Datensatz auch via `GET /api/v2/bookings/{id}/report-dataset`.
 
 JasperReports **6.20.6** verbindlich.
+
+## Parameter-Katalog (`parameters.json`)
+
+Dieses Bundle liefert ein **Parameter-Manifest** (`parameters.json` an der
+Bundle-Wurzel), damit calServer V2 die konfigurierbaren Parameter beim Anlegen
+von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
+[Konzept](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-report-parameter-katalog.md)).
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Auftragsbeleg). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+
+Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
+und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)
+bleibt wie gehabt maßgeblich.

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
@@ -19,6 +19,10 @@
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<field name="doc_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
 	<field name="doc_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
 	<field name="doc_status" class="java.lang.String"><fieldDescription><![CDATA[document.status]]></fieldDescription></field>
@@ -93,11 +97,12 @@
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="24">
+		<band height="36">
 			<line><reportElement x="0" y="0" width="561" height="1"/></line>
 			<textField><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{doc_status} == null ? "" : $F{doc_status}) + (($F{doc_number} == null) ? "" : (" · " + $F{doc_number}))]]></textFieldExpression></textField>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
 			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="0" y="18" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/parameters.json
+++ b/ORDER-JSON-SAMPLE/parameters.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite des Auftragsbelegs, unterhalb von Belegstatus/-nummer und Seitenzählung — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page of the order document, below the document status/number and page count — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer."
+      },
+      "role": "system"
+    }
+  ]
+}

--- a/REPAIR-JSON-SAMPLE/README.md
+++ b/REPAIR-JSON-SAMPLE/README.md
@@ -66,3 +66,18 @@ Aktivierung in calServer: dem Report-Setting (grid_name `repair`, Ordner
 
 > **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
 > verbindlich (siehe `robots.md`).
+
+## Parameter-Katalog (`parameters.json`)
+
+Dieses Bundle liefert ein **Parameter-Manifest** (`parameters.json` an der
+Bundle-Wurzel), damit calServer V2 die konfigurierbaren Parameter beim Anlegen
+von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
+[Konzept](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-report-parameter-katalog.md)).
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Reparaturbericht). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+
+Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
+und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)
+bleibt wie gehabt maßgeblich.

--- a/REPAIR-JSON-SAMPLE/main_reports/repair-json-sample.jrxml
+++ b/REPAIR-JSON-SAMPLE/main_reports/repair-json-sample.jrxml
@@ -13,6 +13,10 @@
 	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Value" fontSize="9"/>
 	<style name="SectionTitle" fontSize="10" isBold="true"/>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[repair.description]]></fieldDescription></field>
 	<field name="notes" class="java.lang.String"><fieldDescription><![CDATA[repair.notes]]></fieldDescription></field>
 	<field name="repair_date" class="java.lang.String"><fieldDescription><![CDATA[repair.repair_date]]></fieldDescription></field>
@@ -71,11 +75,12 @@
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="24">
+		<band height="36">
 			<line><reportElement x="0" y="0" width="561" height="1"/></line>
 			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Reparaturbericht · calServer V2]]></text></staticText>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
 			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="0" y="18" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/REPAIR-JSON-SAMPLE/parameters.json
+++ b/REPAIR-JSON-SAMPLE/parameters.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite des Reparaturberichts, unterhalb von Berichtsname und Seitenzählung — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page of the repair report, below the report name and page count — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
+    }
+  ]
+}


### PR DESCRIPTION
## Zusammenfassung

Folge-Arbeit zu **#491** (gemergt), das nur den Piloten `DAKKS-JSON-SAMPLE` mit einem Parameter-Manifest bestückt hatte. Damit der in calServer V2 gebaute Parameter-Katalog auch für weitere Berichte „aufleuchtet", bekommen die **Dokument-Bundles** jetzt einen konfigurierbaren Parameter samt Manifest.

Betroffene Bundles: `KALIBRIERKONTROLLBLATT-`, `ORDER-`, `DELIVERY-`, `REPAIR-`, `LOCATION-JSON-SAMPLE`.

## Was neu ist

- **`Company_footer`** (role=`variable`, scope=`type`, input=`textarea`): optionale Fußzeile am unteren Rand jeder Seite. Ins `pageFooter`-Band verdrahtet mit `isBlankWhenNull` und leerem Default — **solange die Berichtsvariable `company_footer` nicht gesetzt ist, ändert sich am aktuellen Output nichts**; erst ein gesetzter Wert druckt die Zeile. Exakt das Muster aus #491 (DAKKS).
  - `REPAIR`/`LOCATION` deklarierten bisher gar keine Parameter — hier neu angelegt (nach den `<style>`-Deklarationen, vor dem ersten `<field>`).
- **`parameters.json`** je Bundle mit deutschem **und** englischem Label + fachlicher Beschreibung, gegen `schema/report-parameters.schema.json` und das jeweilige Haupt-JRXML validiert.
- **`package-reports.yml`**: `parameters.json` in die 5 Roh-Artifact-Schritte aufgenommen (die ZIP-Aufnahme lief bereits generisch über `create_zip`).
- **READMEs** je Bundle um einen kurzen „Parameter-Katalog"-Abschnitt ergänzt.

## Bewusst ausgelassen

- **`INVENTORY-JSON-SAMPLE`** — hat keine `pageFooter`-Band; eine Fußzeile hätte ein neues Band erfordert (größerer Layout-Eingriff).
- **Sticker-Bundles** (`STICKER-*-JSON-SAMPLE`) — Etiketten haben keine sinnvolle Fußzeile/konfigurierbare Fläche.

## Validierung

- `scripts/check_jasper_version.sh` → grün (JasperReports 6.20.6)
- `scripts/check_parameters_manifest.py` → grün (**6 Manifeste**, Schema + JRXML-Abgleich)
- alle geänderten JRXML wohlgeformt; Workflow-YAML geparst

> **Hinweis:** Der Fußzeilentext ist `isBlankWhenNull` und standardmäßig leer, d. h. der aktuelle Layout-Output bleibt unverändert. Die abschließende pixelgenaue Abnahme des Layouts über den report-runner bleibt wie in den Bundle-READMEs beschrieben maßgeblich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129fgDxrMzrxFnStyWDgHXp

---
_Generated by [Claude Code](https://claude.ai/code/session_0129fgDxrMzrxFnStyWDgHXp)_