### PR TITLE
feat(ORDER-JSON-SAMPLE): Positionen je Quellauftrag gruppieren (Sammelrechnung)

### DIFF
--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -23,12 +23,12 @@ andere den Auftraggeber. Das Template verzweigt nur noch auf `document.type`.
 | `subreports/positions-delivery.jrxml` | Positionen **ohne Preise** für Lieferscheine (Pos/Beschreibung/Menge/Einheit); wird bei `document.type = delivery_note` automatisch gewählt. Dieselbe Gruppierung |
 | `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz — § 14 UStG-Aufschlüsselung) |
 | `subreports/custom-fields.jrxml` | Zusatzfelder (W41xx); `document.custom_fields_list`-Array via `subDataSource("document.custom_fields_list")` — Label/Wert je konfiguriertem Feld, generisch |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.6), gewöhnlicher Auftrag |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.7), gewöhnlicher Auftrag |
 | `main_reports/sample-data-collective.json` | Beispiel-Datensatz **Sammelrechnung**: Positionen aus zwei Aufträgen, `collective.is_collective = true` |
 | `main_reports/order-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 | `main_reports/order-json-sample-collective_adapter.xml` | Data-Adapter für die Vorschau des Sammelfalls (im Studio umschalten) |
 
-## Contract `order-document` (v1.6)
+## Contract `order-document` (v1.7)
 
 Wurzelobjekt mit `meta`, `document` (Nummer/Datum/Status/**Typ**/Kommentar/
 Rechtstext, `delivery_condition`/`delivery_costs`, `custom_fields` als Objekt
@@ -95,7 +95,7 @@ Zeilen aus (durchgängig `isBlankWhenNull` — es wird nie „null" gedruckt).
 > eindeutig sind. Die exakte V1-Rabatt-Steuer-Arithmetik bei mehreren Steuersätzen
 > ist ein Dual-Run-Abstimmungspunkt (siehe Builder-Doku).
 
-### Sammelrechnung: eine Gruppe statt einer zweiten Templatevariante (v1.5/v1.6)
+### Sammelrechnung: eine Gruppe statt einer zweiten Templatevariante (v1.5/v1.7)
 
 Ein Beleg kann Positionen aus **mehreren Aufträgen** tragen — die
 Sammelrechnung. V1 braucht dafür eine eigene JRXML-Datei
@@ -130,8 +130,9 @@ genauso — das Feld ist dann null.
 Zum Ansehen: `sample-data-collective.json` mit dem Adapter
 `order-json-sample-collective_adapter.xml`.
 
-> **v1.4 → v1.5 → v1.6 (additiv, nicht brechend):** v1.5 bringt `collective`,
-> `positions[].source_order` und `positions[].line_id`; v1.6 ergänzt
+> **v1.4 → v1.7 (additiv, nicht brechend):** v1.5 bringt `collective`,
+> `positions[].source_order` und `positions[].line_id`; v1.6 die
+> Belegwährung (`statistics.currency`); v1.7 ergänzt
 > `source_order.delivery_recipient` (der Subreport kommt während der Iteration
 > über `positions` nicht an `collective.source_orders` heran). Bestehende
 > Bindungen bleiben unverändert.

--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -19,14 +19,16 @@ andere den Auftraggeber. Das Template verzweigt nur noch auf `document.type`.
 | Datei | Zweck |
 |-------|-------|
 | `main_reports/order-json-sample.jrxml` | Hauptbericht: Absenderzeile + Briefkopf (`recipient` je Dokumenttyp, Meta-Box Belegnummer/Datum/Kunde/Kontakt/Lieferbedingung/-kosten), abweichende Liefer-/Rechnungsadresse als Info-Block, typabhängiger Betreff, Positionstabelle + Statistik + Zusatzfelder, Rechnungs-/Lieferschein-Spezifika, Fußzeile mit Firmen-/Steuer-/Bankangaben. Alle Labels als `staticText` |
-| `subreports/positions.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` (Pos/Beschreibung/Menge/Einzelpreis/Rabatt/Betrag/MwSt) |
-| `subreports/positions-delivery.jrxml` | Positionen **ohne Preise** für Lieferscheine (Pos/Beschreibung/Menge/Einheit); wird bei `document.type = delivery_note` automatisch gewählt |
+| `subreports/positions.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` (Pos/Beschreibung/Menge/Einzelpreis/Rabatt/Betrag/MwSt). Gruppe `sourceOrder` je Quellauftrag — Kopfzeile nur bei einer Sammelrechnung (s.u.) |
+| `subreports/positions-delivery.jrxml` | Positionen **ohne Preise** für Lieferscheine (Pos/Beschreibung/Menge/Einheit); wird bei `document.type = delivery_note` automatisch gewählt. Dieselbe Gruppierung |
 | `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz — § 14 UStG-Aufschlüsselung) |
 | `subreports/custom-fields.jrxml` | Zusatzfelder (W41xx); `document.custom_fields_list`-Array via `subDataSource("document.custom_fields_list")` — Label/Wert je konfiguriertem Feld, generisch |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.2) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.6), gewöhnlicher Auftrag |
+| `main_reports/sample-data-collective.json` | Beispiel-Datensatz **Sammelrechnung**: Positionen aus zwei Aufträgen, `collective.is_collective = true` |
 | `main_reports/order-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+| `main_reports/order-json-sample-collective_adapter.xml` | Data-Adapter für die Vorschau des Sammelfalls (im Studio umschalten) |
 
-## Contract `order-document` (v1.2)
+## Contract `order-document` (v1.6)
 
 Wurzelobjekt mit `meta`, `document` (Nummer/Datum/Status/**Typ**/Kommentar/
 Rechtstext, `delivery_condition`/`delivery_costs`, `custom_fields` als Objekt
@@ -92,6 +94,47 @@ Zeilen aus (durchgängig `isBlankWhenNull` — es wird nie „null" gedruckt).
 > **Auftragsrabatt (W4114):** Die Muster sind rabattfrei, damit die Summen
 > eindeutig sind. Die exakte V1-Rabatt-Steuer-Arithmetik bei mehreren Steuersätzen
 > ist ein Dual-Run-Abstimmungspunkt (siehe Builder-Doku).
+
+### Sammelrechnung: eine Gruppe statt einer zweiten Templatevariante (v1.5/v1.6)
+
+Ein Beleg kann Positionen aus **mehreren Aufträgen** tragen — die
+Sammelrechnung. V1 braucht dafür eine eigene JRXML-Datei
+(`Angebot_V0.8_Billing_Group.jrxml`), weil dort das SQL im Template steht und
+ein Template kein zweites Join-Muster schalten kann. Beim JSON-Datensatz
+entfällt der Grund: der Server liefert die vereinigten Positionen bereits in
+der richtigen Reihenfolge, und die Gruppe `sourceOrder` im Positions-Subreport
+bricht sie um.
+
+Drei Felder tragen das:
+
+| Feld | Bedeutung |
+|---|---|
+| `collective.is_collective` | true, wenn der Beleg mehrere Aufträge zusammenfasst. Geht als Subreport-Parameter `Is_collective` weiter und schaltet **allein** die Gruppenkopfzeile |
+| `positions[].source_order` | `{id, number, delivery_recipient}` — **immer** gesetzt, beim gewöhnlichen Auftrag auf ihn selbst. Deshalb braucht die Gruppe keine Fallunterscheidung |
+| `collective.source_orders[]` | Kopfblock: je Quellauftrag Nummer, Datum, Auftraggeber, Warenempfänger, Positionsanzahl und Netto. Leer, wenn nichts zusammengefasst wird |
+
+Die Kopfzeile druckt „Auftrag &lt;Nummer&gt;" und rechts den **Warenempfänger**
+des Quellauftrags — dieselbe Information, mit der V1 seine Gruppen beschriftet
+(„Lieferung: …"). Das ist der Anwendungsfall der Sammelrechnung: ein
+Rechnungsempfänger, mehrere Warenempfänger.
+
+Die Positionsnummer bleibt die **auftragsbezogene** (`pos_number`) und läuft je
+Gruppe von vorn. Der belegweit eindeutige Zeilenbezeichner `line_id`
+(EN 16931 BT-126) wird nicht gedruckt — er ist für die E-Rechnung da.
+
+**Für einen gewöhnlichen Auftrag ändert sich nichts:** `is_collective` ist
+false, das Band wird übersprungen, das Layout bleibt Zeile für Zeile das
+bisherige. Ein Datensatz älteren Contracts (ohne `collective`) verhält sich
+genauso — das Feld ist dann null.
+
+Zum Ansehen: `sample-data-collective.json` mit dem Adapter
+`order-json-sample-collective_adapter.xml`.
+
+> **v1.4 → v1.5 → v1.6 (additiv, nicht brechend):** v1.5 bringt `collective`,
+> `positions[].source_order` und `positions[].line_id`; v1.6 ergänzt
+> `source_order.delivery_recipient` (der Subreport kommt während der Iteration
+> über `positions` nicht an `collective.source_orders` heran). Bestehende
+> Bindungen bleiben unverändert.
 
 ## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
 

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample-collective_adapter.xml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample-collective_adapter.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the COLLECTIVE order-document sample
+  (Sammelrechnung: Positionen aus zwei Auftraegen, collective.is_collective =
+  true). Zum Pruefen der Gruppenkopfzeile je Quellauftrag in der Vorschau —
+  im Studio unter "Data Adapter" auswaehlen statt des Standard-Adapters.
+
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Order Document JSON Sample — Sammelrechnung (sample-data-collective.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data-collective.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 order document, ADR-009 contract "order-document" v1.2. ONE template for all
+  V2 order document, ADR-009 contract "order-document" v1.5. ONE template for all
   status-dependent document types: the server derives document.type from the
   booking status (offer / order_confirmation / delivery_note / invoice — V1
   status groups) and pre-resolves the letter-head "recipient" for that type
@@ -18,6 +18,13 @@
     (statistics.tax_groups), service-date note, payment terms;
   - offer / order confirmation: full price table + totals, status-specific
     description text (booking_offer/…_report_description).
+
+  Sammelrechnung (v1.5): der Beleg kann Positionen aus mehreren Auftraegen
+  tragen. Das Flag collective.is_collective geht als Parameter Is_collective an
+  den Positions-Subreport; nur dort entscheidet es, ob die Tabelle je
+  Quellauftrag eine Gruppenkopfzeile bekommt. Ein gewoehnlicher Auftrag setzt es
+  auf false und sieht unveraendert aus. V1 braucht dafuer eine zweite
+  Templatevariante (Angebot_V0.8_Billing_Group.jrxml) — hier reicht die Gruppe.
 
   Filled from a JSON data source — NO SQL, NO V1 code columns. Positions and the
   per-tax-rate statistics are pre-aggregated server-side (OrderDocumentDataBuilder);
@@ -46,6 +53,14 @@
 	<field name="doc_type_label" class="java.lang.String"><fieldDescription><![CDATA[document.type_label]]></fieldDescription></field>
 	<field name="doc_comment" class="java.lang.String"><fieldDescription><![CDATA[document.comment]]></fieldDescription></field>
 	<field name="doc_description" class="java.lang.String"><fieldDescription><![CDATA[document.description]]></fieldDescription></field>
+	<!--
+	  Sammelrechnung (Contract v1.5): true, wenn der Beleg Positionen aus MEHREREN
+	  Auftraegen zusammenfasst. Wird an die Positions-Subreports durchgereicht;
+	  nur dort entscheidet es, ob die Gruppenkopfzeile je Quellauftrag druckt.
+	  Bei einem Datensatz aelteren Contracts fehlt das Feld und bleibt null —
+	  der Beleg sieht dann aus wie bisher.
+	-->
+	<field name="collective_is" class="java.lang.Boolean"><fieldDescription><![CDATA[collective.is_collective]]></fieldDescription></field>
 	<field name="rcpt_name" class="java.lang.String"><fieldDescription><![CDATA[recipient.name]]></fieldDescription></field>
 	<field name="rcpt_street" class="java.lang.String"><fieldDescription><![CDATA[recipient.street]]></fieldDescription></field>
 	<field name="rcpt_zip" class="java.lang.String"><fieldDescription><![CDATA[recipient.zip]]></fieldDescription></field>
@@ -149,6 +164,7 @@
 		<band height="230">
 			<subreport>
 				<reportElement positionType="Float" x="0" y="0" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Is_collective"><subreportParameterExpression><![CDATA[$F{collective_is}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + ("delivery_note".equals($F{doc_type}) ? "/subreports/positions-delivery.jasper" : "/subreports/positions.jasper")]]></subreportExpression>
 			</subreport>

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data-collective.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data-collective.json
@@ -6,7 +6,7 @@
     "locale": "de-DE"
   },
   "document": {
-    "number": "AU-2026-0042",
+    "number": "SR-2026-0001",
     "date": "2026-07-15",
     "status": "Auftrag",
     "type": "order_confirmation",
@@ -107,9 +107,40 @@
     }
   },
   "collective": {
-    "is_collective": false,
+    "is_collective": true,
     "invoice_order_id": "b1a7c0de-0000-4000-a000-000000000001",
-    "source_orders": []
+    "source_orders": [
+      {
+        "id": "b1a7c0de-0000-4000-a000-000000000001",
+        "number": "SR-2026-0001",
+        "date": "2026-07-15",
+        "customer": {
+          "name": "Muster GmbH",
+          "customer_number": "K-1001"
+        },
+        "delivery_recipient": {
+          "name": "Muster GmbH – Wareneingang",
+          "customer_number": "K-1001-L"
+        },
+        "position_count": 2,
+        "line_net": 245.0
+      },
+      {
+        "id": "b1a7c0de-0000-4000-a000-000000000042",
+        "number": "AU-2026-0042",
+        "date": "2026-07-02",
+        "customer": {
+          "name": "Muster GmbH",
+          "customer_number": "K-1001"
+        },
+        "delivery_recipient": {
+          "name": "Werk Nord GmbH",
+          "customer_number": "KD-0009"
+        },
+        "position_count": 1,
+        "line_net": 80.0
+      }
+    ]
   },
   "positions": [
     {
@@ -125,7 +156,7 @@
       "line_net": 200.0,
       "source_order": {
         "id": "b1a7c0de-0000-4000-a000-000000000001",
-        "number": "AU-2026-0042",
+        "number": "SR-2026-0001",
         "delivery_recipient": "Muster GmbH – Wareneingang"
       }
     },
@@ -142,8 +173,25 @@
       "line_net": 45.0,
       "source_order": {
         "id": "b1a7c0de-0000-4000-a000-000000000001",
-        "number": "AU-2026-0042",
+        "number": "SR-2026-0001",
         "delivery_recipient": "Muster GmbH – Wareneingang"
+      }
+    },
+    {
+      "line_id": 3,
+      "pos_number": 1,
+      "name": "Kalibrierung Widerstand",
+      "article_type": "article",
+      "quantity": 1,
+      "unit": "Stk",
+      "price": 80.0,
+      "discount": 0.0,
+      "tax": 19.0,
+      "line_net": 80.0,
+      "source_order": {
+        "id": "b1a7c0de-0000-4000-a000-000000000042",
+        "number": "AU-2026-0042",
+        "delivery_recipient": "Werk Nord GmbH"
       }
     }
   ],
@@ -159,20 +207,20 @@
       },
       {
         "rate": 19,
-        "line_net": 200,
+        "line_net": 280,
         "allowance": 0,
         "charge": 0,
-        "net": 200,
-        "vat": 38
+        "net": 280,
+        "vat": 53.2
       }
     ],
-    "net_total": 245,
+    "net_total": 325,
     "order_discount_percent": 0,
     "discount_amount": 0,
-    "net_after_discount": 245,
+    "net_after_discount": 325,
     "charge_total": 0,
-    "net_taxable": 245,
-    "vat_total": 41.15,
-    "gross_total": 286.15
+    "net_taxable": 325,
+    "vat_total": 56.35,
+    "gross_total": 381.35
   }
 }

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data-collective.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data-collective.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "order-document",
-    "schema_version": "1.6",
+    "schema_version": "1.7",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE"
   },
@@ -221,6 +221,7 @@
     "charge_total": 0,
     "net_taxable": 325,
     "vat_total": 56.35,
-    "gross_total": 381.35
+    "gross_total": 381.35,
+    "currency": "EUR"
   }
 }

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "order-document",
-    "schema_version": "1.6",
+    "schema_version": "1.7",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE"
   },
@@ -173,6 +173,7 @@
     "charge_total": 0,
     "net_taxable": 245,
     "vat_total": 41.15,
-    "gross_total": 286.15
+    "gross_total": 286.15,
+    "currency": "EUR"
   }
 }

--- a/ORDER-JSON-SAMPLE/subreports/positions-delivery.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions-delivery.jrxml
@@ -2,17 +2,39 @@
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
   V2 order positions subreport, delivery-note variant (contract order-document
-  v1.2): fed the "positions" array via subDataSource("positions"). A Lieferschein
+  v1.5): fed the "positions" array via subDataSource("positions"). A Lieferschein
   carries no prices — only position, description, quantity and unit. Column
   geometry matches the delivery header frame of order-json-sample.jrxml.
   No $V{} variables.
+
+  Gruppierung wie in `positions.jrxml`: fasst der Beleg mehrere Auftraege
+  zusammen, bricht die Gruppe `sourceOrder` die Tabelle je Quellauftrag um. Fuer
+  einen Sammel-Lieferschein ist das noch wichtiger als fuer die Rechnung — wer
+  die Ware annimmt, muss sehen, welche Zeilen zu welchem Auftrag gehoeren.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0304-4d64-9f54-000000000304">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Is_collective" class="java.lang.Boolean">
+		<parameterDescription><![CDATA[true = der Beleg fasst mehrere Auftraege zusammen; nur dann druckt die Gruppenkopfzeile je Quellauftrag. Wird vom Hauptbericht aus collective.is_collective gesetzt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[Boolean.FALSE]]></defaultValueExpression>
+	</parameter>
 	<field name="pos_number" class="java.lang.Integer"><fieldDescription><![CDATA[pos_number]]></fieldDescription></field>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
 	<field name="quantity" class="java.lang.Double"><fieldDescription><![CDATA[quantity]]></fieldDescription></field>
 	<field name="unit" class="java.lang.String"><fieldDescription><![CDATA[unit]]></fieldDescription></field>
+	<field name="source_order_number" class="java.lang.String"><fieldDescription><![CDATA[source_order.number]]></fieldDescription></field>
+	<field name="source_order_recipient" class="java.lang.String"><fieldDescription><![CDATA[source_order.delivery_recipient]]></fieldDescription></field>
+	<group name="sourceOrder" isReprintHeaderOnEachPage="true">
+		<groupExpression><![CDATA[$F{source_order_number}]]></groupExpression>
+		<groupHeader>
+			<band height="20">
+				<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{Is_collective})]]></printWhenExpression>
+				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="280" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement x="280" y="4" width="281" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
+				<line><reportElement x="0" y="18" width="561" height="1"/></line>
+			</band>
+		</groupHeader>
+	</group>
 	<detail>
 		<band height="15">
 			<textField isBlankWhenNull="true"><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>

--- a/ORDER-JSON-SAMPLE/subreports/positions.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions.jrxml
@@ -1,12 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 order positions subreport (contract order-document v1.0): fed the "positions"
+  V2 order positions subreport (contract order-document v1.5): fed the "positions"
   array via subDataSource("positions"). One row per line item; the pre-computed
   line_net is printed as-is (no running-sum in Jasper). No $V{} variables.
+
+  Sammelrechnung (v1.5): der Beleg kann Positionen aus MEHREREN Auftraegen
+  tragen. Jede Position nennt deshalb ihren Quellauftrag in `source_order` —
+  auch beim gewoehnlichen Auftrag, dann auf ihn selbst. Die Gruppe `sourceOrder`
+  bricht die Tabelle danach um; ihr Kopf druckt nur, wenn der Hauptbericht den
+  Parameter `Is_collective` auf true setzt (`collective.is_collective`). Bei
+  einem gewoehnlichen Auftrag gibt es also genau eine Gruppe OHNE Kopfzeile, und
+  das Layout bleibt Zeile fuer Zeile das bisherige.
+
+  Warum die Gruppe und nicht zwei Templates: V1 braucht dafuer eine zweite
+  JRXML-Variante (`Angebot_V0.8_Billing_Group.jrxml`), weil das SQL im Template
+  steht und ein Template kein zweites Join-Muster schalten kann. Beim
+  JSON-Datensatz entfaellt der Grund.
+
+  Die Positionsnummer bleibt die AUFTRAGSBEZOGENE (`pos_number`) — sie laeuft je
+  Quellauftrag von vorn, was innerhalb einer Gruppe richtig ist. Der belegweit
+  eindeutige Zeilenbezeichner `line_id` (EN 16931 BT-126) wird nicht gedruckt; er
+  ist fuer die E-Rechnung da, nicht fuer das Papier.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0301-4d61-9f51-000000000301">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Is_collective" class="java.lang.Boolean">
+		<parameterDescription><![CDATA[true = der Beleg fasst mehrere Auftraege zusammen; nur dann druckt die Gruppenkopfzeile je Quellauftrag. Wird vom Hauptbericht aus collective.is_collective gesetzt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[Boolean.FALSE]]></defaultValueExpression>
+	</parameter>
 	<field name="pos_number" class="java.lang.Integer"><fieldDescription><![CDATA[pos_number]]></fieldDescription></field>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
 	<field name="quantity" class="java.lang.Double"><fieldDescription><![CDATA[quantity]]></fieldDescription></field>
@@ -15,6 +37,29 @@
 	<field name="discount" class="java.lang.Double"><fieldDescription><![CDATA[discount]]></fieldDescription></field>
 	<field name="line_net" class="java.lang.Double"><fieldDescription><![CDATA[line_net]]></fieldDescription></field>
 	<field name="tax" class="java.lang.Double"><fieldDescription><![CDATA[tax]]></fieldDescription></field>
+	<field name="source_order_number" class="java.lang.String"><fieldDescription><![CDATA[source_order.number]]></fieldDescription></field>
+	<field name="source_order_recipient" class="java.lang.String"><fieldDescription><![CDATA[source_order.delivery_recipient]]></fieldDescription></field>
+	<!--
+	  Gruppe je Quellauftrag. isReprintHeaderOnEachPage: nach einem Seitenumbruch
+	  muss wieder dastehen, zu welchem Auftrag die folgenden Zeilen gehoeren —
+	  sonst steht die Fortsetzung ohne Bezug da.
+	-->
+	<group name="sourceOrder" isReprintHeaderOnEachPage="true">
+		<groupExpression><![CDATA[$F{source_order_number}]]></groupExpression>
+		<groupHeader>
+			<band height="20">
+				<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{Is_collective})]]></printWhenExpression>
+				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="280" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
+				<!-- Der Warenempfaenger des Quellauftrags: V1 beschriftet seine
+				     Gruppen genau damit ("Lieferung: …"), und das ist der Fall,
+				     fuer den es die Sammelrechnung gibt — ein Rechnungsempfaenger,
+				     mehrere Warenempfaenger. Fehlt er (Contract < 1.6 oder kein
+				     abweichender Lieferkunde), bleibt die Zeile leer. -->
+				<textField isBlankWhenNull="true"><reportElement x="280" y="4" width="281" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
+				<line><reportElement x="0" y="18" width="561" height="1"/></line>
+			</band>
+		</groupHeader>
+	</group>
 	<detail>
 		<band height="15">
 			<textField><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>

--- a/ORDER-JSON-SAMPLE/subreports/positions.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions.jrxml
@@ -53,7 +53,7 @@
 				<!-- Der Warenempfaenger des Quellauftrags: V1 beschriftet seine
 				     Gruppen genau damit ("Lieferung: …"), und das ist der Fall,
 				     fuer den es die Sammelrechnung gibt — ein Rechnungsempfaenger,
-				     mehrere Warenempfaenger. Fehlt er (Contract < 1.6 oder kein
+				     mehrere Warenempfaenger. Fehlt er (Contract < 1.7 oder kein
 				     abweichender Lieferkunde), bleibt die Zeile leer. -->
 				<textField isBlankWhenNull="true"><reportElement x="280" y="4" width="281" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
 				<line><reportElement x="0" y="18" width="561" height="1"/></line>


### PR DESCRIPTION
Ein Auftragsbeleg kann Positionen aus **mehreren Aufträgen** tragen — die Sammelrechnung. Der Server liefert sie seit Contract v1.5 vereinigt und in V1s Reihenfolge ([calServer-yii#3512](https://github.com/calhelp/calServer-yii/pull/3512)); das Template druckte sie bisher als eine flache Liste, ohne erkennbar zu machen, welche Zeile zu welchem Auftrag gehört.

## Was drin ist

**Die Gruppe `sourceOrder`** in beiden Positions-Subreports. Ihre Kopfzeile druckt „Auftrag &lt;Nummer&gt;" und rechts den Warenempfänger des Quellauftrags — dieselbe Information, mit der V1 seine Gruppen beschriftet („Lieferung: …"), und der eigentliche Anwendungsfall: ein Rechnungsempfänger, mehrere Warenempfänger.

**Geschaltet wird sie allein über den Subreport-Parameter `Is_collective`**, den der Hauptbericht aus `collective.is_collective` durchreicht. Ein gewöhnlicher Auftrag setzt ihn auf false, das Band wird übersprungen, das Layout bleibt Zeile für Zeile das bisherige. Ein Datensatz älteren Contracts verhält sich genauso (Feld null).

Damit entfällt der Grund für V1s zweite Templatevariante `Angebot_V0.8_Billing_Group.jrxml`: dort steht das SQL im Template und kann kein zweites Join-Muster schalten — hier reicht eine Gruppe mit bedingtem Kopf.

**Der Lieferschein-Zweig** (`positions-delivery`) bekommt dieselbe Gruppierung. Für einen Sammel-Lieferschein ist sie noch wichtiger als für die Rechnung: wer die Ware annimmt, muss die Zuordnung sehen.

`isReprintHeaderOnEachPage` sorgt dafür, dass nach einem Seitenumbruch wieder dasteht, zu welchem Auftrag die folgenden Zeilen gehören.

## Beispieldaten

- **`sample-data.json` auf Contract 1.7 nachgezogen.** Die Datei stand noch auf **1.2** und war damit als Feldreferenz veraltet: es fehlten die 1.4-Statistikfelder (`tax_groups[].line_net/allowance/charge`, `charge_total`, `net_taxable`), die 1.6-Belegwährung sowie `line_id` und `source_order`. Die Struktur ist jetzt aus dem echten `OrderDocumentDataBuilder` erzeugt, nicht von Hand geschrieben; die lesbaren Beispielinhalte sind geblieben.
- **`sample-data-collective.json` neu**, mit eigenem Studio-Adapter: zwei Quellaufträge, damit sich die Gruppierung in der Vorschau ansehen lässt.

## Geprüft

Nicht nur kompiliert, sondern **gerendert** — gegen JasperReports mit JSON-Datenquelle, beide Fälle:

*Gewöhnlicher Auftrag* (unverändert):
```
Pos   Beschreibung                       Menge  Einzelpreis  Rabatt     Betrag  MwSt
1     Kalibrierung Gleichspannung      2  Stk      100.00 €     0 %   200.00 €  19 %
2     Versand                          1  Stk       50.00 €    10 %    45.00 €   7 %
```

*Sammelrechnung*:
```
Pos   Beschreibung                       Menge  Einzelpreis  Rabatt     Betrag  MwSt
Auftrag SR-2026-0001                          Lieferung: Muster GmbH – Wareneingang
1     Kalibrierung Gleichspannung      2  Stk      100.00 €     0 %   200.00 €  19 %
2     Versand                          1  Stk       50.00 €    10 %    45.00 €   7 %
Auftrag AU-2026-0042                                      Lieferung: Werk Nord GmbH
1     Kalibrierung Widerstand          1  Stk       80.00 €     0 %    80.00 €  19 %
```

Summen: 325,00 netto statt 245,00, USt. je Satz korrekt aufgeteilt (45,00 @ 7 % und 280,00 @ 19 %), Gesamtbetrag 381,35. Der Lieferschein-Zweig gruppiert ebenso, ohne Preise.

Die Positionsnummer bleibt die **auftragsbezogene** (`pos_number`) und läuft je Gruppe von vorn — wie in V1. Der belegweit eindeutige `line_id` (EN 16931 BT-126) wird nicht gedruckt, er ist für die E-Rechnung da.

CI-Checks lokal grün: `check_jasper_version.sh` und `check_parameters_manifest.py` (die zwei Warnungen dort betreffen `DAKKS-JSON-SAMPLE` und sind vorbestehend).

## Abhängigkeit

`source_order.delivery_recipient` kommt mit **Contract 1.7** ([calServer-yii](https://github.com/calhelp/calServer-yii), Branch `claude/sammelrechnung-v2-konzept-jq84dm`). Das Template ist null-sicher: fehlt das Feld, bleibt die rechte Hälfte der Kopfzeile leer und die Auftragsnummer steht trotzdem da. Es läuft also auch gegen einen Server mit Contract 1.5/1.6.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7Uu4zLaMYS9uTs9qvCwTy)_