### PR TITLE
feat(order): Rechnungs-/Lieferadresse, Lieferbedingung und Zusatzfelder im Auftragsreport

### DIFF
--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -10,22 +10,33 @@ und ist unabhängig vom DB-Backend (MySQL, PostgreSQL, MSSQL).
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/order-json-sample.jrxml` | Hauptbericht: Briefkopf (Empfängeradresse + Meta-Box Belegnummer/Datum/Kunde/Kontakt), Betreff, Positionstabelle + Statistik. Alle Labels als `staticText` |
+| `main_reports/order-json-sample.jrxml` | Hauptbericht: Briefkopf (Empfängeradresse + Meta-Box Belegnummer/Datum/Kunde/Kontakt/Lieferbedingung/-kosten), abweichende Liefer-/Rechnungsadresse, Betreff, Positionstabelle + Statistik + Zusatzfelder. Alle Labels als `staticText` |
 | `subreports/positions.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` (Pos/Beschreibung/Menge/Einzelpreis/Rabatt/Betrag/MwSt) |
 | `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz) |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.0) |
+| `subreports/custom-fields.jrxml` | Zusatzfelder (W41xx); `document.custom_fields_list`-Array via `subDataSource("document.custom_fields_list")` — Label/Wert je konfiguriertem Feld, generisch |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.1) |
 | `main_reports/order-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
-## Contract `order-document` (v1.0)
+## Contract `order-document` (v1.1)
 
-Wurzelobjekt mit `meta`, `document` (Nummer/Datum/Status/Kommentar/Rechtstext +
-`custom_fields` für W41xx-Zusatzfelder), drei Adressrollen `customer`/`delivery`/
-`invoice` (mit `contact`-Unterobjekt, serverseitig mit V1-Fallback aufgelöst),
-`positions[]` und **serverseitig vorberechneter `statistics`** (`tax_groups[]` je
-Steuersatz + Skalare `net_total`/`discount_amount`/`net_after_discount`/`vat_total`/
-`gross_total`). **Jasper kann ein JSON-Array nicht gruppieren** — die
-Steuergruppen-Aggregation macht daher der `OrderDocumentDataBuilder` (Laravel);
-der Bericht druckt nur. Feldreferenz siehe `sample-data.json`.
+Wurzelobjekt mit `meta`, `document` (Nummer/Datum/Status/Kommentar/Rechtstext,
+`delivery_condition`/`delivery_costs`, `custom_fields` als Objekt **und**
+`custom_fields_list` als geordnete `[{key,label,value}]`-Liste für die
+W41xx-Zusatzfelder), drei Adressrollen `customer`/`delivery`/`invoice` (mit
+`contact`-Unterobjekt, serverseitig mit V1-Fallback aufgelöst), `positions[]`
+und **serverseitig vorberechneter `statistics`** (`tax_groups[]` je Steuersatz +
+Skalare `net_total`/`discount_amount`/`net_after_discount`/`vat_total`/
+`gross_total`). **Jasper kann ein JSON-Array/-Objekt nicht gruppieren bzw.
+iterieren** — deshalb liefert der `OrderDocumentDataBuilder` (Laravel) die
+Steuergruppen vorberechnet und die Zusatzfelder zusätzlich als **Liste**
+(`custom_fields_list`), damit das Template sie generisch (ohne Kenntnis der
+Feldbedeutung) rendern kann; der Bericht druckt nur. Feldreferenz siehe
+`sample-data.json`.
+
+> **v1.0 → v1.1 (additiv, nicht brechend):** neu sind
+> `document.custom_fields_list` sowie die im Template nun gerenderten Blöcke
+> Liefer-/Rechnungsadresse (nur wenn abweichend vom Auftraggeber) und
+> Lieferbedingung/-kosten. Bestehende v1.0-Bindungen bleiben unverändert.
 
 > **Auftragsrabatt (W4114):** Die Muster sind rabattfrei, damit die Summen
 > eindeutig sind. Die exakte V1-Rabatt-Steuer-Arithmetik bei mehreren Steuersätzen

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 order document (Auftrag/Angebot/Rechnung), ADR-009 contract "order-document"
-  v1.0. Filled from a JSON data source — NO SQL, NO V1 code columns. Positions and
+  V2 order document (Auftrag/Angebot/Rechnung/Lieferung), ADR-009 contract
+  "order-document" v1.1. Renders the ordering customer plus — when they differ —
+  the delivery and invoice address, the delivery condition/costs, and the booking
+  custom fields (W41xx) generically via document.custom_fields_list.
+  Filled from a JSON data source — NO SQL, NO V1 code columns. Positions and
   the per-tax-rate statistics are pre-aggregated server-side (OrderDocumentDataBuilder)
   because a JSON template cannot group an array; the template only prints them:
   positions[] via subDataSource("positions"), statistics.tax_groups[] via
@@ -40,6 +43,18 @@
 	<field name="vat_total" class="java.lang.Double"><fieldDescription><![CDATA[statistics.vat_total]]></fieldDescription></field>
 	<field name="gross_total" class="java.lang.Double"><fieldDescription><![CDATA[statistics.gross_total]]></fieldDescription></field>
 	<field name="order_discount_percent" class="java.lang.Double"><fieldDescription><![CDATA[statistics.order_discount_percent]]></fieldDescription></field>
+	<field name="doc_delivery_condition" class="java.lang.String"><fieldDescription><![CDATA[document.delivery_condition]]></fieldDescription></field>
+	<field name="doc_delivery_costs" class="java.lang.Double"><fieldDescription><![CDATA[document.delivery_costs]]></fieldDescription></field>
+	<field name="del_name" class="java.lang.String"><fieldDescription><![CDATA[delivery.name]]></fieldDescription></field>
+	<field name="del_street" class="java.lang.String"><fieldDescription><![CDATA[delivery.street]]></fieldDescription></field>
+	<field name="del_zip" class="java.lang.String"><fieldDescription><![CDATA[delivery.zip]]></fieldDescription></field>
+	<field name="del_city" class="java.lang.String"><fieldDescription><![CDATA[delivery.city]]></fieldDescription></field>
+	<field name="del_number" class="java.lang.String"><fieldDescription><![CDATA[delivery.customer_number]]></fieldDescription></field>
+	<field name="inv_name" class="java.lang.String"><fieldDescription><![CDATA[invoice.name]]></fieldDescription></field>
+	<field name="inv_street" class="java.lang.String"><fieldDescription><![CDATA[invoice.street]]></fieldDescription></field>
+	<field name="inv_zip" class="java.lang.String"><fieldDescription><![CDATA[invoice.zip]]></fieldDescription></field>
+	<field name="inv_city" class="java.lang.String"><fieldDescription><![CDATA[invoice.city]]></fieldDescription></field>
+	<field name="inv_number" class="java.lang.String"><fieldDescription><![CDATA[invoice.customer_number]]></fieldDescription></field>
 	<title>
 		<band height="200">
 			<!-- Sender line -->
@@ -57,6 +72,26 @@
 			<textField><reportElement style="Value" x="460" y="46" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
 			<staticText><reportElement style="Label" x="380" y="60" width="80" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
 			<textField><reportElement style="Value" x="460" y="60" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="74" width="80" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><text><![CDATA[Lieferung]]></text></staticText>
+			<textField><reportElement style="Value" x="460" y="74" width="101" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_condition}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="88" width="80" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0]]></printWhenExpression></reportElement><text><![CDATA[Lieferkosten]]></text></staticText>
+			<textField pattern="#,##0.00 €"><reportElement style="Value" x="460" y="88" width="101" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_costs}]]></textFieldExpression></textField>
+			<!-- Lieferadresse (nur wenn abweichend vom Auftraggeber) -->
+			<frame>
+				<reportElement x="0" y="64" width="175" height="52"><printWhenExpression><![CDATA[$F{del_number} != null && !$F{del_number}.equals($F{cust_number})]]></printWhenExpression></reportElement>
+				<staticText><reportElement style="Label" x="0" y="0" width="175" height="11"/><text><![CDATA[Lieferadresse]]></text></staticText>
+				<textField><reportElement x="0" y="12" width="175" height="12"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{del_name}]]></textFieldExpression></textField>
+				<textField><reportElement x="0" y="24" width="175" height="12"/><textFieldExpression><![CDATA[$F{del_street}]]></textFieldExpression></textField>
+				<textField><reportElement x="0" y="36" width="175" height="12"/><textFieldExpression><![CDATA[($F{del_zip} == null ? "" : $F{del_zip}) + " " + ($F{del_city} == null ? "" : $F{del_city})]]></textFieldExpression></textField>
+			</frame>
+			<!-- Rechnungsadresse (nur wenn abweichend vom Auftraggeber) -->
+			<frame>
+				<reportElement x="185" y="64" width="175" height="52"><printWhenExpression><![CDATA[$F{inv_number} != null && !$F{inv_number}.equals($F{cust_number})]]></printWhenExpression></reportElement>
+				<staticText><reportElement style="Label" x="0" y="0" width="175" height="11"/><text><![CDATA[Rechnungsadresse]]></text></staticText>
+				<textField><reportElement x="0" y="12" width="175" height="12"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{inv_name}]]></textFieldExpression></textField>
+				<textField><reportElement x="0" y="24" width="175" height="12"/><textFieldExpression><![CDATA[$F{inv_street}]]></textFieldExpression></textField>
+				<textField><reportElement x="0" y="36" width="175" height="12"/><textFieldExpression><![CDATA[($F{inv_zip} == null ? "" : $F{inv_zip}) + " " + ($F{inv_city} == null ? "" : $F{inv_city})]]></textFieldExpression></textField>
+			</frame>
 			<!-- Subject -->
 			<textField><reportElement x="0" y="120" width="561" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA[($F{doc_status} == null ? "Beleg" : $F{doc_status}) + " " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
 			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="144" width="561" height="14"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
@@ -93,6 +128,12 @@
 			<line><reportElement positionType="Float" x="330" y="84" width="231" height="1"/></line>
 			<staticText><reportElement style="Label" positionType="Float" x="330" y="88" width="150" height="14"/><textElement><font size="10" isBold="true"/></textElement><text><![CDATA[Gesamtbetrag]]></text></staticText>
 			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="470" y="88" width="91" height="14"/><textElement textAlignment="Right"><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{gross_total}]]></textFieldExpression></textField>
+			<!-- Weitere Angaben: Zusatzfelder (W41xx) generisch aus custom_fields_list (Contract 1.1) -->
+			<subreport>
+				<reportElement positionType="Float" x="0" y="30" width="320" height="12" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("document.custom_fields_list")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/custom-fields.jasper"]]></subreportExpression>
+			</subreport>
 			<textField textAdjust="StretchHeight"><reportElement positionType="Float" x="0" y="120" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{doc_description}]]></textFieldExpression></textField>
 		</band>
 	</detail>

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "order-document",
-    "schema_version": "1.0",
+    "schema_version": "1.1",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE"
   },
@@ -11,13 +11,18 @@
     "status": "Auftrag",
     "comment": "Vielen Dank für Ihren Auftrag.",
     "delivery_condition": "frei Haus",
-    "delivery_costs": 0,
+    "delivery_costs": 12.5,
     "description": "Es gelten unsere Allgemeinen Geschäftsbedingungen.",
     "custom_fields": {
-      "W4104": "Ihre Bestellung 12345",
+      "W4104": "12345",
       "W4105": "2026-07-10",
       "W4109": "2026-07-20"
-    }
+    },
+    "custom_fields_list": [
+      { "key": "W4104", "label": "Ihre Bestellnummer", "value": "12345" },
+      { "key": "W4105", "label": "Bestelldatum", "value": "2026-07-10" },
+      { "key": "W4109", "label": "Liefertermin", "value": "2026-07-20" }
+    ]
   },
   "customer": {
     "name": "Muster GmbH",
@@ -36,18 +41,18 @@
     }
   },
   "delivery": {
-    "name": "Muster GmbH",
-    "customer_number": "K-1001",
-    "street": "Musterstraße 1",
-    "zip": "54321",
-    "city": "Beispielstadt",
+    "name": "Muster GmbH – Wareneingang",
+    "customer_number": "K-1001-L",
+    "street": "Wareneingang, Tor 3",
+    "zip": "54322",
+    "city": "Beispielstadt-Industriegebiet",
     "country": "DE"
   },
   "invoice": {
-    "name": "Muster GmbH",
-    "customer_number": "K-1001",
-    "street": "Musterstraße 1",
-    "zip": "54321",
+    "name": "Muster GmbH – Buchhaltung",
+    "customer_number": "K-1001-R",
+    "street": "Rechnungsstelle, Postfach 90",
+    "zip": "54320",
     "city": "Beispielstadt",
     "country": "DE"
   },

--- a/ORDER-JSON-SAMPLE/subreports/custom-fields.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/custom-fields.jrxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 custom-fields subreport (contract order-document v1.1): fed the
+  document.custom_fields_list array via subDataSource("document.custom_fields_list").
+  One row per configured booking custom field (V1 W41xx) — a human label from the
+  field registry plus the value. Generic: the template does NOT know any code's
+  meaning, so a re-configured field renders with its own label without a template
+  change. Empty when no custom fields are populated.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="custom-fields" pageWidth="320" pageHeight="842" columnWidth="320" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0303-4d63-9f53-000000000303">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="label" class="java.lang.String"><fieldDescription><![CDATA[label]]></fieldDescription></field>
+	<field name="value" class="java.lang.String"><fieldDescription><![CDATA[value]]></fieldDescription></field>
+	<detail>
+		<band height="12">
+			<textField><reportElement x="0" y="0" width="130" height="11"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[($F{label} == null ? "" : $F{label}) + ":"]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="132" y="0" width="188" height="11"/><textFieldExpression><![CDATA[$F{value}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
## Zweck

Ergänzt das V2-Auftragstemplate (`ORDER-JSON-SAMPLE`) um die Felder, die der `order-document`-Contract bereits trägt, im V2-Template aber bisher nicht gerendert wurden. Gehört zu Gap G5 des V1-Funktionsumfangsberichts der Auftragsverwaltung; der Backend-Teil (Contract-Erweiterung) liegt im PR calServer-yii#2991.

## Änderungen

- **Liefer- und Rechnungsadresse**: eigene Blöcke, die nur erscheinen, wenn die Rolle vom Auftraggeber abweicht (Vergleich über `customer_number`) — so bleibt der Standardfall (Fallback auf den Besteller) unverändert schlicht.
- **Lieferbedingung + Lieferkosten**: neue Zeilen in der Meta-Box (nur wenn gesetzt/≠0).
- **Zusatzfelder (V1 W41xx) generisch**: neues Subreport `subreports/custom-fields.jrxml`, gespeist aus `document.custom_fields_list` (`[{key,label,value}]`). Das Label kommt aus der Feld-Registry — ein umkonfiguriertes Feld druckt mit seinem eigenen Label, **ohne** Template-Änderung (ein JSON-Objekt lässt sich in Jasper nicht iterieren, eine Liste schon).

## Contract

`order-document` v1.0 → **v1.1** (rein additiv): neu `document.custom_fields_list`; die Adress-/Lieferfelder existierten bereits im Contract. Bestehende v1.0-Bindungen unverändert. `sample-data.json` auf 1.1 gehoben, mit unterscheidbarer Liefer-/Rechnungsadresse und `custom_fields_list`, damit die Studio-Vorschau die neuen Bindungen ausübt.

## Prüfungen

- `scripts/check_jasper_version.sh` (alle JRXML inkl. neuem Subreport tragen den Versionskommentar 6.20.6) — grün.
- `scripts/check_parameters_manifest.py` — grün (Warnungen betreffen nur DAKKS; `parameters.json` unverändert, kein neuer Parameter nötig).
- XML/JSON well-formed. Die pixelgenaue Layout-Abnahme über den report-runner bleibt wie üblich maßgeblich (kein Compile-/Pixel-Test in CI).

## Folgeschritt

`DELIVERY-JSON-SAMPLE` (Lieferschein) nutzt denselben Contract und könnte `custom_fields_list`/`delivery_condition` analog aufnehmen — bewusst separat gehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157aZrAYBGxJEfpeNBkum9H

---
_Generated by [Claude Code](https://claude.ai/code/session_0157aZrAYBGxJEfpeNBkum9H)_