### PR TITLE
fix(dcc): Konformitätslegende ausrichten und Seitenzahl verbinden (analog #494)

### DIFF
--- a/DCC/main_reports/dcc-sample.jrxml
+++ b/DCC/main_reports/dcc-sample.jrxml
@@ -90,9 +90,7 @@
 	</parameter>
 	<parameter name="Conformity_description_2" class="java.lang.String">
 		<parameterDescription><![CDATA[Kurzlegende für Symbolik (? / !? / ! / *).]]></parameterDescription>
-		<defaultValueExpression><![CDATA[$P{Sprache}.equals("Deutsch")
-? "? innerhalb der Spezifikation<br/>!? außerhalb der Spezifikation (keine Aussage möglich)<br/>! außerhalb der Spezifikation<br/>* nicht im Akkreditierungsumfang"
-: "? within the specification<br/>!? out of specification (no statement possible)<br/>! out of specification<br/>* not covered by the accreditation scope"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["?\n\n\n!?\n\n\n!\n\n*"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Conformity_description_3" class="java.lang.String">
                 <parameterDescription><![CDATA[Detailbeschreibungen zu den Symbolen für Konformität und Akkreditierungsumfang.]]></parameterDescription>
@@ -1588,7 +1586,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="16" y="8" width="70" height="17" uuid="a1b2c3d4-0001-4a01-8e01-000000000001">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left"/>
+				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
@@ -1596,7 +1594,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="8" width="100" height="17" uuid="a1b2c3d4-0002-4a01-8e01-000000000003">
@@ -1648,7 +1646,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="16" y="25" width="70" height="15" uuid="a2b2c3d4-0001-4a01-8e01-000000000001">
 					<printWhenExpression><![CDATA[($P{PageNumberPosition} == null || $P{PageNumberPosition}.trim().isEmpty() || $P{PageNumberPosition}.trim().equalsIgnoreCase("HeaderLeft")) && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left">
+				<textElement textAlignment="Right">
 					<font size="8" isItalic="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
@@ -1660,7 +1658,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="25" width="100" height="15" uuid="a2b2c3d4-0002-4a01-8e01-000000000003">
@@ -1707,7 +1705,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="0" y="8" width="70" height="17" uuid="a1b2c3d4-0004-4a01-8e01-000000000007">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft")]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left"/>
+				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Seite " + $V{PAGE_NUMBER} + " von ") : ("Page " + $V{PAGE_NUMBER} + " of ")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
@@ -1715,7 +1713,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft")]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Left"/>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="220" y="8" width="100" height="17" uuid="a1b2c3d4-0005-4a01-8e01-000000000009">
@@ -1749,7 +1747,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<reportElement x="0" y="25" width="70" height="15" uuid="a2b2c3d4-0004-4a01-8e01-000000000007">
 					<printWhenExpression><![CDATA[$P{PageNumberPosition} != null && $P{PageNumberPosition}.trim().equalsIgnoreCase("FooterLeft") && !java.util.Arrays.asList("n", "no", "false", "0").contains(($P{PageNumberBilingual} == null ? "y" : $P{PageNumberBilingual}.toString()).trim().toLowerCase())]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Left">
+				<textElement textAlignment="Right">
 					<font size="8" isItalic="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Sprache}.equals("Deutsch") ? ("Page " + $V{PAGE_NUMBER} + " of ") : ("Seite " + $V{PAGE_NUMBER} + " von ")]]></textFieldExpression>
@@ -1761,7 +1759,7 @@ END AS cert_field, COALESCE(c.C2307, "") AS C2307, COALESCE(c.C2327, "") AS C232
 				<textElement textAlignment="Left">
 					<font size="8" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["\u00A0" + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="220" y="25" width="100" height="15" uuid="a2b2c3d4-0005-4a01-8e01-000000000009">


### PR DESCRIPTION
## Kontext

Folge-PR zu #494 (DAkkS-Schein). Der eigenständige DCC-Report `DCC/main_reports/dcc-sample.jrxml` enthielt **dieselben zwei Layoutfehler** wie der DAkkS-Schein – bei byte-identischen Bändern/UUIDs, nur mit eigenen Report-Namen. Dieser PR überträgt die beiden Korrekturen 1:1 auf den DCC.

DCC ist ein **standalone-Report** (nicht via `build_dakks_json_clone.py` aus `DAKKS-SAMPLE` abgeleitet), daher direkte Bearbeitung ohne Klon-Regenerierung.

## Fixes

### 1. Konformitätslegende (`Conformity_description_2`)
Default war eine Symbol-**plus-Text**-Legende (`"? innerhalb der Spezifikation<br/>…"`), die in der nur **48px** breiten Symbolspalte umbrach und die Ausrichtung zur Beschreibungsspalte zerstörte. Ersetzt durch die V1-Symbolfolge `"?\n\n\n!?\n\n\n!\n\n*"`. Die passende **2/2/1/1**-Zeilenumbrechung von `Conformity_description_3` bei 480px wurde für **DE und EN** per DejaVu-Sans-Font-Metrik bestätigt (die DCC-EN-Variante endet auf „accreditation scope" statt „DAkkS accreditation", bricht aber ebenfalls 2/2/1/1 um).

### 2. Seitenzahl „Seite x von y" (HeaderLeft / FooterLeft)
Label linksbündig in fester 70px-Box → am Berichtsende ausgewertete Gesamtseitenzahl schwebte daneben. Jetzt Label **rechtsbündig** + Gesamtzahl mit führendem ` ` – identisch zum bereits korrekten Muster von HeaderCenter/HeaderRight.

## Geänderte Datei
- `DCC/main_reports/dcc-sample.jrxml` (9 insertions, 11 deletions – gleiche Form wie #494)

## Prüfungen
- ✅ XML wohlgeformt
- ✅ `scripts/check_jasper_version.sh` (6.20.6)
- ✅ `scripts/check_parameters_manifest.py`
- ✅ Font-Metrik-Nachweis der 2/2/1/1-Ausrichtung (DE + EN)

## Separater Hinweis: DCC als JSON-Bundle
Auf deine Frage „ist DCC komplett als JSON verfügbar, analog DAkkS": **Nein.** Es gibt **kein** `DCC-JSON-SAMPLE` (JSON-Datasource-PDF-Bundle). Der DCC-PDF-Report ist weiterhin **SQL-basiert** (`<queryString language="SQL">`, keine `fieldDescription`/`dataSourceExpression`-Bindings). DCCs JSON-Bezug beschränkt sich auf: (a) die Fixture `DCC/main_reports/sample-data/dcc-sample.json` und (b) `scripts/dcc_xml_writer.py`, das aus dieser JSON das **DCC-XML** (`schema/dcc-certificate.xsd`) erzeugt. Ein vollwertiges `DCC-JSON-SAMPLE` analog `DAKKS-JSON-SAMPLE` müsste – wie bei DAkkS via `build_dakks_json_clone.py` – erst noch abgeleitet werden. Details/Umsetzung gern separat, wenn gewünscht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gWQabAuxR2kALeasZ8WCs

---
_Generated by [Claude Code](https://claude.ai/code/session_015gWQabAuxR2kALeasZ8WCs)_