### PR TITLE
feat(location-json-sample): Prüfmittel-Tabelle als Subreport über devices[]

### DIFF
--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -32,7 +32,8 @@ derselben Zeile genauso hochgeladen.
 | Datei | Zweck |
 |-------|-------|
 | `main_reports/location-json-sample.jrxml` | Hauptbericht: Kopf mit Kunde-/Lieferadresse + Kontakten, Leihdaten-Block, Prüfmittel-Grid, Standortblock (`location_1..5`), Signaturzeilen (Entleiher/Ausgabe), Seiten-Footer |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `location-report` **v1.0**) |
+| `subreports/devices.jrxml` | Prüfmittel-Zeilen, gefüllt aus `devices[]` — eine Zeile je Gerät der Leihe |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `location-report` **v1.1**) |
 | `main_reports/location-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
 
 ## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
@@ -65,6 +66,17 @@ sondern die fehlende Datenanbindung. Abhilfe:
   (Wurzelobjekt).
 - Das Rückgabedatum ist ein konfiguriertes Custom Field und wird unter seinem
   `api_name` gebunden: `location.custom_fields.rental_end`.
+- Das **Prüfmittel-Grid** läuft über `subDataSource("devices")` in
+  `subreports/devices.jrxml`. Ein Set (Koffer) wird als **ein** Objekt
+  verliehen und auf **einem** Schein quittiert, also stehen seine Teile mit
+  darauf. Bis v1.0 band der Hauptbericht eine feste Zeile an `device.*` — der
+  Entleiher unterschrieb für einen Koffer, dessen Inhalt das Papier nicht
+  nannte. `device` bleibt daneben bestehen, damit eine gegen v1.0 geschriebene
+  Vorlage weiterläuft.
+- `location_1..5` und `status` liefern **lesbaren Text**, keine uIDs: Ist ein
+  Standortfeld als `[CURRENT_USER]` konfiguriert, hält die Spalte eine
+  Benutzer-uID — der Bericht bekommt den Namen. Genauso wird der Status-uID zum
+  Status-Titel.
 - Die Lieferadresse (`delivery_customer`) fällt **serverseitig** auf den
   Kunden zurück, wenn kein eigener Lieferkunde hinterlegt ist — das Template
   braucht keine Fallback-Logik.
@@ -77,13 +89,14 @@ Systembericht-Platzhalter (siehe oben). Der Contract wird am Bundle erkannt
 `data_contract` ist nur nötig, wenn davon abgewichen werden soll (Details siehe
 V2-Doku „V2-Berichte mit JSON-Datenquelle").
 
-## Contract `location-report` (v1.0)
+## Contract `location-report` (v1.1)
 
 | Block | Felder |
 |-------|--------|
 | `meta` | `contract`, `schema_version`, `generated_at`, `locale` |
 | `location` | `location_1..5`, `location_date`, `location_time`, `is_active`, `status`, `custom_fields{}` (inkl. `rental_end`, wenn konfiguriert) |
 | `device` | `asset_number`, `serial_number`, `description`, `manufacturer`, `model`, `type_code`, `next_calibration_date`, `custom_fields{}` (`{}` wenn kein Gerät verknüpft) |
+| `devices[]` | **v1.1** — alle Geräte der Leihe, Wurzelgerät zuerst; Felder wie `device`. Bei einer Einzelbuchung genau ein Eintrag. |
 | `customer` | `name`, `customer_number`, `street`, `zip`, `city`, `country`, `custom_fields{}` |
 | `customer_contact` | `name`, `street`, `zip`, `city`, `email`, `phone` (`{}` wenn kein Kontakt verknüpft) |
 | `delivery_customer` | wie `customer`; serverseitiger Fallback auf `customer` |

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
@@ -17,6 +17,9 @@
 	<style name="Value" fontSize="9"/>
 	<style name="SectionTitle" fontSize="10" isBold="true"/>
 	<style name="Small" fontSize="8"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
 	<parameter name="Company_footer" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
@@ -116,13 +119,16 @@
 			<staticText><reportElement style="Label" x="210" y="18" width="150" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
 			<staticText><reportElement style="Label" x="360" y="18" width="201" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
 			<line><reportElement x="0" y="32" width="561" height="1"/></line>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="0" y="36" width="100" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="100" y="36" width="110" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
-			<textField>
-				<reportElement style="Small" x="210" y="36" width="150" height="13"/>
-				<textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression>
-			</textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="360" y="36" width="201" height="13"/><textFieldExpression><![CDATA[$F{device_description}]]></textFieldExpression></textField>
+			<!-- Eine Zeile je Gerät der Leihe (Contract v1.1, devices[]): ein
+			     Set wird als ein Objekt verliehen und auf einem Schein
+			     quittiert, also gehören seine Teile auf das Papier. Das
+			     Wurzelgerät steht zuerst; bei einer Einzelbuchung bleibt es
+			     bei dieser einen Zeile. -->
+			<subreport>
+				<reportElement positionType="Float" x="0" y="36" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("devices")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/devices.jasper"]]></subreportExpression>
+			</subreport>
 			<staticText><reportElement style="SectionTitle" positionType="Float" x="0" y="62" width="561" height="14"/><text><![CDATA[Standort]]></text></staticText>
 			<staticText><reportElement style="Label" positionType="Float" x="0" y="80" width="130" height="13"/><text><![CDATA[Standort 1]]></text></staticText>
 			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="80" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_1}]]></textFieldExpression></textField>

--- a/LOCATION-JSON-SAMPLE/main_reports/sample-data.json
+++ b/LOCATION-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "location-report",
-    "schema_version": "1.0",
+    "schema_version": "1.1",
     "generated_at": "2026-07-16T10:00:00+00:00",
     "locale": "de-DE"
   },
@@ -15,7 +15,9 @@
     "location_time": "08:00:00",
     "is_active": 1,
     "status": "verliehen",
-    "custom_fields": { "rental_end": "2026-09-30" }
+    "custom_fields": {
+      "rental_end": "2026-09-30"
+    }
   },
   "device": {
     "asset_number": "INV-9001",
@@ -27,6 +29,48 @@
     "next_calibration_date": "2027-06-30",
     "custom_fields": {}
   },
+  "devices": [
+    {
+      "asset_number": "INV-9001",
+      "serial_number": "SN-12345",
+      "description": "Digitalmultimeter Fluke 87V",
+      "manufacturer": "Fluke",
+      "model": "87V",
+      "type_code": "DMM",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    },
+    {
+      "asset_number": "INV-9002",
+      "serial_number": "SN-22450",
+      "description": "Kalibrator Fluke 5522A",
+      "manufacturer": "Fluke",
+      "model": "5522A",
+      "type_code": "CALSTD",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    },
+    {
+      "asset_number": "INV-9003",
+      "serial_number": "SN-33110",
+      "description": "Isolationsmessgerät",
+      "manufacturer": "Fluke",
+      "model": "1507",
+      "type_code": "ISO",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    },
+    {
+      "asset_number": "INV-9004",
+      "serial_number": "SN-44870",
+      "description": "Klemmzange",
+      "manufacturer": "Keysight",
+      "model": "U1194A",
+      "type_code": "CLM",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    }
+  ],
   "customer": {
     "name": "Muster GmbH",
     "customer_number": "K-1001",

--- a/LOCATION-JSON-SAMPLE/parameters.json
+++ b/LOCATION-JSON-SAMPLE/parameters.json
@@ -18,6 +18,18 @@
       "required": false,
       "group": "Layout",
       "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer."
+      },
+      "role": "system"
     }
   ]
 }

--- a/LOCATION-JSON-SAMPLE/subreports/devices.jrxml
+++ b/LOCATION-JSON-SAMPLE/subreports/devices.jrxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 Prüfmittel-Subreport (Contract location-report v1.1): bekommt das
+  "devices"-Array über subDataSource("devices").
+
+  Eine Leihe kann mehr als ein Gerät umfassen: Ein Set (Koffer) wird als ein
+  Objekt verliehen und auf einem Schein quittiert. Vorher band der Hauptbericht
+  eine feste Zeile an device.*, der Entleiher unterschrieb also für einen
+  Koffer, dessen Inhalt auf dem Papier nicht stand.
+
+  Das Wurzelgerät steht immer an erster Stelle; bei einer Einzelbuchung enthält
+  die Liste nur dieses eine. Keine $V{}-Variablen.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Small" fontSize="8"/>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[asset_number]]></fieldDescription></field>
+	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[serial_number]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[model]]></fieldDescription></field>
+	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[description]]></fieldDescription></field>
+	<detail>
+		<band height="15">
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="0" y="0" width="100" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="100" y="0" width="110" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="210" y="0" width="150" height="13"/><textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="360" y="0" width="201" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
Ein Set (Koffer) wird als **ein** Objekt verliehen und auf **einem** Schein quittiert. Bis v1.0 band der Hauptbericht eine feste Zeile an `device.*` — der Entleiher unterschrieb also für einen Koffer, dessen Inhalt das Papier nicht nannte.

Die feste Zeile weicht einem Subreport auf `subDataSource("devices")`: eine Zeile je Gerät der Leihe, Wurzelgerät zuerst. Bei einer Einzelbuchung ist das genau ein Eintrag, das Layout bleibt also unverändert.

## Was drin ist

| Datei | Änderung |
|-------|----------|
| `subreports/devices.jrxml` | **neu** — Inventarnummer, Seriennummer, Hersteller, Modell, Bezeichnung; eine Detail-Band-Zeile |
| `main_reports/location-json-sample.jrxml` | feste Gerätezeile → `<subreport>` mit `positionType="Float"` und `isRemoveLineWhenBlank`; dazu der im Bundle bisher **fehlende** Parameter `Reportpath` |
| `parameters.json` | `Reportpath` mit `"role": "system"` nachgetragen, wie in `DELIVERY-JSON-SAMPLE` |
| `main_reports/sample-data.json` | Contract-Version 1.1, `devices[]` mit vier Einträgen direkt hinter `device` |
| `README.md` | Dateitabelle, Contract-Tabelle (v1.1, `devices[]`), Hinweise zur Datenanbindung |

Der fehlende `Reportpath` ist dabei kein Nebenprodukt, sondern Voraussetzung: ohne ihn kann `$P{Reportpath} + "/subreports/devices.jasper"` nicht auflösen.

`device` bleibt im Contract neben `devices[]` bestehen, damit eine gegen v1.0 geschriebene Vorlage weiterläuft.

## Backend-Seite

`LocationReportDataBuilder` in **calhelp/calServer-yii** liefert `devices[]` ab Schema 1.1. Für eine gebuchte Leihe kommen die Teile aus der protokollierten Set-Mitgliedschaft (`reservation_set_items`), nicht aus der Gerätehierarchie — ein Koffer darf auch allein verliehen werden.

## Prüfstand

Lokal grün: `scripts/check_parameters_manifest.py` („7 Parameter-Manifest(e) geprüft, keine Fehler") und `scripts/check_jasper_version.sh` („All JRXML files use JasperReports Library version 6.20.6"). XML-Wohlgeformtheit beider JRXMLs über `xml.dom.minidom` geprüft.

**Nicht geprüft:** ein echter Render. In dieser Umgebung steht kein JasperReports zur Verfügung, das Bundle wurde also nicht kompiliert und nicht ausgegeben. Die pixelgenaue Abnahme über den report-runner bleibt wie gehabt maßgeblich — insbesondere der vertikale Umbruch, wenn `devices[]` über eine Seite hinauswächst.

---
_Generated by [Claude Code](https://claude.ai/code/session_0162bXu5Svt2sZpBBPgE64fr)_