### PR TITLE
ci: PRICE-LIST-JSON-SAMPLE als Download-Artefakt aufnehmen

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -254,6 +254,16 @@ jobs:
             LOCATION-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
+      - name: Upload PRICE-LIST-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PRICE-LIST-JSON-SAMPLE
+          path: |
+            PRICE-LIST-JSON-SAMPLE/main_reports
+            PRICE-LIST-JSON-SAMPLE/subreports
+            PRICE-LIST-JSON-SAMPLE/parameters.json
+          if-no-files-found: error
+
       - name: List files before zipping (Debug)
         run: |
           echo "📂 Inhalt von DAKKS-SAMPLE:"
@@ -391,6 +401,7 @@ jobs:
           create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
           create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"
           create_zip "LOCATION-JSON-SAMPLE" "location-json-sample"
+          create_zip "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
 
 
       - name: Upload report ZIPs as artifact

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -110,6 +110,7 @@ jobs:
           get_last_modified "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
           get_last_modified "REPAIR-JSON-SAMPLE" "repair-json-sample"
           get_last_modified "LOCATION-JSON-SAMPLE" "location-json-sample"
+          get_last_modified "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
 
           echo "Last-modified dates:"
           cat artifacts/last-modified.tsv
@@ -195,6 +196,7 @@ jobs:
               "delivery-json-sample":               "DELIVERY-JSON-SAMPLE/README.md",
               "repair-json-sample":                 "REPAIR-JSON-SAMPLE/README.md",
               "location-json-sample":               "LOCATION-JSON-SAMPLE/README.md",
+              "price-list-json-sample":             "PRICE-LIST-JSON-SAMPLE/README.md",
           }
 
           SCHEMA_MAP = {
@@ -222,6 +224,7 @@ jobs:
               "delivery-json-sample":               "Lieferschein (APEX · V2)",
               "repair-json-sample":                 "Reparaturbericht (APEX · V2)",
               "location-json-sample":               "Standort-/Leihbericht (APEX · V2)",
+              "price-list-json-sample":             "Preisliste (APEX · V2)",
           }
 
           INFO_TEMPLATE = """<!doctype html>


### PR DESCRIPTION
## Worum es geht

Das Preislisten-Bündel liegt seit #504 im Repo, taucht aber auf der
[Downloads-Seite](https://calhelp.github.io/calServer-reports/downloads/) nicht auf.

Die Ursache ist keine Panne beim Deploy: Die Seite rendert ihre Tabelle aus
`downloads/latest.json`, und dieses `latest.json` entsteht aus den ZIPs, die
`package-reports.yml` baut. Bündel werden dort **namentlich** eingetragen, nicht
automatisch gefunden. #504 hat nur das Verzeichnis angelegt — damit gibt es kein
ZIP, keinen Eintrag, keine Zeile auf der Seite.

## Was sich ändert

Drei fehlende Einträge, sonst nichts:

**`.github/workflows/package-reports.yml`**
- Upload-Artefakt `PRICE-LIST-JSON-SAMPLE` (main_reports, subreports, parameters.json)
- `create_zip "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"`

**`.github/workflows/publish-downloads.yml`**
- `get_last_modified` — sonst bleibt die Spalte „Letzte Änderung" leer
- `README_MAP` — Beschreibung in der Tabelle und Info-Seite
- `TITLE_MAP` — „Preisliste (APEX · V2)"

`downloads/index.html` bleibt unangetastet: Die Kategorie „APEX · V2
(JSON-Datenquelle)" leitet sich aus dem Artefaktnamen ab (`-json-sample`),
und die trifft `price-list-json-sample` von selbst.

`release-reports.yml` bleibt ebenfalls unangetastet — dieser Workflow führt
generell keine V2-JSON-Bündel, das ist bestehende Linie und nicht Sache dieses PRs.

## Geprüft

Beide Workflow-Schritte lokal nachgebaut, nicht nur gelesen:

- **Paketieren:** Das ZIP enthält die sieben JRXML (Hauptbericht + sechs
  Subreports), `sample-data.json`, den Jaspersoft-Studio-Adapter, `README.md`
  und `parameters.json` — 13 Einträge, ~40 kB. (`rsync` fehlt in der lokalen
  Umgebung, die Include-/Exclude-Muster wurden dafür in Python identisch
  nachgezogen; im Runner läuft der Original-Schritt.)
- **Publizieren:** Beschreibung wird sauber aus dem README gezogen (erster
  Absatz, Markdown entfernt), die Info-Seite rendert inklusive Tabellen.
- `scripts/check_parameters_manifest.py`: 8 Manifeste, keine Fehler.
- `scripts/check_jasper_version.sh`: alle JRXML auf 6.20.6.

Der eigentliche Beweis kommt nach dem Merge: „Package Reports" läuft auf `main`,
„Publish Downloads" hängt sich dran, danach steht die Zeile auf der Seite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQXdNUH6CgFuN2LwnWAkjr)_