### PR TITLE
feat: Preislisten-Vorlage (PRICE-LIST-JSON-SAMPLE)

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/README.md
+++ b/PRICE-LIST-JSON-SAMPLE/README.md
@@ -1,0 +1,94 @@
+# PRICE-LIST-JSON-SAMPLE — Preisliste (V2)
+
+Die **Preisliste**, wie ein Labor sie seinem Kunden übergibt: Kategoriebaum mit
+den geltenden Kalibrierpreisen (Typausnahmen eingerückt), Zusatzleistungen mit
+Mengenstaffel, Standardartikel und die Konditions-Fußnoten. Gefüllt aus einem
+**JSON-Datensatz** (Contract `price-list` v1.0) statt aus SQL — DB-agnostisch,
+keine V1-Codespalten.
+
+## Der Briefkopf steht nicht in dieser Vorlage
+
+Das ist der Punkt der Vorlage, nicht eine Lücke. Der Briefkopf kommt **je
+Mandant** über das PDF-Overlay des Berichtswesens; die Vorlage hält dafür oben
+im Titelband **128 pt (≈ 45 mm)** frei und druckt dort selbst nichts.
+
+Eine fest eingebaute Absenderzeile wäre für jeden zweiten Mandanten falsch und
+ließe sich nicht wegkonfigurieren, ohne die Vorlage zu ändern. Der Freiraum ist
+bewusst **fest** und kein Parameter: eine Berichtsvariable könnte die
+Bandgeometrie zur Laufzeit gar nicht verschieben, sie sähe nur so aus. Wer mehr
+oder weniger Platz braucht, ändert die Bandhöhe und die y-Werte darunter — das
+ist ein Layout-Eingriff und gehört in die Vorlage.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/price-list-json-sample.jrxml` | Hauptbericht: Briefkopf-Freiraum, Kopf (Titel, Preisgruppe, Stichtag, Währung, Ableitungsregel), Abschnittsüberschriften, Fußzeile |
+| `subreports/price-list-categories.jrxml` | Kategoriebaum aus `list.calibration`; Obergruppen fett, Untergruppen eingerückt |
+| `subreports/price-list-exceptions.jrxml` | Typausnahmen einer Kategorie (`exceptions`) — die einzige zweistufige Stelle des Bündels |
+| `subreports/price-list-services.jrxml` | Zusatzleistungen aus `list.services` |
+| `subreports/price-list-scales.jrxml` | Mengenstaffel einer Zeile (`scales`), als Kondition unter dem Betrag |
+| `subreports/price-list-articles.jrxml` | Standardartikel aus `list.articles` |
+| `subreports/price-list-surcharges.jrxml` | Konditions-Fußnoten aus `list.surcharges` |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.0) |
+| `main_reports/price-list-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Contract `price-list` (v1.0)
+
+Dataset-Builder: Laravel `PriceListReportDataBuilder`; derselbe Aufbau, den die
+Preislisten-Seite liest (`PriceListService`). Datensatz zum Vorlagenbau:
+`GET /api/v2/price-list/reports/dataset`.
+
+Der Umschlag trägt `meta` (Contract, Schema-Version, Erzeugungszeit, Locale) und
+`list` mit `group`, `date`, `currency`, `derivation`, `surcharges[]`,
+`calibration[]` (je Kategorie `number`, `name`, `depth`, `amount`, `derived`,
+`inherited_from`, `exceptions[]`, `scales[]`), `services[]`, `articles[]` und
+`counts`.
+
+Zwei Feinheiten, die man beim Lesen des Datensatzes leicht übersieht:
+
+- **Eine Kategorie ohne Betrag ist eine Überschrift, keine Lücke.** Sie bündelt
+  ihre Untergruppen. Die Vorlage druckt dort nichts, nicht „0,00".
+- **`derived` heißt abgeleitet, nicht geschätzt.** Der Betrag entsteht aus der
+  Kondition der Preisgruppe auf dem Listenpreis; er ist so verbindlich wie ein
+  eingetragener.
+
+### Bewusst nicht gedruckt
+
+`list.other_type_prices` — die bei 200 gekappte Liste der Typpreise **ohne**
+Kategorie. Das ist ein Übergangsbestand auf dem Weg zur Kategorisierung, kein
+Bestandteil einer Kundenliste; eine willkürlich abgeschnittene Aufzählung
+gehört nicht auf ein Dokument, das man aus der Hand gibt. Wer sie braucht,
+nimmt den CSV-Export der Preislisten-Seite.
+
+## Zahlenformat folgt der Locale
+
+Beträge stehen mit `pattern="#,##0.00"` und werden über `REPORT_LOCALE`
+formatiert, das calServer je Mandant setzt — `de-DE` ergibt `84,15`, `en-US`
+ergibt `84.15`. In Jaspersoft Studio ohne gesetzte Locale zeigt die Vorschau das
+Format des Rechners; das ist kein Vorlagenfehler.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle bleibt die Seite leer bzw. bricht auf `subDataSource(...)`
+ab. Vorschau: mitgelieferter Adapter (Default über
+`com.jaspersoft.studio.data.defadapter`) → „Open → Preview". Live (calServer V2):
+Report-Setting-Variable `data_contract = price-list`. JasperReports **6.20.6**
+verbindlich.
+
+## Parameter-Katalog (`parameters.json`)
+
+| Parameter | Rolle | Wirkung |
+|-----------|-------|---------|
+| `List_title` | variable (type) | Überschrift des Dokuments; Vorgabe „Preisliste". |
+| `Company_footer` | variable (type) | Optionale Fußzeile auf jeder Seite. Leer lassen, wenn der Briefkopf schon eine mitbringt. |
+| `Reportpath` | system | Bundle-Wurzel für die Subreport-Auflösung, von calServer gesetzt. |
+
+## Geprüft
+
+Alle sieben JRXML übersetzen mit JasperReports 6.20.6, und der Hauptbericht
+füllt gegen `sample-data.json` durch (eine Seite). Geprüft wurde dabei auch,
+dass die zweistufige Auflösung `subDataSource("exceptions")` innerhalb des
+Kategorie-Subreports wirklich greift — die Typausnahme erscheint eingerückt
+unter ihrer Kategorie. Die pixelgenaue Abnahme des Layouts (report-runner)
+bleibt wie gehabt maßgeblich.

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 Preisliste (customer-facing), Contract "price-list" v1.0. Gefüllt aus einem
+  JSON-Datensatz — kein SQL, keine V1-Codespalten.
+
+  DER BRIEFKOPF STEHT NICHT IN DIESER VORLAGE. Er kommt je Mandant über das
+  PDF-Overlay des Berichtswesens; deshalb hält das Titelband oben 128 pt
+  (≈ 45 mm) frei, statt eine Absenderzeile fest einzubauen. Eine hier
+  eingebaute Adresse wäre für jeden zweiten Mandanten falsch — und ließe sich
+  nicht wegkonfigurieren, ohne die Vorlage zu ändern.
+
+  Aufbau: Kopf (Titel, Preisgruppe, Stichtag, Währung, Ableitungsregel) →
+  Kalibrierpreise (Kategoriebaum mit Typausnahmen) → Zusatzleistungen →
+  Standardartikel → Konditions-Fußnoten. Alle Abschnitte verschwinden
+  vollständig, wenn ihr Array leer ist.
+
+  Bewusst NICHT gedruckt: `list.other_type_prices`. Das ist die gekappte Liste
+  der Typpreise ohne Kategorie (Obergrenze 200) — ein Übergangsbestand auf dem
+  Weg zur Kategorisierung, kein Bestandteil einer Kundenliste. Wer sie braucht,
+  nimmt den CSV-Export.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="a1b2c3d4-0000-4000-8000-000000000000">
+	<property name="com.jaspersoft.studio.data.defadapter" value="price-list-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<style name="Section" fontSize="11" isBold="true"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="List_title" class="java.lang.String">
+		<parameterDescription><![CDATA[Überschrift des Dokuments. Leer = "Preisliste".]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Preisliste"]]></defaultValueExpression>
+	</parameter>
+	<field name="group_name" class="java.lang.String"><fieldDescription><![CDATA[list.group.name]]></fieldDescription></field>
+	<field name="date" class="java.lang.String"><fieldDescription><![CDATA[list.date]]></fieldDescription></field>
+	<field name="currency" class="java.lang.String"><fieldDescription><![CDATA[list.currency]]></fieldDescription></field>
+	<field name="derivation_mode" class="java.lang.String"><fieldDescription><![CDATA[list.derivation.mode]]></fieldDescription></field>
+	<field name="derivation_value" class="java.math.BigDecimal"><fieldDescription><![CDATA[list.derivation.value]]></fieldDescription></field>
+	<field name="count_categories" class="java.lang.Integer"><fieldDescription><![CDATA[list.counts.categories]]></fieldDescription></field>
+	<field name="count_services" class="java.lang.Integer"><fieldDescription><![CDATA[list.counts.services]]></fieldDescription></field>
+	<field name="count_articles" class="java.lang.Integer"><fieldDescription><![CDATA[list.counts.articles]]></fieldDescription></field>
+	<!--
+		Die oberen 128 pt (≈ 45 mm) des Titelbandes bleiben leer: dort stempelt
+		das PDF-Overlay den Briefkopf des Mandanten. Der Freiraum ist bewusst
+		FEST und kein Parameter — ein Parameter könnte die Bandgeometrie zur
+		Laufzeit gar nicht verschieben, er sähe nur so aus. Wer mehr oder
+		weniger Platz braucht, ändert diese Bandhöhe und die y-Werte darunter;
+		das ist ein Layout-Eingriff und gehört in die Vorlage, nicht in eine
+		Berichtsvariable.
+	-->
+	<title>
+		<band height="224">
+			<textField>
+				<reportElement style="Section" x="0" y="168" width="330" height="18"/>
+				<textElement><font size="14" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$P{List_title}]]></textFieldExpression>
+			</textField>
+			<staticText><reportElement style="Label" x="380" y="168" width="90" height="12"/><text><![CDATA[Preisgruppe]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="470" y="168" width="91" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{group_name} == null ? "Listenpreise" : $F{group_name}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="182" width="90" height="12"/><text><![CDATA[Stichtag]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="470" y="182" width="91" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{date}]]></textFieldExpression></textField>
+			<staticText><reportElement style="Label" x="380" y="196" width="90" height="12"/><text><![CDATA[Währung]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement style="Value" x="470" y="196" width="91" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{currency}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="190" width="360" height="20">
+					<printWhenExpression><![CDATA[$F{derivation_mode} != null]]></printWhenExpression>
+				</reportElement>
+				<textElement><font size="7" isItalic="true"/></textElement>
+				<textFieldExpression><![CDATA["Diese Gruppe leitet vom Listenpreis ab: " + ($F{derivation_value} != null && $F{derivation_value}.signum() >= 0 ? "+" : "") + ($F{derivation_value} == null ? "" : new java.text.DecimalFormat("#,##0.##").format($F{derivation_value})) + ("absolute".equals($F{derivation_mode}) ? " " + ($F{currency} == null ? "" : $F{currency}) : " %") + "."]]></textFieldExpression>
+			</textField>
+			<line><reportElement x="0" y="218" width="561" height="1"/></line>
+		</band>
+	</title>
+	<pageHeader>
+		<band height="0"/>
+	</pageHeader>
+	<detail>
+		<band height="60">
+			<staticText>
+				<reportElement style="Section" x="0" y="0" width="404" height="14">
+					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Kalibrierpreise]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Label" x="410" y="2" width="80" height="11">
+					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right"/>
+				<text><![CDATA[Betrag]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="16" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>
+				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.calibration")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-categories.jasper"]]></subreportExpression>
+			</subreport>
+			<staticText>
+				<reportElement style="Section" positionType="Float" x="0" y="20" width="404" height="14" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Zusatzleistungen]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="36" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>
+				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.services")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-services.jasper"]]></subreportExpression>
+			</subreport>
+			<staticText>
+				<reportElement style="Section" positionType="Float" x="0" y="40" width="404" height="14" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{count_articles} != null && $F{count_articles}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Standardartikel]]></text>
+			</staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="56" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.articles")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-articles.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="24">
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="2" width="460" height="18"/>
+				<textElement><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="470" y="2" width="91" height="10"/>
+				<textElement textAlignment="Right"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+	<summary>
+		<band height="40">
+			<line><reportElement positionType="Float" x="0" y="4" width="561" height="1"/></line>
+			<staticText><reportElement style="Label" positionType="Float" x="0" y="8" width="200" height="11"/><text><![CDATA[Konditionen]]></text></staticText>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="20" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.surcharges")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-surcharges.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</summary>
+</jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample_adapter.xml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 price-list sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Price List JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,144 @@
+{
+  "meta": {
+    "contract": "price-list",
+    "schema_version": "1.0",
+    "generated_at": "2026-08-10T09:00:00+02:00",
+    "locale": "de-DE"
+  },
+  "list": {
+    "group": { "id": "g-1", "name": "Händler" },
+    "date": "2026-08-10",
+    "currency": "EUR",
+    "derivation": { "mode": "percent", "value": -15 },
+    "surcharges": [
+      {
+        "reference_id": "DAkkS",
+        "mode": "percent",
+        "value": 45,
+        "price_class_id": null,
+        "price_class_label": null
+      },
+      {
+        "reference_id": "Vor-Ort",
+        "mode": "absolute",
+        "value": 120,
+        "price_class_id": "pk-200",
+        "price_class_label": "Temperatur"
+      }
+    ],
+    "calibration": [
+      {
+        "id": "pk-100",
+        "number": "PK100",
+        "name": "Elektrische Messgeräte",
+        "parent_id": null,
+        "depth": 0,
+        "amount": null,
+        "derived": false,
+        "inherited_from": null,
+        "exceptions": [],
+        "scales": []
+      },
+      {
+        "id": "pk-100-01",
+        "number": "PK100.01",
+        "name": "Multimeter handheld",
+        "parent_id": "pk-100",
+        "depth": 1,
+        "amount": 84.15,
+        "derived": true,
+        "inherited_from": null,
+        "exceptions": [
+          {
+            "type_id": "T-1",
+            "type_label": "Keithley DMM6500",
+            "amount": 110.0,
+            "derived": false,
+            "scales": []
+          }
+        ],
+        "scales": []
+      },
+      {
+        "id": "pk-100-02",
+        "number": "PK100.02",
+        "name": "Multimeter Tischgerät",
+        "parent_id": "pk-100",
+        "depth": 1,
+        "amount": 101.15,
+        "derived": true,
+        "inherited_from": null,
+        "exceptions": [],
+        "scales": [{ "min_quantity": 5, "price": null, "discount": 10 }]
+      },
+      {
+        "id": "pk-200",
+        "number": "PK200",
+        "name": "Temperatur",
+        "parent_id": null,
+        "depth": 0,
+        "amount": null,
+        "derived": false,
+        "inherited_from": null,
+        "exceptions": [],
+        "scales": []
+      },
+      {
+        "id": "pk-200-01",
+        "number": "PK200.01",
+        "name": "Temperaturfühler",
+        "parent_id": "pk-200",
+        "depth": 1,
+        "amount": 50.15,
+        "derived": true,
+        "inherited_from": null,
+        "exceptions": [],
+        "scales": []
+      },
+      {
+        "id": "pk-200-02",
+        "number": "PK200.02",
+        "name": "Klimaschrank / Ofen",
+        "parent_id": "pk-200",
+        "depth": 1,
+        "amount": 296.65,
+        "derived": false,
+        "inherited_from": { "id": "pk-200", "name": "Temperatur" },
+        "exceptions": [],
+        "scales": []
+      }
+    ],
+    "other_type_prices": { "count": 0, "truncated": false, "entries": [] },
+    "services": [
+      {
+        "id": "sv-1",
+        "name": "Zusätzlicher Messpunkt",
+        "amount": 25.0,
+        "variants": [],
+        "scales": [
+          { "min_quantity": 5, "price": null, "discount": 10 },
+          { "min_quantity": 10, "price": null, "discount": 20 }
+        ]
+      },
+      {
+        "id": "sv-2",
+        "name": "Express-Bearbeitung",
+        "amount": 60.0,
+        "variants": [],
+        "scales": []
+      }
+    ],
+    "articles": [
+      { "id": "a-1", "name": "Gerät reinigen", "amount": 12.0, "unit": "EA" },
+      { "id": "a-2", "name": "Versandpauschale", "amount": 9.5, "unit": "EA" }
+    ],
+    "counts": {
+      "categories": 6,
+      "categories_priced": 4,
+      "type_exceptions": 1,
+      "other_type_prices": 0,
+      "services": 2,
+      "articles": 2
+    }
+  }
+}

--- a/PRICE-LIST-JSON-SAMPLE/parameters.json
+++ b/PRICE-LIST-JSON-SAMPLE/parameters.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "List_title",
+      "label": {
+        "de": "Überschrift",
+        "en": "Document title"
+      },
+      "description": {
+        "de": "Überschrift des Dokuments, oben links unter dem Briefkopf. Leer lassen für „Preisliste\".",
+        "en": "Title of the document, top left below the letterhead. Leave empty for \"Preisliste\"."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Layout",
+      "example": "Preisliste Kalibrierdienstleistungen 2026"
+    },
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn der Briefkopf des Mandanten die Fußzeile bereits mitbringt.",
+        "en": "Optional footer at the bottom of every page — e.g. company name, address and contact details. Leave empty when the tenant's letterhead already carries a footer."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "example": "Musterlabor GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterlabor.de"
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer."
+      },
+      "role": "system"
+    }
+  ]
+}

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-articles.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-articles.jrxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  Standardartikel der Preisliste, Contract "price-list" v1.0 (`list.articles`).
+  Eine Zeile je Artikel: Bezeichnung, Betrag, Einheit.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-articles" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0005-4000-8000-000000000005">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
+	<field name="unit" class="java.lang.String"><fieldDescription><![CDATA[unit]]></fieldDescription></field>
+	<detail>
+		<band height="13">
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="404" height="12"/>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="410" y="0" width="80" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="494" y="0" width="67" height="12">
+					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
+				</reportElement>
+				<textFieldExpression><![CDATA[$P{Currency} + ($F{unit} != null ? " / " + $F{unit} : "")]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  Kategoriebaum der Preisliste, Contract "price-list" v1.0. Eine Zeile je
+  Preiskategorie aus `list.calibration`; die Baumtiefe steckt als Zahl in
+  `depth` und wird als Einrückung gerechnet (der Datensatz ist bereits in
+  Baumreihenfolge sortiert — hier wird nicht umsortiert).
+
+  Eine Kategorie OHNE Betrag ist eine Gruppenüberschrift, keine Lücke: sie
+  bündelt ihre Untergruppen. Deshalb steht dort kein "0,00", sondern nichts.
+
+  Typausnahmen hängen als Array `exceptions` an der Kategorie und laufen über
+  einen eingebetteten Subreport — die einzige zweistufige Stelle des Bündels.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-categories" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0001-4000-8000-000000000001">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String"/>
+	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<field name="number" class="java.lang.String"><fieldDescription><![CDATA[number]]></fieldDescription></field>
+	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="depth" class="java.lang.Integer"><fieldDescription><![CDATA[depth]]></fieldDescription></field>
+	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
+	<field name="derived" class="java.lang.Boolean"><fieldDescription><![CDATA[derived]]></fieldDescription></field>
+	<field name="inherited_from_name" class="java.lang.String"><fieldDescription><![CDATA[inherited_from.name]]></fieldDescription></field>
+	<detail>
+		<band height="15">
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="70" height="12">
+					<printWhenExpression><![CDATA[$F{depth} != null && $F{depth}.intValue() == 0]]></printWhenExpression>
+				</reportElement>
+				<textElement><font isBold="true" size="9"/></textElement>
+				<textFieldExpression><![CDATA[$F{number}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="70" height="12">
+					<printWhenExpression><![CDATA[$F{depth} == null || $F{depth}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<textElement><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$F{number}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="74" y="0" width="330" height="12">
+					<printWhenExpression><![CDATA[$F{depth} != null && $F{depth}.intValue() == 0]]></printWhenExpression>
+				</reportElement>
+				<textElement><font isBold="true" size="9"/></textElement>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="86" y="0" width="318" height="12">
+					<printWhenExpression><![CDATA[$F{depth} == null || $F{depth}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="410" y="0" width="80" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="494" y="0" width="30" height="12">
+					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
+				</reportElement>
+				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="527" y="0" width="34" height="12"/>
+				<textElement textAlignment="Right"><font size="6"/></textElement>
+				<textFieldExpression><![CDATA[($F{derived} != null && $F{derived}.booleanValue() ? "abgel." : "") + ($F{inherited_from_name} != null ? " geerbt" : "")]]></textFieldExpression>
+			</textField>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="12" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$P{Currency}]]></subreportParameterExpression></subreportParameter>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("exceptions")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-exceptions.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+</jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-exceptions.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-exceptions.jrxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  Typausnahmen einer Preiskategorie, Contract "price-list" v1.0. Läuft über
+  `exceptions` der jeweiligen Kategoriezeile (zweite Stufe, aufgerufen aus
+  price-list-categories).
+
+  Eine Ausnahme ist ein echter Preis, den der Kunde zahlt — sie gehört auf das
+  Papier, eingerückt unter ihre Kategorie, damit erkennbar bleibt, wovon sie
+  die Ausnahme ist.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-exceptions" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0002-4000-8000-000000000002">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<field name="type_label" class="java.lang.String"><fieldDescription><![CDATA[type_label]]></fieldDescription></field>
+	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
+	<detail>
+		<band height="12">
+			<staticText>
+				<reportElement x="98" y="0" width="8" height="11"/>
+				<textElement><font size="8"/></textElement>
+				<text><![CDATA[↳]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="108" y="0" width="296" height="11"/>
+				<textElement><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$F{type_label}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="410" y="0" width="80" height="11"/>
+				<textElement textAlignment="Right"><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="494" y="0" width="30" height="11">
+					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
+				</reportElement>
+				<textElement><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-scales.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-scales.jrxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  Mengenstaffel einer Zeile, Contract "price-list" v1.0 (`scales`).
+
+  Eine Stufe trägt entweder einen festen Stückpreis ODER einen Nachlass in
+  Prozent — nie beides. Deshalb entscheidet der Ausdruck, was gedruckt wird,
+  statt zwei Spalten zu führen, von denen immer eine leer bliebe.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-scales" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0004-4000-8000-000000000004">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<field name="min_quantity" class="java.math.BigDecimal"><fieldDescription><![CDATA[min_quantity]]></fieldDescription></field>
+	<field name="price" class="java.math.BigDecimal"><fieldDescription><![CDATA[price]]></fieldDescription></field>
+	<field name="discount" class="java.math.BigDecimal"><fieldDescription><![CDATA[discount]]></fieldDescription></field>
+	<detail>
+		<band height="11">
+			<textField isBlankWhenNull="true">
+				<reportElement x="108" y="0" width="416" height="10"/>
+				<textElement><font size="7" isItalic="true"/></textElement>
+				<textFieldExpression><![CDATA["ab " + ($F{min_quantity} == null ? "" : new java.text.DecimalFormat("#,##0.##").format($F{min_quantity})) + ": " + ($F{price} != null ? new java.text.DecimalFormat("#,##0.00").format($F{price}) + " " + $P{Currency} : ($F{discount} != null ? "−" + new java.text.DecimalFormat("#,##0.##").format($F{discount}) + " %" : ""))]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  Zusatzleistungen der Preisliste, Contract "price-list" v1.0 (`list.services`).
+
+  Die Mengenstaffel steht nicht als eigene Tabelle, sondern als Zusatz hinter
+  dem Betrag ("ab 5: −10 %") — auf einer Kundenliste ist sie eine Kondition,
+  keine zweite Preiszeile. Gerendert aus `scales` über einen eingebetteten
+  Subreport, damit beliebig viele Stufen mitlaufen.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-services" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0003-4000-8000-000000000003">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Reportpath" class="java.lang.String"/>
+	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
+	<detail>
+		<band height="15">
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="404" height="12"/>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="410" y="0" width="80" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="494" y="0" width="30" height="12">
+					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
+				</reportElement>
+				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
+			</textField>
+			<subreport>
+				<reportElement positionType="Float" x="0" y="12" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$P{Currency}]]></subreportParameterExpression></subreportParameter>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("scales")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-scales.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+</jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-surcharges.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-surcharges.jrxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  Konditions-Fußnoten der Preisliste, Contract "price-list" v1.0
+  (`list.surcharges`).
+
+  Ein Zuschlag gilt entweder pauschal oder nur für eine Preiskategorie; im
+  zweiten Fall steht die Kategorie dahinter in Klammern. Prozent und fester
+  Betrag stehen im selben Feld, weil eine Fußnote gelesen und nicht gerechnet
+  wird — die Zahl steht dort, wo der Satz sie erwartet.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-surcharges" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0006-4000-8000-000000000006">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<field name="reference_id" class="java.lang.String"><fieldDescription><![CDATA[reference_id]]></fieldDescription></field>
+	<field name="mode" class="java.lang.String"><fieldDescription><![CDATA[mode]]></fieldDescription></field>
+	<field name="value" class="java.math.BigDecimal"><fieldDescription><![CDATA[value]]></fieldDescription></field>
+	<field name="price_class_label" class="java.lang.String"><fieldDescription><![CDATA[price_class_label]]></fieldDescription></field>
+	<detail>
+		<band height="11">
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="0" width="561" height="10"/>
+				<textElement><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[($F{reference_id} == null ? "" : $F{reference_id}) + " " + ($F{value} != null && $F{value}.signum() >= 0 ? "+" : "") + ($F{value} == null ? "" : new java.text.DecimalFormat("#,##0.##").format($F{value})) + ("absolute".equals($F{mode}) ? " " + $P{Currency} : " %") + ($F{price_class_label} != null ? " (" + $F{price_class_label} + ")" : "")]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
calServer V2 kann die Preisliste seit P3 als PDF erzeugen — Datenvertrag, Endpunkte und Briefkopf-Overlay stehen. Was fehlte, war die **Vorlage selbst**: jeder Mandant musste sie in Jaspersoft Studio erst bauen.

Dieses Bündel liefert sie fertig, gegen Contract `price-list` v1.0.

## Was gedruckt wird

Kopf (Titel, Preisgruppe, Stichtag, Währung, Ableitungsregel der Gruppe) → Kategoriebaum mit den geltenden Kalibrierpreisen, Typausnahmen eingerückt darunter → Zusatzleistungen mit Mengenstaffel → Standardartikel → Konditions-Fußnoten. Jeder Abschnitt verschwindet vollständig, wenn sein Array leer ist.

## Der Briefkopf steht bewusst nicht in der Vorlage

Das ist der Punkt, nicht eine Lücke. Der Briefkopf kommt **je Mandant** über das PDF-Overlay des Berichtswesens; das Titelband hält dafür oben **128 pt (≈ 45 mm)** frei und druckt dort selbst nichts.

Eine fest eingebaute Absenderzeile wäre für jeden zweiten Mandanten falsch und ließe sich nicht wegkonfigurieren, ohne die Vorlage zu ändern.

Der Freiraum ist **fest und kein Parameter**. Eine Berichtsvariable könnte die Bandgeometrie zur Laufzeit gar nicht verschieben — sie sähe nur so aus. Wer mehr oder weniger Platz braucht, ändert Bandhöhe und y-Werte; das ist ein Layout-Eingriff und gehört in die Vorlage.

## Aufbau

| Datei | Zweck |
|-------|-------|
| `main_reports/price-list-json-sample.jrxml` | Hauptbericht: Briefkopf-Freiraum, Kopf, Abschnittsüberschriften, Fußzeile |
| `subreports/price-list-categories.jrxml` | Kategoriebaum (`list.calibration`), Obergruppen fett, Untergruppen eingerückt |
| `subreports/price-list-exceptions.jrxml` | Typausnahmen einer Kategorie (`exceptions`) |
| `subreports/price-list-services.jrxml` | Zusatzleistungen (`list.services`) |
| `subreports/price-list-scales.jrxml` | Mengenstaffel einer Zeile (`scales`) |
| `subreports/price-list-articles.jrxml` | Standardartikel (`list.articles`) |
| `subreports/price-list-surcharges.jrxml` | Konditions-Fußnoten (`list.surcharges`) |

Dazu `sample-data.json`, der Studio-Adapter und ein `parameters.json` mit `List_title` und `Company_footer`.

## Bewusst nicht gedruckt

`list.other_type_prices` — die bei 200 gekappte Liste der Typpreise **ohne** Kategorie. Ein Übergangsbestand auf dem Weg zur Kategorisierung; eine willkürlich abgeschnittene Aufzählung gehört nicht auf ein Dokument, das man aus der Hand gibt. Wer sie braucht, nimmt den CSV-Export der Preislisten-Seite.

## Geprüft

Alle sieben JRXML übersetzen mit **JasperReports 6.20.6**, und der Hauptbericht **füllt gegen `sample-data.json` durch** (eine Seite, alle Abschnitte belegt).

Zwei Dinge hat dieser Lauf gefunden, die eine reine Sichtprüfung nicht gefunden hätte:

1. **Entities werden in einem CDATA-Abschnitt nicht aufgelöst.** Ein logisches Und muss dort als die beiden nackten Kaufmanns-Und-Zeichen stehen; schreibt man es entity-kodiert (`&amp;` gefolgt von `amp;`), landet genau diese Zeichenfolge wörtlich im Java-Ausdruck und der Compiler bricht mit „amp cannot be resolved to a variable". Betroffen waren drei Dateien.
2. **Die Bandreihenfolge ist schemagebunden:** `pageFooter` steht **vor** `summary`, sonst scheitert schon das Laden der JRXML an der Schema-Validierung.

Außerdem belegt: die **zweistufige** Auflösung `subDataSource("exceptions")` innerhalb des Kategorie-Subreports greift — die Typausnahme erscheint eingerückt unter ihrer Kategorie. Dafür gab es bislang keinen Präzedenzfall im Repo, alle anderen Bündel bleiben einstufig.

Nicht geprüft werden konnte der PDF-Export selbst: in der Bau-Umgebung fehlt die Schrift DejaVu Sans, die das Runner-Image mitbringt. Die pixelgenaue Abnahme des Layouts (report-runner) bleibt wie gehabt maßgeblich.

## Zahlenformat

Beträge stehen mit `pattern="#,##0.00"` und folgen `REPORT_LOCALE`, das calServer je Mandant setzt: `de-DE` ergibt `84,15`, `en-US` ergibt `84.15`. In Studio ohne gesetzte Locale zeigt die Vorschau das Format des Rechners — kein Vorlagenfehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQXdNUH6CgFuN2LwnWAkjr

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQXdNUH6CgFuN2LwnWAkjr)_