### PR TITLE
docs: LOCATION-JSON-SAMPLE ist das Bundle für den Systembericht „Leihschein"

### DIFF
--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -10,6 +10,23 @@ Sechste Bundle-Familie; das Layout folgt dem V1-Leihschein
 Lieferadresse mit Kontakten, Leihdaten (Leihdatum/-zeit, Rückgabedatum, Status),
 Prüfmittel-Grid und Standortblock (`location_1..5`) mit Signaturzeilen.
 
+## Referenz-Bundle für den Systembericht „Leihschein"
+
+Dieses Bundle ist die empfohlene Vorlage für den **Leihschein**, den calServer
+beim Buchen einer Ausleihe erzeugt und der Leihschein-E-Mail anhängt.
+
+Dafür gibt es auf jeder calServer-V2-Installation eine feste Zeile in
+**Administration > Berichtsverwaltung > Master-Reports**: den Platzhalter
+**Leihschein** (Etikett „Systembericht", Grid `location`, Ordner `locations`).
+Er wird bei der Installation angelegt, ist nicht löschbar und wartet auf sein
+Bundle — hochladen genügt, danach hängt der Leihschein an der Mail. Solange
+nichts hochgeladen ist, geht die Mail ohne Anhang raus.
+
+Details: [Systemberichte](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/admin/berichte/systemberichte.md).
+
+Als Referenz gedacht, nicht als Vorschrift: Ein eigenes Layout wird auf
+derselben Zeile genauso hochgeladen.
+
 ## Aufbau
 
 | Datei | Zweck |
@@ -53,9 +70,12 @@ sondern die fehlende Datenanbindung. Abhilfe:
   braucht keine Fallback-Logik.
 - Den Datensatz erzeugt das calServer-V2-Backend (`LocationReportDataBuilder`).
 
-Aktivierung in calServer: dem Report-Setting (grid_name `location`, Ordner
-`locations`) eine Report-Variable `data_contract = location-report` zuweisen
-(Details siehe V2-Doku „V2-Berichte mit JSON-Datenquelle").
+Aktivierung in calServer: Bundle auf ein Report-Setting mit grid_name
+`location` und Ordner `locations` hochladen — für den Leihschein ist das der
+Systembericht-Platzhalter (siehe oben). Der Contract wird am Bundle erkannt
+(kein `<queryString>` → `location-report`); eine Report-Variable
+`data_contract` ist nur nötig, wenn davon abgewichen werden soll (Details siehe
+V2-Doku „V2-Berichte mit JSON-Datenquelle").
 
 ## Contract `location-report` (v1.0)
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ calServer V2 verwendet ein neues Datenbankschema mit **lesbaren Feldnamen** (`se
 
 - **Die bestehenden Bundles in diesem Repository bleiben der stabile V1-Stand** (eingebettetes SQL über JDBC mit den Codespalten). Sie laufen unverändert auf allen V1-Systemen und werden weiter mit Bugfixes gepflegt.
 - **V2-Bundles** (Ordner mit Endung `-JSON-SAMPLE`, z. B. `DAKKS-JSON-SAMPLE`, `INVENTORY-JSON-SAMPLE`) nutzen eine **JSON-Datasource** mit lesbaren API-Feldnamen (`$F{serial_number}` statt `$F{I4202}`). Die Daten liefert das calServer-Backend als berichtsförmiges JSON-Paket — die Vorlagen enthalten kein eigenes SQL mehr und funktionieren dadurch unabhängig vom Datenbank-Backend (MySQL, PostgreSQL, MSSQL). Auf der [Downloads-Seite](https://calhelp.github.io/calServer-reports/downloads/) erscheinen sie in der eigenen Kategorie **„APEX · V2 (JSON-Datenquelle)"** (APEX = interner Codename für V2), getrennt von den V1-Vorlagen.
+- **Systemberichte:** Ein paar Berichte erzeugt calServer V2 von sich aus, ohne dass jemand sie aus einem Menü wählt. Für jeden davon gibt es auf jeder Installation eine feste, nicht löschbare Zeile in der Berichtsverwaltung — den Platzhalter, der auf sein Bundle wartet. Welches Bundle wohin gehört:
+
+  | Systembericht | Bundle | Wann calServer ihn erzeugt |
+  |---------------|--------|-----------------------------|
+  | Leihschein | [`LOCATION-JSON-SAMPLE`](LOCATION-JSON-SAMPLE/) | Beim Buchen einer Ausleihe, als Anhang der Leihschein-E-Mail |
+
+  Details: [Systemberichte](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/admin/berichte/systemberichte.md).
 - Bestehende Vorlagen bitte **nicht** auf das V2-Schema-SQL umschreiben — die Strategie und der Migrationspfad sind hier dokumentiert: [Evaluierung: JasperReports-Strategie für calServer V2](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md).
 - Als Übersetzungshilfe zwischen alten Codes und neuen Feldnamen dient weiterhin der [FIELD-NAMES-Report](FIELD-NAMES/) sowie die Mapping-Referenz in der Strategie-Dokumentation.
 


### PR DESCRIPTION
## Hintergrund

calServer V2 legt für **fest zugewiesene Berichte** — solche, die calServer selbst erzeugt, ohne dass jemand sie aus einem Menü wählt — einen unlöschbaren Platzhalter in der Berichtsverwaltung an. Für den Leihschein ist das die Zeile **Leihschein** (Grid `location`, Ordner `locations`). Sie ist auf jeder Installation vorhanden und wartet auf ihr Bundle; hochladen genügt.

Bisher stand nirgends, welches Bundle aus diesem Repository dort hingehört. Zugehöriger PR: calhelp/calServer-yii#3495.

## Änderungen

**`LOCATION-JSON-SAMPLE/README.md`**

- Neuer Abschnitt: Dieses Bundle ist die empfohlene Vorlage für den Systembericht „Leihschein", mit dem Weg dorthin (Administration → Berichtsverwaltung → Master-Reports, Zeile mit Etikett „Systembericht") und dem Hinweis, dass die Mail ohne Anhang rausgeht, solange nichts hochgeladen ist.
- Als Referenz gekennzeichnet, nicht als Vorschrift: Ein eigenes Layout wird auf derselben Zeile genauso hochgeladen.
- **Korrektur:** Der Aktivierungsabschnitt verlangte noch eine Report-Variable `data_contract = location-report`. Das stimmt seit der Auto-Erkennung nicht mehr — ein Bundle ohne `<queryString>` wird als JSON-Bundle erkannt und bekommt den Standard-Contract seines Grids. Die Variable ist nur noch nötig, wenn davon abgewichen werden soll.

**`README.md`**

- Im Abschnitt „Ausblick: calServer V2" eine Tabelle, welches Bundle zu welchem Systembericht gehört und wann calServer ihn erzeugt.

Reine Doku-Änderung — keine JRXML, keine Beispieldaten, keine Skripte berührt.

---
_Generated by [Claude Code](https://claude.ai/code/session_0162bXu5Svt2sZpBBPgE64fr)_