### PR TITLE
feat(inventory): Bundle SUBORDINATE-INVENTORY-JSON-SAMPLE (Gerät + untergeordnete Geräte)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -175,6 +175,16 @@ jobs:
             INVENTORY-JSON-SAMPLE/subreports
           if-no-files-found: error
 
+      - name: Upload SUBORDINATE-INVENTORY-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SUBORDINATE-INVENTORY-JSON-SAMPLE
+          path: |
+            SUBORDINATE-INVENTORY-JSON-SAMPLE/main_reports
+            SUBORDINATE-INVENTORY-JSON-SAMPLE/subreports
+            SUBORDINATE-INVENTORY-JSON-SAMPLE/parameters.json
+          if-no-files-found: error
+
       - name: Upload KALIBRIERKONTROLLBLATT-JSON-SAMPLE as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -372,6 +382,7 @@ jobs:
           # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL)
           create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"
           create_zip "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
+          create_zip "SUBORDINATE-INVENTORY-JSON-SAMPLE" "subordinate-inventory-json-sample"
           create_zip "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
           create_zip "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -101,6 +101,7 @@ jobs:
           get_last_modified "STICKERS/Sticker_Vorlage" "sticker-vorlage"
           get_last_modified "DAKKS-JSON-SAMPLE" "dakks-json-sample"
           get_last_modified "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
+          get_last_modified "SUBORDINATE-INVENTORY-JSON-SAMPLE" "subordinate-inventory-json-sample"
           get_last_modified "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
           get_last_modified "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           get_last_modified "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
@@ -185,6 +186,7 @@ jobs:
               "trace-backward":    "TRACE-BACKWARD/main_reports/README.md",
               "dakks-json-sample":     "DAKKS-JSON-SAMPLE/README.md",
               "inventory-json-sample": "INVENTORY-JSON-SAMPLE/README.md",
+              "subordinate-inventory-json-sample": "SUBORDINATE-INVENTORY-JSON-SAMPLE/README.md",
               "kalibrierkontrollblatt-json-sample": "KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md",
               "sticker-dakks-12mm-json-sample":     "STICKER-DAKKS-12MM-JSON-SAMPLE/README.md",
               "sticker-dakks-18mm-json-sample":     "STICKER-DAKKS-18MM-JSON-SAMPLE/README.md",
@@ -211,6 +213,7 @@ jobs:
               "trace-backward":         "Trace-Backward (Rückführungskette)",
               "dakks-json-sample":      "DAkkS-Kalibrierschein (APEX · V2)",
               "inventory-json-sample":  "Geräte-Datenblatt (APEX · V2)",
+              "subordinate-inventory-json-sample": "Gerät mit untergeordneten Geräten (APEX · V2)",
               "kalibrierkontrollblatt-json-sample": "Kalibrierkontrollblatt (APEX · V2)",
               "sticker-dakks-12mm-json-sample":     "DAkkS-Aufkleber 12 mm (APEX · V2)",
               "sticker-dakks-18mm-json-sample":     "DAkkS-Aufkleber 18 mm (APEX · V2)",

--- a/SUBORDINATE-INVENTORY-JSON-SAMPLE/README.md
+++ b/SUBORDINATE-INVENTORY-JSON-SAMPLE/README.md
@@ -1,0 +1,40 @@
+# SUBORDINATE-INVENTORY-JSON-SAMPLE — V2-Bundle (JSON-Datasource)
+
+Gerät mit Details und **allen untergeordneten Geräten** als V2-Bundle im Sinne
+von [ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md)
+und [ADR-011](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/011-untergeordnete-inventare-v2.md):
+gefüllt aus dem Report-Data-Contract `inventory-datasheet` (ab Schema **1.2**)
+mit lesbaren API-Feldnamen statt aus eingebettetem SQL gegen V1-Codespalten.
+
+Der Contract 1.2 liefert zusätzlich zum Gerät:
+
+- `parent` — das übergeordnete Gerät (V1: `I4217` / „Accessory Asset"),
+  leeres Objekt bei einem Root-Gerät;
+- `children` — den **kompletten Teilbaum** der untergeordneten Geräte,
+  tiefensortiert, mit `level` (1 = direkte Kinder, 2 = deren Kinder usw.).
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/subordinate-inventory-json-sample.jrxml` | Gerätedetails + Zeile „Übergeordnetes Gerät" (nur wenn vorhanden) + Abschnitt „Untergeordnete Geräte" |
+| `subreports/children.jrxml` | Teilbaum-Tabelle (Ebene, Inventar-Nr., Serien-Nr., Beschreibung, Standort, nächste Kalibrierung); erhält das `children`-Array via `subDataSource("children")` |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `inventory-datasheet` v1.2) für den JSON-Data-Adapter in Jaspersoft Studio |
+| `parameters.json` | Parameter-Manifest (nur Systemparameter `Reportpath`) |
+
+## Datenanbindung
+
+- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
+- Der Runner füllt den Hauptbericht mit einer `JsonDataSource`; das Datenblatt
+  ist genau ein Datensatz (Wurzelobjekt).
+- Den Datensatz erzeugt das calServer-V2-Backend
+  (`InventoryReportDataBuilder`, Schema 1.2) — ohne die `children`-Sektion im
+  Contract bleibt der Subreport leer.
+
+Aktivierung in calServer: Report-Setting auf dem Inventar-Grid anlegen
+(Kontext „Detail"), Vorlage = dieses Bundle, und die Report-Variable
+`data_contract = inventory-datasheet` zuweisen (Details siehe V2-Doku
+„V2-Berichte mit JSON-Datenquelle").
+
+> **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
+> verbindlich (siehe `robots.md`).

--- a/SUBORDINATE-INVENTORY-JSON-SAMPLE/main_reports/sample-data.json
+++ b/SUBORDINATE-INVENTORY-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,82 @@
+{
+  "meta": {
+    "contract": "inventory-datasheet",
+    "schema_version": "1.2",
+    "generated_at": "2026-07-24T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Prüfplatz Elektrik A",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "type_code": "DMM",
+    "accuracy_class": "2026-01-15",
+    "location": "Labor 1 / Schrank A",
+    "active_location": {},
+    "cost_center": "CC-4711",
+    "status": 1,
+    "calibration_interval": 12,
+    "last_calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30",
+    "custom_fields": {
+      "customer_tag": "KND-DMM-7"
+    }
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "12345",
+    "city": "Musterstadt",
+    "custom_fields": {}
+  },
+  "calibrations": [
+    {
+      "calibration_date": "2026-06-30",
+      "next_calibration_date": "2027-06-30",
+      "certificate_number": "DAkkS-K-2026-0042",
+      "technician": "Erika Musterfrau"
+    }
+  ],
+  "parent": {
+    "asset_number": "INV-8000",
+    "serial_number": "SN-8000",
+    "description": "Messsystem Halle 2",
+    "manufacturer": "Keysight",
+    "model": "System-2000"
+  },
+  "children": [
+    {
+      "level": 1,
+      "asset_number": "INV-9001-1",
+      "serial_number": "SN-90011",
+      "description": "Multimeter Fluke 87V",
+      "manufacturer": "Fluke",
+      "model": "87V",
+      "location": "Labor 1 / Schrank A",
+      "next_calibration_date": "2027-06-30"
+    },
+    {
+      "level": 2,
+      "asset_number": "INV-9001-1-1",
+      "serial_number": "SN-901111",
+      "description": "Messleitungssatz",
+      "manufacturer": "Fluke",
+      "model": "TL71",
+      "location": "Labor 1 / Schrank A",
+      "next_calibration_date": "2027-08-15"
+    },
+    {
+      "level": 1,
+      "asset_number": "INV-9001-2",
+      "serial_number": "SN-90012",
+      "description": "Netzteil",
+      "manufacturer": "Rohde & Schwarz",
+      "model": "HMP4040",
+      "location": "Labor 1 / Schrank B",
+      "next_calibration_date": "2027-05-01"
+    }
+  ]
+}

--- a/SUBORDINATE-INVENTORY-JSON-SAMPLE/main_reports/subordinate-inventory-json-sample.jrxml
+++ b/SUBORDINATE-INVENTORY-JSON-SAMPLE/main_reports/subordinate-inventory-json-sample.jrxml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2-Bundle (ADR-009/ADR-011): Gerät mit Details und allen untergeordneten
+  Geräten, gefüllt aus dem "inventory-datasheet"-Contract (ab Schema 1.2) via
+  JSON-Datasource - KEIN SQL, KEINE V1-Codespalten. Der Teilbaum kommt als
+  "children"-Array (tiefensortiert, level = 1 für direkte Kinder) und wird per
+  subDataSource an den Subreport gereicht; das übergeordnete Gerät steht im
+  "parent"-Objekt (leer bei einem Root-Gerät).
+  Dataset builder: Laravel InventoryReportDataBuilder; siehe sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="subordinate-inventory-json-sample" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="30" bottomMargin="30" uuid="a7c4e2d0-0001-4c30-9e11-000000000201">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false"/>
+	<style name="Label" fontSize="9" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<field name="asset_number" class="java.lang.String">
+		<fieldDescription><![CDATA[device.asset_number]]></fieldDescription>
+	</field>
+	<field name="serial_number" class="java.lang.String">
+		<fieldDescription><![CDATA[device.serial_number]]></fieldDescription>
+	</field>
+	<field name="description" class="java.lang.String">
+		<fieldDescription><![CDATA[device.description]]></fieldDescription>
+	</field>
+	<field name="manufacturer" class="java.lang.String">
+		<fieldDescription><![CDATA[device.manufacturer]]></fieldDescription>
+	</field>
+	<field name="model" class="java.lang.String">
+		<fieldDescription><![CDATA[device.model]]></fieldDescription>
+	</field>
+	<field name="type_code" class="java.lang.String">
+		<fieldDescription><![CDATA[device.type_code]]></fieldDescription>
+	</field>
+	<field name="location" class="java.lang.String">
+		<fieldDescription><![CDATA[device.location]]></fieldDescription>
+	</field>
+	<field name="next_calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription>
+	</field>
+	<field name="customer_name" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.name]]></fieldDescription>
+	</field>
+	<field name="customer_city" class="java.lang.String">
+		<fieldDescription><![CDATA[customer.city]]></fieldDescription>
+	</field>
+	<field name="parent_asset_number" class="java.lang.String">
+		<fieldDescription><![CDATA[parent.asset_number]]></fieldDescription>
+	</field>
+	<field name="parent_description" class="java.lang.String">
+		<fieldDescription><![CDATA[parent.description]]></fieldDescription>
+	</field>
+	<title>
+		<band height="50">
+			<staticText>
+				<reportElement x="0" y="0" width="535" height="24"/>
+				<textElement><font size="16" isBold="true"/></textElement>
+				<text><![CDATA[Gerät mit untergeordneten Geräten]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="0" y="28" width="535" height="14"/>
+				<textElement><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($F{asset_number} == null ? "" : $F{asset_number}) + "  ·  " + ($F{description} == null ? "" : $F{description})]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<detail>
+		<band height="190">
+			<staticText>
+				<reportElement style="Label" x="0" y="0" width="120" height="14"/>
+				<text><![CDATA[Inventar-Nr.]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="0" width="160" height="14"/>
+				<textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="290" y="0" width="120" height="14"/>
+				<text><![CDATA[Serien-Nr.]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="410" y="0" width="125" height="14"/>
+				<textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="16" width="120" height="14"/>
+				<text><![CDATA[Hersteller / Typ]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="16" width="415" height="14"/>
+				<textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + "  " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="32" width="120" height="14"/>
+				<text><![CDATA[Typ-Code]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="32" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{type_code}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="48" width="120" height="14"/>
+				<text><![CDATA[Standort]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="48" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{location}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="64" width="120" height="14"/>
+				<text><![CDATA[Nächste Kalibrierung]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="64" width="415" height="14"/>
+				<textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="80" width="120" height="14"/>
+				<text><![CDATA[Eigentümer / Kunde]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="80" width="415" height="14"/>
+				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + ($F{customer_city} == null ? "" : ", " + $F{customer_city})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="0" y="104" width="120" height="14">
+					<printWhenExpression><![CDATA[$F{parent_asset_number} != null]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Übergeordnetes Gerät]]></text>
+			</staticText>
+			<textField>
+				<reportElement style="Value" x="120" y="104" width="415" height="14" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{parent_asset_number} != null]]></printWhenExpression>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{parent_asset_number} + ($F{parent_description} == null ? "" : "  ·  " + $F{parent_description})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" positionType="Float" x="0" y="130" width="535" height="14"/>
+				<textElement><font size="11" isBold="true"/></textElement>
+				<text><![CDATA[Untergeordnete Geräte]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="148" width="535" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("children")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/children.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+</jasperReport>

--- a/SUBORDINATE-INVENTORY-JSON-SAMPLE/parameters.json
+++ b/SUBORDINATE-INVENTORY-JSON-SAMPLE/parameters.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Report-Basisverzeichnis",
+        "en": "Report base path"
+      },
+      "description": {
+        "de": "Wird vom report-runner automatisch auf das entpackte Bundle gesetzt (Subreport-Auflösung).",
+        "en": "Set automatically by the report runner to the extracted bundle root (subreport resolution)."
+      },
+      "role": "system",
+      "group": "System",
+      "order": 10
+    }
+  ]
+}

--- a/SUBORDINATE-INVENTORY-JSON-SAMPLE/subreports/children.jrxml
+++ b/SUBORDINATE-INVENTORY-JSON-SAMPLE/subreports/children.jrxml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2-Subreport: erhält das "children"-Array des inventory-datasheet-Contracts
+  (ab Schema 1.2) via
+  ((JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("children").
+  Die Zeilen sind tiefensortiert; "level" (1 = direktes Kind) macht die
+  Hierarchie in der Ebene-Spalte sichtbar.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="children" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenNoDataType="NoDataSection" uuid="a7c4e2d0-0002-4c30-9e12-000000000202">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
+	<field name="level" class="java.lang.Integer">
+		<fieldDescription><![CDATA[level]]></fieldDescription>
+	</field>
+	<field name="asset_number" class="java.lang.String">
+		<fieldDescription><![CDATA[asset_number]]></fieldDescription>
+	</field>
+	<field name="serial_number" class="java.lang.String">
+		<fieldDescription><![CDATA[serial_number]]></fieldDescription>
+	</field>
+	<field name="description" class="java.lang.String">
+		<fieldDescription><![CDATA[description]]></fieldDescription>
+	</field>
+	<field name="location" class="java.lang.String">
+		<fieldDescription><![CDATA[location]]></fieldDescription>
+	</field>
+	<field name="next_calibration_date" class="java.lang.String">
+		<fieldDescription><![CDATA[next_calibration_date]]></fieldDescription>
+	</field>
+	<columnHeader>
+		<band height="16">
+			<staticText>
+				<reportElement x="0" y="0" width="35" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Ebene]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="35" y="0" width="105" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Inventar-Nr.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="140" y="0" width="90" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Serien-Nr.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="230" y="0" width="150" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Beschreibung]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="380" y="0" width="90" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Standort]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="470" y="0" width="65" height="15"/>
+				<textElement><font isBold="true"/></textElement>
+				<text><![CDATA[Nächste Kal.]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="14">
+			<textField>
+				<reportElement x="0" y="0" width="35" height="13"/>
+				<textFieldExpression><![CDATA[$F{level}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="35" y="0" width="105" height="13"/>
+				<textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="140" y="0" width="90" height="13"/>
+				<textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="230" y="0" width="150" height="13"/>
+				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="380" y="0" width="90" height="13"/>
+				<textFieldExpression><![CDATA[$F{location}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="470" y="0" width="65" height="13"/>
+				<textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<noData>
+		<band height="14">
+			<staticText>
+				<reportElement x="0" y="0" width="535" height="13"/>
+				<text><![CDATA[Keine untergeordneten Geräte vorhanden.]]></text>
+			</staticText>
+		</band>
+	</noData>
+</jasperReport>


### PR DESCRIPTION
## Zusammenfassung

Neuer V2-Beispielbericht nach ADR-009/ADR-011: zeigt das **gewählte Gerät mit Details und alle untergeordneten Geräte** als Teilbaum-Tabelle (Ebene, Inventar-Nr., Serien-Nr., Beschreibung, Standort, nächste Kalibrierung). Gegenstück zum Backend-PR calhelp/calServer-yii#3168, der den Contract liefert.

- **JSON-Datasource, kein SQL** (kein `<queryString>`, keine `REPORT_CONNECTION`): liest den `inventory-datasheet`-Contract ab Schema **1.2** — neu darin `parent` (Objekt, leer bei Root) und `children` (kompletter Teilbaum, tiefensortiert, `level` = 1 für direkte Kinder).
- Hauptbericht `main_reports/subordinate-inventory-json-sample.jrxml`: Gerätedetails, Zeile „Übergeordnetes Gerät" nur wenn vorhanden (`printWhenExpression`), Abschnitt „Untergeordnete Geräte" via `subDataSource("children")`.
- Subreport `subreports/children.jrxml`: Teilbaum-Tabelle mit Ebene-Spalte, `whenNoDataType="NoDataSection"` rendert „Keine untergeordneten Geräte vorhanden."
- `parameters.json`-Manifest (nur Systemparameter `Reportpath`), README und `sample-data.json` (Contract 1.2) für den JSON-Adapter in Jaspersoft Studio.
- In `package-reports.yml` (Artifact + ZIP `subordinate-inventory-json-sample`) und `publish-downloads.yml` (README-Map, Titel „Gerät mit untergeordneten Geräten (APEX · V2)") registriert; `release-reports.yml` listet bewusst nur V1-Bundles und bleibt unverändert.

Aktivierung in calServer: Report-Setting auf dem Inventar-Grid (Kontext „Detail") mit Report-Variable `data_contract = inventory-datasheet`.

## Checks

- `scripts/check_jasper_version.sh`: alle JRXML mit JasperReports 6.20.6.
- `scripts/check_parameters_manifest.py`: Manifest valide, Parameter im Haupt-JRXML deklariert.
- JRXML wohlgeformt (XML-Parse), `sample-data.json` valide, Workflow-YAML parst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnsXEcZQw6yjYo2s6K37LB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnsXEcZQw6yjYo2s6K37LB)_