### PR TITLE
fix(dakks): Konformitätslegende ausrichten und Seitenzahl „Seite x von y" verbinden

### DIFF
--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
@@ -90,9 +90,7 @@
 	</parameter>
 	<parameter name="Conformity_description_2" class="java.lang.String">
 		<parameterDescription><![CDATA[Kurzlegende für Symbolik (? / !? / ! / *).]]></parameterDescription>
-		<defaultValueExpression><![CDATA[$P{Sprache}.equals("Deutsch")
-? "? innerhalb der Spezifikation<br/>!? außerhalb der Spezifikation (keine Aussage möglich)<br/>! außerhalb der Spezifikation<br/>* nicht im Akkreditierungsumfang"
-: "? within the specification<br/>!? out of specification (no statement possible)<br/>! out of specification<br/>* not covered by the accreditation scope"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["?\n\n\n!?\n\n\n!\n\n*"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Conformity_description_3" class="java.lang.String">
 		<parameterDescription><![CDATA[Detailbeschreibungen zu den Symbolen für Konformität und Akkreditierungsumfang.]]></parameterDescription>
@@ -1672,7 +1670,7 @@
 				<reportElement x="16" y="8" width="70" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000001">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left"/>
+				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
@@ -1680,7 +1678,7 @@
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="8" width="100" height="17" uuid="a1b2c3d4-0002-4a01-8e01-000000000003">
@@ -1732,7 +1730,7 @@
 				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
 					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left">
+				<textElement textAlignment="Right">
 					<font size="8" isItalic="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
@@ -1744,7 +1742,7 @@
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="25" width="100" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000003">
@@ -1791,7 +1789,7 @@
 				<reportElement x="0" y="8" width="70" height="17" uuid="a1b2c3d4-0004-4a01-8e01-000000000007">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft")]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left"/>
+				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
@@ -1799,7 +1797,7 @@
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="220" y="8" width="100" height="17" uuid="a1b2c3d4-0005-4a01-8e01-000000000009">
@@ -1833,7 +1831,7 @@
 				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left">
+				<textElement textAlignment="Right">
 					<font size="8" isItalic="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
@@ -1845,7 +1843,7 @@
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="220" y="25" width="100" height="15" uuid="a2b2c3d4-0005-4a01-8e01-000000000009">

--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -90,9 +90,7 @@
 	</parameter>
 	<parameter name="Conformity_description_2" class="java.lang.String">
 		<parameterDescription><![CDATA[Kurzlegende für Symbolik (? / !? / ! / *).]]></parameterDescription>
-		<defaultValueExpression><![CDATA[$P{Sprache}.equals("Deutsch")
-? "? innerhalb der Spezifikation<br/>!? außerhalb der Spezifikation (keine Aussage möglich)<br/>! außerhalb der Spezifikation<br/>* nicht im Akkreditierungsumfang"
-: "? within the specification<br/>!? out of specification (no statement possible)<br/>! out of specification<br/>* not covered by the accreditation scope"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["?\n\n\n!?\n\n\n!\n\n*"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Conformity_description_3" class="java.lang.String">
 		<parameterDescription><![CDATA[Detailbeschreibungen zu den Symbolen für Konformität und Akkreditierungsumfang.]]></parameterDescription>
@@ -1639,7 +1637,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="16" y="8" width="70" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000001">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left"/>
+				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
@@ -1647,7 +1645,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="8" width="100" height="17" uuid="a1b2c3d4-0002-4a01-8e01-000000000003">
@@ -1699,7 +1697,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
 					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left">
+				<textElement textAlignment="Right">
 					<font size="8" isItalic="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
@@ -1711,7 +1709,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="25" width="100" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000003">
@@ -1758,7 +1756,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="0" y="8" width="70" height="17" uuid="a1b2c3d4-0004-4a01-8e01-000000000007">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft")]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left"/>
+				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
@@ -1766,7 +1764,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="220" y="8" width="100" height="17" uuid="a1b2c3d4-0005-4a01-8e01-000000000009">
@@ -1800,7 +1798,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left">
+				<textElement textAlignment="Right">
 					<font size="8" isItalic="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
@@ -1812,7 +1810,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="220" y="25" width="100" height="15" uuid="a2b2c3d4-0005-4a01-8e01-000000000009">


### PR DESCRIPTION
## Problem

Im DAkkS-Kalibrierschein (JSON-Report `DAKKS-JSON-SAMPLE`) waren unter **KONFORMITÄT** zwei Layoutfehler sichtbar:

1. **Verschobene Beispielanzeige der Konformitätslegende** – die Symbolspalte brach unschön um und war gegenüber den Beschreibungen verschoben.
2. **Seitenzahl „Seite x von y" nicht sinnvoll verbunden** – die Gesamtseitenzahl schwebte mit großem Abstand rechts neben „Seite x von".

Beide Fehler stammen aus der Vorlagenquelle `DAKKS-SAMPLE`, aus der `DAKKS-JSON-SAMPLE` über `scripts/build_dakks_json_clone.py` byte-genau abgeleitet wird. Die Korrektur erfolgt daher in der Quelle; der JSON-Klon wurde neu generiert.

## Ursache & Fix

### 1. Konformitätslegende (`Conformity_description_2`)
Der Parameter-Default war fälschlich eine Symbol-**plus-Text**-Legende
(`"? innerhalb der Spezifikation<br/>!? …"`). Die Symbolspalte des Bandes ist aber nur **48px** breit (bewusst schmal, nur für die Symbole `? / !? / ! / *`). Der lange Text brach dort in einen schmalen, vielzeiligen Stapel um, lief über und zerstörte die zeilenweise Ausrichtung zur Beschreibungsspalte.

Ersetzt durch die V1-Symbolfolge `"?\n\n\n!?\n\n\n!\n\n*"`. Die Leerzeilen-Polsterung richtet jedes Symbol exakt am Anfang seines zugehörigen Absatzes in `Conformity_description_3` aus. Dass die Beschreibungen bei 480px Spaltenbreite mit **2/2/1/1** Zeilen umbrechen (und die Polsterung damit passt), wurde für **Deutsch und Englisch** per DejaVu-Sans-Font-Metrik nachgemessen. Der Default entspricht damit wieder der eigenen `parameterDescription` „Kurzlegende für Symbolik (? / !? / ! / *)".

### 2. Seitenzahl (Positionen HeaderLeft / FooterLeft)
Das Label „Seite x von " stand **linksbündig** in einer festen 70px-Box; die am Berichtsende ausgewertete Gesamtseitenzahl saß fix an der rechten Boxkante und schwebte dadurch mit variablem Abstand daneben. Jetzt ist das Label **rechtsbündig** und die Gesamtzahl trägt ein führendes ` ` – exakt das Muster, das HeaderCenter/HeaderRight bereits korrekt verwenden. „Seite x von y" liest sich nun als zusammenhängende Angabe.

## Geänderte Dateien
- `DAKKS-SAMPLE/main_reports/dakks-sample.jrxml` (Quelle)
- `DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml` (neu generiert via `--write`)

## Prüfungen
- ✅ `scripts/build_dakks_json_clone.py --check` (Byte-Parität V1→JSON)
- ✅ `scripts/check_parameters_manifest.py`
- ✅ `scripts/check_jasper_version.sh` (6.20.6)
- ✅ XML wohlgeformt
- ✅ Font-Metrik-Nachweis der 2/2/1/1-Ausrichtung (DE + EN)

## Hinweis
Der Report `DCC/main_reports/dcc-sample.jrxml` enthält denselben `Conformity_description_2`-Default in einer ebenfalls 48px breiten Symbolspalte und hat damit denselben latenten Fehler. Er wurde hier **nicht** angefasst (außerhalb des angefragten Scopes) – bei Bedarf gern in einem Folge-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gWQabAuxR2kALeasZ8WCs

---
_Generated by [Claude Code](https://claude.ai/code/session_015gWQabAuxR2kALeasZ8WCs)_