### PR TITLE
ci: V2-JSON-Bündel in die getaggten Releases aufnehmen

### DIFF
--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -29,14 +29,19 @@ jobs:
             local zip_name="$2"
             local stage_dir="staging/${zip_name}"
             local rsync_excludes=()
-            local allowed_patterns=('*.jrxml')
+            local allowed_patterns=('*.jrxml' '*.md')
             local include_args=(--include='*/')
 
             if [ "$sample" = "DAKKS-SAMPLE" ]; then
               rsync_excludes+=(--exclude='config/**')
-              allowed_patterns+=('*.properties' '*.md')
+              allowed_patterns+=('*.properties')
             elif [ "$sample" = "DCC" ]; then
-              allowed_patterns+=('*.xsd' '*.md' '*.json')
+              allowed_patterns+=('*.xsd' '*.json')
+            elif [[ "$sample" == *-JSON-SAMPLE ]]; then
+              # V2 (APEX) bundles ship a JSON data-adapter sample (sample-data.json)
+              # plus a Jaspersoft Studio data-adapter (*.xml) so the report
+              # previews out-of-the-box — keep both in the ZIP.
+              allowed_patterns+=('*.json' '*.xml')
             fi
 
             rm -rf "${stage_dir}"
@@ -54,6 +59,17 @@ jobs:
                   "${sample}/${folder}/" "${stage_dir}/${folder}/"
               fi
             done
+
+            # Top-level README.md des Samples mitnehmen, falls vorhanden.
+            if [ -f "${sample}/README.md" ]; then
+              cp "${sample}/README.md" "${stage_dir}/README.md"
+            fi
+
+            # Parameter-Manifest an der Bundle-Wurzel mitnehmen (nur V2-JSON-
+            # Bundles pflegen eins; calServer liest daraus den Parameter-Katalog).
+            if [ -f "${sample}/parameters.json" ]; then
+              cp "${sample}/parameters.json" "${stage_dir}/parameters.json"
+            fi
 
             # Sicherstellen, dass nur explizit erlaubte Dateitypen in den ZIPs landen.
             local allowed_conditions=()
@@ -74,17 +90,17 @@ jobs:
             fi
 
             pushd "${stage_dir}" >/dev/null
-            if [ -d main_reports ] && [ -d subreports ]; then
-              zip -r "../../output/${zip_name}.zip" main_reports subreports
-            elif [ -d main_reports ]; then
-              zip -r "../../output/${zip_name}.zip" main_reports
-            elif [ -d subreports ]; then
-              zip -r "../../output/${zip_name}.zip" subreports
-            else
-              echo "❌ No report folders found for ${sample}" >&2
+            local zip_targets=()
+            [ -d main_reports ] && zip_targets+=(main_reports)
+            [ -d subreports ] && zip_targets+=(subreports)
+            [ -f README.md ] && zip_targets+=(README.md)
+            [ -f parameters.json ] && zip_targets+=(parameters.json)
+            if [ "${#zip_targets[@]}" -eq 0 ]; then
+              echo "❌ No report content found for ${sample}" >&2
               popd >/dev/null
               exit 1
             fi
+            zip -r "../../output/${zip_name}.zip" "${zip_targets[@]}"
             popd >/dev/null
           }
 
@@ -104,6 +120,22 @@ jobs:
           create_zip "TRACE-FORWARD" "trace-forward"
           create_zip "TRACE-BACKWARD" "trace-backward"
           create_zip "STICKERS/Sticker_Vorlage" "sticker-vorlage"
+
+          # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL).
+          # Gleiche Liste wie in package-reports.yml; ein Release ohne sie wäre
+          # nur der halbe Stand.
+          create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"
+          create_zip "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
+          create_zip "SUBORDINATE-INVENTORY-JSON-SAMPLE" "subordinate-inventory-json-sample"
+          create_zip "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
+          create_zip "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
+          create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
+          create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
+          create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
+          create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
+          create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"
+          create_zip "LOCATION-JSON-SAMPLE" "location-json-sample"
+          create_zip "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
 
       - name: Determine release metadata
         id: release_meta


### PR DESCRIPTION
## Worum es geht

`release-reports.yml` paketiert bis heute ausschließlich V1-Bündel. Wer den in der
README empfohlenen Weg geht — „Letztes Release herunterladen (empfohlen)" — bekommt
damit **keine einzige V2-Vorlage**. Die Downloads-Seite kennt sie, die Releases nicht,
und der Abstand wächst mit jedem neuen Bündel.

## Was sich ändert

**Ein Paketierer statt zwei.** Der `create_zip`-Helfer ist jetzt identisch mit dem aus
`package-reports.yml`:

- Markdown generell erlaubt (bisher nur bei DAKKS und DCC)
- für `*-JSON-SAMPLE` zusätzlich `*.json` und `*.xml` — Beispieldatensatz und
  Jaspersoft-Studio-Adapter, ohne die sich die Vorlage ohne Backend nicht öffnen lässt
- `README.md` und `parameters.json` von der Bündelwurzel werden mitgenommen

Zwei getrennt gepflegte Paketierer für dieselben Bündel waren der eigentliche Defekt —
dass die V2-Bündel fehlten, ist nur die sichtbare Folge.

**Alle zwölf V2-Bündel** kommen in die Liste, in derselben Reihenfolge wie im
Paket-Workflow.

## Geprüft

Beide Skripte aus den Workflows extrahiert und lokal ausgeführt. (`rsync` fehlt in der
Umgebung; die Include-/Exclude-Regeln sind als Ersatz nachgebildet, im Runner läuft das
Original.)

- Release baut **28 statt 16 ZIPs**, Exit 0.
- Für die 27 Bündel, die beide Workflows kennen, sind die Dateilisten **identisch**.
  Einziger Unterschied: `price-list-json-sample`, das auf der Paketseite noch an #505 hängt.
- Die bestehenden V1-ZIPs gewinnen **ausschließlich Dokumentation**:

  | ZIP | neu enthalten |
  |-----|---------------|
  | `dakks-sample`, `delivery-standalone` | `README.md` |
  | `field-names`, `inventory-sample`, `order-sample` | `main_reports/README.md`, `subreports/README.md` |
  | `kalibrierkontrollblatt` | `README.md` + beide Unter-READMEs |
  | `trace-forward`, `trace-backward` | `main_reports/README.md`, `main_reports/NEWS.md` |

  Kein JRXML kommt hinzu oder fällt weg. Sticker- und DCC-Pakete bleiben unverändert.
  Dass eine README im Bündel unschädlich ist, ist keine Annahme: die Downloads-ZIPs
  tragen sie längst, und genau die werden hochgeladen.

Der Beweis am Ende ist der nächste Tag — dann hängen die zwölf V2-ZIPs am Release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQXdNUH6CgFuN2LwnWAkjr)_