### PR TITLE
Prüfplan-Bundles: Schritt-Bilder (Anschluss, Messanleitung, LCD-Testbild)

### DIFF
--- a/PRUEFPLAN-FLUKE-23/images/fluke-23-anschluss-a.svg
+++ b/PRUEFPLAN-FLUKE-23/images/fluke-23-anschluss-a.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" font-family="sans-serif">
+  <rect width="640" height="360" fill="#ffffff"/>
+  <text x="320" y="28" text-anchor="middle" font-size="17" font-weight="bold" fill="#1f2937">Anschluss Strom (mA / A)</text>
+
+  <rect x="30" y="60" width="240" height="240" rx="10" fill="#eef2f7" stroke="#334155" stroke-width="2"/>
+  <text x="150" y="90" text-anchor="middle" font-size="15" font-weight="bold" fill="#334155">Fluke 5520A</text>
+  <text x="150" y="110" text-anchor="middle" font-size="12" fill="#64748b">AUX / 20A OUTPUT</text>
+  <circle cx="110" cy="160" r="16" fill="#dc2626" stroke="#7f1d1d" stroke-width="3"/>
+  <text x="110" y="196" text-anchor="middle" font-size="12" fill="#334155">AUX HI / 20A</text>
+  <circle cx="190" cy="160" r="16" fill="#111827" stroke="#000000" stroke-width="3"/>
+  <text x="190" y="196" text-anchor="middle" font-size="12" fill="#334155">LO</text>
+  <text x="150" y="270" text-anchor="middle" font-size="11" fill="#64748b">Ab 3 A den 20A-Ausgang</text>
+  <text x="150" y="286" text-anchor="middle" font-size="11" fill="#64748b">verwenden, Einschaltdauer beachten</text>
+
+  <rect x="370" y="60" width="240" height="240" rx="10" fill="#fefce8" stroke="#334155" stroke-width="2"/>
+  <text x="490" y="90" text-anchor="middle" font-size="15" font-weight="bold" fill="#334155">Fluke 23 Series II</text>
+  <circle cx="450" cy="160" r="16" fill="#dc2626" stroke="#7f1d1d" stroke-width="3"/>
+  <text x="450" y="196" text-anchor="middle" font-size="12" fill="#334155">A / 10A</text>
+  <circle cx="530" cy="160" r="16" fill="#111827" stroke="#000000" stroke-width="3"/>
+  <text x="530" y="196" text-anchor="middle" font-size="12" fill="#334155">COM</text>
+  <text x="490" y="270" text-anchor="middle" font-size="11" fill="#64748b">Für mA-Bereiche die</text>
+  <text x="490" y="286" text-anchor="middle" font-size="11" fill="#64748b">mA-Buchse verwenden</text>
+
+  <path d="M 126 160 C 240 120, 380 120, 434 160" fill="none" stroke="#dc2626" stroke-width="4"/>
+  <path d="M 206 160 C 300 210, 420 210, 514 160" fill="none" stroke="#111827" stroke-width="4"/>
+  <text x="320" y="118" text-anchor="middle" font-size="12" fill="#dc2626">AUX HI → A (rot)</text>
+  <text x="320" y="232" text-anchor="middle" font-size="12" fill="#111827">LO → COM (schwarz)</text>
+
+  <text x="320" y="336" text-anchor="middle" font-size="12" fill="#475569">Nach der Strommessung Leitungen zurück auf V·Ω stecken — Schutz vor versehentlichem Kurzschluss.</text>
+</svg>

--- a/PRUEFPLAN-FLUKE-23/images/fluke-23-anschluss-v-ohm.svg
+++ b/PRUEFPLAN-FLUKE-23/images/fluke-23-anschluss-v-ohm.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" font-family="sans-serif">
+  <rect width="640" height="360" fill="#ffffff"/>
+  <text x="320" y="28" text-anchor="middle" font-size="17" font-weight="bold" fill="#1f2937">Anschluss Spannung / Widerstand</text>
+
+  <!-- Fluke 5520A -->
+  <rect x="30" y="60" width="240" height="240" rx="10" fill="#eef2f7" stroke="#334155" stroke-width="2"/>
+  <text x="150" y="90" text-anchor="middle" font-size="15" font-weight="bold" fill="#334155">Fluke 5520A</text>
+  <text x="150" y="110" text-anchor="middle" font-size="12" fill="#64748b">NORMAL OUTPUT</text>
+  <circle cx="110" cy="160" r="16" fill="#dc2626" stroke="#7f1d1d" stroke-width="3"/>
+  <text x="110" y="196" text-anchor="middle" font-size="12" fill="#334155">HI</text>
+  <circle cx="190" cy="160" r="16" fill="#111827" stroke="#000000" stroke-width="3"/>
+  <text x="190" y="196" text-anchor="middle" font-size="12" fill="#334155">LO</text>
+  <text x="150" y="270" text-anchor="middle" font-size="11" fill="#64748b">Ausgang erst nach dem</text>
+  <text x="150" y="286" text-anchor="middle" font-size="11" fill="#64748b">Anschließen aktivieren (OPR)</text>
+
+  <!-- Fluke 23 -->
+  <rect x="370" y="60" width="240" height="240" rx="10" fill="#fefce8" stroke="#334155" stroke-width="2"/>
+  <text x="490" y="90" text-anchor="middle" font-size="15" font-weight="bold" fill="#334155">Fluke 23 Series II</text>
+  <circle cx="450" cy="160" r="16" fill="#dc2626" stroke="#7f1d1d" stroke-width="3"/>
+  <text x="450" y="196" text-anchor="middle" font-size="12" fill="#334155">V·Ω</text>
+  <circle cx="530" cy="160" r="16" fill="#111827" stroke="#000000" stroke-width="3"/>
+  <text x="530" y="196" text-anchor="middle" font-size="12" fill="#334155">COM</text>
+  <text x="490" y="270" text-anchor="middle" font-size="11" fill="#64748b">Drehschalter auf die geprüfte</text>
+  <text x="490" y="286" text-anchor="middle" font-size="11" fill="#64748b">Messgröße stellen</text>
+
+  <!-- Leitungen -->
+  <path d="M 126 160 C 240 120, 380 120, 434 160" fill="none" stroke="#dc2626" stroke-width="4"/>
+  <path d="M 206 160 C 300 210, 420 210, 514 160" fill="none" stroke="#111827" stroke-width="4"/>
+  <text x="320" y="118" text-anchor="middle" font-size="12" fill="#dc2626">HI → V·Ω (rot)</text>
+  <text x="320" y="232" text-anchor="middle" font-size="12" fill="#111827">LO → COM (schwarz)</text>
+
+  <text x="320" y="336" text-anchor="middle" font-size="12" fill="#475569">Gilt für alle Gleich-/Wechselspannungs- und Widerstandsgruppen. Leitungen kurz und verdrillt führen.</text>
+</svg>

--- a/PRUEFPLAN-FLUKE-23/images/fluke-23-lcd-testbild.svg
+++ b/PRUEFPLAN-FLUKE-23/images/fluke-23-lcd-testbild.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" font-family="sans-serif">
+  <rect width="640" height="320" fill="#ffffff"/>
+  <text x="320" y="30" text-anchor="middle" font-size="17" font-weight="bold" fill="#1f2937">LCD-Testbild — Segmenttest beim Einschalten</text>
+
+  <!-- Display-Gehäuse -->
+  <rect x="120" y="60" width="400" height="170" rx="12" fill="#1f2937"/>
+  <rect x="140" y="80" width="360" height="130" rx="6" fill="#b7c4a3"/>
+
+  <!-- Annunciatoren oben -->
+  <g font-size="14" font-weight="bold" fill="#1f2937">
+    <text x="160" y="104">AC</text>
+    <text x="196" y="104">DC</text>
+    <text x="236" y="104">−</text>
+    <text x="262" y="104">Ω</text>
+    <text x="292" y="104">V</text>
+    <text x="320" y="104">A</text>
+    <text x="350" y="104">mV</text>
+    <text x="392" y="104">kΩ</text>
+    <text x="430" y="104">🔊</text>
+    <text x="462" y="104">⚡</text>
+  </g>
+
+  <!-- 3½-stellige Segmentanzeige: 1 8 8 8 -->
+  <g fill="#1f2937">
+    <rect x="176" y="124" width="12" height="64" rx="3"/>
+    <g transform="translate(210,118)">
+      <rect x="4" y="0" width="52" height="10" rx="3"/><rect x="0" y="6" width="10" height="32" rx="3"/><rect x="50" y="6" width="10" height="32" rx="3"/>
+      <rect x="4" y="34" width="52" height="10" rx="3"/><rect x="0" y="40" width="10" height="32" rx="3"/><rect x="50" y="40" width="10" height="32" rx="3"/>
+      <rect x="4" y="68" width="52" height="10" rx="3"/>
+    </g>
+    <g transform="translate(290,118)">
+      <rect x="4" y="0" width="52" height="10" rx="3"/><rect x="0" y="6" width="10" height="32" rx="3"/><rect x="50" y="6" width="10" height="32" rx="3"/>
+      <rect x="4" y="34" width="52" height="10" rx="3"/><rect x="0" y="40" width="10" height="32" rx="3"/><rect x="50" y="40" width="10" height="32" rx="3"/>
+      <rect x="4" y="68" width="52" height="10" rx="3"/>
+    </g>
+    <g transform="translate(370,118)">
+      <rect x="4" y="0" width="52" height="10" rx="3"/><rect x="0" y="6" width="10" height="32" rx="3"/><rect x="50" y="6" width="10" height="32" rx="3"/>
+      <rect x="4" y="34" width="52" height="10" rx="3"/><rect x="0" y="40" width="10" height="32" rx="3"/><rect x="50" y="40" width="10" height="32" rx="3"/>
+      <rect x="4" y="68" width="52" height="10" rx="3"/>
+    </g>
+    <circle cx="288" cy="196" r="5"/>
+    <circle cx="368" cy="196" r="5"/>
+    <rect x="440" y="150" width="44" height="22" rx="4" fill="none" stroke="#1f2937" stroke-width="4"/>
+    <text x="462" y="167" text-anchor="middle" font-size="13" font-weight="bold">BAT</text>
+  </g>
+
+  <text x="320" y="262" text-anchor="middle" font-size="13" fill="#475569">Beim Einschalten zeigt das Display kurz alle Segmente: -1888 mit beiden Dezimalpunkten,</text>
+  <text x="320" y="282" text-anchor="middle" font-size="13" fill="#475569">alle Messarten-Anzeigen und das Batteriesymbol. Fehlende Segmente = Prüfling abweisen.</text>
+</svg>

--- a/PRUEFPLAN-FLUKE-23/manifest.json
+++ b/PRUEFPLAN-FLUKE-23/manifest.json
@@ -5,7 +5,7 @@
   "name": "Fluke 23 Series II — Kalibrierung mit Fluke 5520A",
   "document": {
     "format": "calserver.procedure",
-    "version": 2
+    "version": 3
   },
   "plan": {
     "major_version": 0,
@@ -18,13 +18,28 @@
   "files": [
     {
       "path": "procedure.json",
-      "sha256": "212e72596a00f4f9a5177d53e6c978311f5c085e8b024a9a2b13218ff4f0db9d",
-      "size_bytes": 37801
+      "sha256": "9b18cfa180f1fe0f423d7a21776f6ea7c46987ff87a23c50aa3ff12abea3755d",
+      "size_bytes": 38997
     },
     {
       "path": "README.md",
       "sha256": "bfcd3ac7b8558b5a7c703cb4804c7ae296e35ff592b67ef08e74c761eee667d9",
       "size_bytes": 2636
+    },
+    {
+      "path": "images/fluke-23-anschluss-a.svg",
+      "sha256": "2ec2824b223b077f64a6a3b661b03330df4dd380e894214487326a0a8f0f5ac2",
+      "size_bytes": 2528
+    },
+    {
+      "path": "images/fluke-23-anschluss-v-ohm.svg",
+      "sha256": "9125dd89ca2b4909fd6dd9bf9feeb2ebd9935963a55d93e1e826aff1576aff91",
+      "size_bytes": 2589
+    },
+    {
+      "path": "images/fluke-23-lcd-testbild.svg",
+      "sha256": "36890fbf5f3420126e783db832787347ed05eff04d2cefeb4b027f29940c5b09",
+      "size_bytes": 2923
     }
   ]
 }

--- a/PRUEFPLAN-FLUKE-23/procedure.json
+++ b/PRUEFPLAN-FLUKE-23/procedure.json
@@ -1,6 +1,6 @@
 {
   "format": "calserver.procedure",
-  "version": 2,
+  "version": 3,
   "name": "Fluke 23 Series II — Kalibrierung mit Fluke 5520A",
   "test_steps": [
     {
@@ -108,7 +108,10 @@
         "uncertainty": 0.03,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 7,
@@ -214,7 +217,10 @@
         "uncertainty": 0.0003,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 13,
@@ -320,7 +326,10 @@
         "uncertainty": 0.003,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 19,
@@ -426,7 +435,10 @@
         "uncertainty": 0.03,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 25,
@@ -532,7 +544,10 @@
         "uncertainty": 0.15,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 31,
@@ -622,7 +637,10 @@
         "uncertainty": 0.0015,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 36,
@@ -712,7 +730,10 @@
         "uncertainty": 0.15,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 41,
@@ -786,7 +807,10 @@
         "uncertainty": 0.04,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 45,
@@ -861,7 +885,10 @@
         "uncertainty": 0.0004,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 49,
@@ -936,7 +963,10 @@
         "uncertainty": 0.004,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 53,
@@ -1011,7 +1041,10 @@
         "uncertainty": 0.0008,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 57,
@@ -1070,7 +1103,10 @@
         "uncertainty": 0.08,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-a.svg"
+      ]
     },
     {
       "row_number": 60,
@@ -1144,7 +1180,10 @@
         "uncertainty": 0.008,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-a.svg"
+      ]
     },
     {
       "row_number": 64,
@@ -1219,7 +1258,10 @@
         "uncertainty": 0.15,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "fluke-23-anschluss-a.svg"
+      ]
     },
     {
       "row_number": 68,
@@ -1283,7 +1325,10 @@
       "auxalary": null,
       "resolution": null,
       "tolerance": null,
-      "uncertainty": null
+      "uncertainty": null,
+      "images": [
+        "fluke-23-anschluss-v-ohm.svg"
+      ]
     },
     {
       "row_number": 72,
@@ -1337,8 +1382,8 @@
       "row_number": 75,
       "test_step": 17.001,
       "test_type": "Manual Test",
-      "description": "Alle Anzeigesegmente und Schalterstellungen vollständig",
-      "test_mode": "<p>Segmenttest über die Einschaltroutine, danach jede Schalterstellung einmal durchfahren.</p>",
+      "description": "Segmenttest: alles wie auf dem Testbild zu sehen?",
+      "test_mode": "<p>Prüfling aus- und wieder einschalten. Beim Einschalten zeigt das Display kurz alle Segmente — mit dem Testbild vergleichen: -1888, beide Dezimalpunkte, alle Messarten-Anzeigen, Batteriesymbol. Zusätzlich alle Drehschalterstellungen durchschalten.</p>",
       "config": "TEXT(Y=PASS)",
       "range": null,
       "test_value": null,
@@ -1347,7 +1392,10 @@
       "auxalary": null,
       "resolution": null,
       "tolerance": null,
-      "uncertainty": null
+      "uncertainty": null,
+      "images": [
+        "fluke-23-lcd-testbild.svg"
+      ]
     },
     {
       "row_number": 76,

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/images/messschieber-aussenmessung.svg
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/images/messschieber-aussenmessung.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 340" font-family="sans-serif">
+  <rect width="640" height="340" fill="#ffffff"/>
+  <text x="320" y="28" text-anchor="middle" font-size="17" font-weight="bold" fill="#1f2937">Außenmessung — Endmaß zwischen den Außenmessflächen</text>
+
+  <!-- Schiene -->
+  <rect x="60" y="90" width="520" height="34" fill="#e2e8f0" stroke="#334155" stroke-width="2"/>
+  <g font-size="10" fill="#64748b">
+    <text x="90" y="112">0</text><text x="180" y="112">30</text><text x="270" y="112">60</text><text x="360" y="112">90</text><text x="450" y="112">120</text><text x="535" y="112">150</text>
+  </g>
+
+  <!-- fester Schenkel -->
+  <path d="M 60 90 L 60 250 L 92 250 L 92 124 Z" fill="#cbd5e1" stroke="#334155" stroke-width="2"/>
+  <!-- Schieber mit beweglichem Schenkel -->
+  <rect x="236" y="82" width="120" height="50" fill="#cbd5e1" stroke="#334155" stroke-width="2"/>
+  <path d="M 236 124 L 236 250 L 268 250 L 268 124 Z" fill="#cbd5e1" stroke="#334155" stroke-width="2"/>
+
+  <!-- Endmaß -->
+  <rect x="92" y="170" width="144" height="60" fill="#fcd34d" stroke="#92400e" stroke-width="2"/>
+  <text x="164" y="204" text-anchor="middle" font-size="13" font-weight="bold" fill="#78350f">Endmaß</text>
+
+  <!-- Messflächen-Markierung -->
+  <line x1="92" y1="160" x2="92" y2="240" stroke="#dc2626" stroke-width="3"/>
+  <line x1="236" y1="160" x2="236" y2="240" stroke="#dc2626" stroke-width="3"/>
+  <text x="164" y="258" text-anchor="middle" font-size="11" fill="#dc2626">Messflächen vollflächig anlegen</text>
+
+  <g font-size="12" fill="#475569">
+    <text x="320" y="290" text-anchor="middle">Endmaß mittig und winkelrecht zwischen die Außenmessflächen nehmen, mit gleichmäßiger,</text>
+    <text x="320" y="308" text-anchor="middle">gefühlvoller Messkraft schließen (kein Kippen), Anzeige erst nach Stillstand ablesen.</text>
+  </g>
+</svg>

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/images/messschieber-innenmessung.svg
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/images/messschieber-innenmessung.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 340" font-family="sans-serif">
+  <rect width="640" height="340" fill="#ffffff"/>
+  <text x="320" y="28" text-anchor="middle" font-size="17" font-weight="bold" fill="#1f2937">Innenmessung — Einstellring über den Innenmessschnäbeln</text>
+
+  <!-- Schiene unten -->
+  <rect x="60" y="220" width="520" height="34" fill="#e2e8f0" stroke="#334155" stroke-width="2"/>
+  <!-- Innenmessschnäbel oben -->
+  <path d="M 60 220 L 60 120 L 78 120 L 78 150 L 92 176 L 92 220 Z" fill="#cbd5e1" stroke="#334155" stroke-width="2"/>
+  <path d="M 262 220 L 262 176 L 276 150 L 276 120 L 294 120 L 294 220 Z" fill="#cbd5e1" stroke="#334155" stroke-width="2"/>
+
+  <!-- Einstellring -->
+  <circle cx="177" cy="120" r="88" fill="none" stroke="#92400e" stroke-width="16"/>
+  <circle cx="177" cy="120" r="80" fill="none" stroke="#fcd34d" stroke-width="8"/>
+  <text x="177" y="30" text-anchor="middle" font-size="13" font-weight="bold" fill="#78350f">Einstellring / Endmaß mit Backen</text>
+
+  <!-- Anlage-Markierung -->
+  <line x1="78" y1="112" x2="78" y2="150" stroke="#dc2626" stroke-width="3"/>
+  <line x1="276" y1="112" x2="276" y2="150" stroke="#dc2626" stroke-width="3"/>
+
+  <g font-size="12" fill="#475569">
+    <text x="320" y="290" text-anchor="middle">Schnäbel im größten Durchmesser anlegen (leicht pendeln, Umkehrpunkt der Anzeige suchen),</text>
+    <text x="320" y="308" text-anchor="middle">nicht verkanten. Der größte angezeigte Wert ist der Messwert.</text>
+  </g>
+</svg>

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/images/messschieber-tiefenmass.svg
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/images/messschieber-tiefenmass.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 340" font-family="sans-serif">
+  <rect width="640" height="340" fill="#ffffff"/>
+  <text x="320" y="28" text-anchor="middle" font-size="17" font-weight="bold" fill="#1f2937">Tiefenmaß — Messstab an der Stufe aus Endmaßen</text>
+
+  <!-- Schiene senkrecht -->
+  <rect x="290" y="60" width="34" height="150" fill="#e2e8f0" stroke="#334155" stroke-width="2"/>
+  <!-- Tiefenmessstab -->
+  <rect x="303" y="210" width="8" height="60" fill="#94a3b8" stroke="#334155" stroke-width="1.5"/>
+  <text x="360" y="245" font-size="12" fill="#475569">Tiefenmessstab</text>
+
+  <!-- Stufe aus Endmaßen -->
+  <rect x="120" y="270" width="400" height="34" fill="#fcd34d" stroke="#92400e" stroke-width="2"/>
+  <rect x="120" y="210" width="150" height="60" fill="#fbbf24" stroke="#92400e" stroke-width="2"/>
+  <text x="195" y="245" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">Endmaß</text>
+  <text x="320" y="292" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">Auflageplatte</text>
+
+  <!-- Auflage-Markierung -->
+  <line x1="270" y1="210" x2="340" y2="210" stroke="#dc2626" stroke-width="3"/>
+  <text x="430" y="205" font-size="11" fill="#dc2626">Schienenende plan auflegen</text>
+
+  <g font-size="12" fill="#475569">
+    <text x="320" y="320" text-anchor="middle">Schienenende satt auf die obere Fläche setzen, Stab bis zur Auflageplatte ausfahren — nicht kippen.</text>
+  </g>
+</svg>

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/manifest.json
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/manifest.json
@@ -5,7 +5,7 @@
   "name": "Messschieber 150 mm — Kalibrierung mit Endmaßsatz",
   "document": {
     "format": "calserver.procedure",
-    "version": 2
+    "version": 3
   },
   "plan": {
     "major_version": 0,
@@ -18,13 +18,28 @@
   "files": [
     {
       "path": "procedure.json",
-      "sha256": "d2fa1bdd548a5b7545fba19a8a4aba3a1ae7589398a92a075569322b62e6916e",
-      "size_bytes": 18947
+      "sha256": "04d7c303f5eab0065e46e934babf944b7ba8f6e69f904dc5e78feebd67baa69f",
+      "size_bytes": 19147
     },
     {
       "path": "README.md",
       "sha256": "343713f397d202adf6a0c3b7edf121a18e2eb27e12608b3848d8591319a6dd2a",
       "size_bytes": 2259
+    },
+    {
+      "path": "images/messschieber-aussenmessung.svg",
+      "sha256": "016fcc573fd1ae8d2943a91e2b77920f8c80fc475539d7c26b6d0e0d12e31fc8",
+      "size_bytes": 1899
+    },
+    {
+      "path": "images/messschieber-innenmessung.svg",
+      "sha256": "930be701f2f42508c5c7d329eb4f15325ba4a00082b2235282cb178da1781e87",
+      "size_bytes": 1531
+    },
+    {
+      "path": "images/messschieber-tiefenmass.svg",
+      "sha256": "e7149d65b14313566e58a9533cbd68da2242d41b73f23efba7bfd96f96195f99",
+      "size_bytes": 1479
     }
   ]
 }

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/procedure.json
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/procedure.json
@@ -1,6 +1,6 @@
 {
   "format": "calserver.procedure",
-  "version": 2,
+  "version": 3,
   "name": "Messschieber 150 mm — Kalibrierung mit Endmaßsatz",
   "test_steps": [
     {
@@ -187,7 +187,10 @@
         "uncertainty": 0.007,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "messschieber-aussenmessung.svg"
+      ]
     },
     {
       "row_number": 12,
@@ -373,7 +376,10 @@
         "uncertainty": 0.01,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "messschieber-innenmessung.svg"
+      ]
     },
     {
       "row_number": 23,
@@ -463,7 +469,10 @@
         "uncertainty": 0.012,
         "k": 2,
         "decision_rule": "ILAC-G8 w = U"
-      }
+      },
+      "images": [
+        "messschieber-tiefenmass.svg"
+      ]
     },
     {
       "row_number": 28,

--- a/robots.md
+++ b/robots.md
@@ -73,8 +73,17 @@ valid Prüfplan bundle end-to-end from this section alone.
 > change a rule here, update that prompt too — and vice versa. There is
 > deliberately no runtime sharing across the two repos.
 
-- Header: `{"format": "calserver.procedure", "version": 2, "name": "...", "test_steps": [...]}`.
-  Version 2 is the current maximum — never write a higher version.
+- Header: `{"format": "calserver.procedure", "version": 3, "name": "...", "test_steps": [...]}`.
+  Version 3 is the current maximum — never write a higher version.
+- **Step images (document version 3):** any step may carry
+  `"images": ["<basename>", ...]` — each entry MUST be a file in the
+  bundle's `images/` folder (`scripts/build_pruefplan_manifest.py --check`
+  enforces existence). calServer shows these pictures right at the step in
+  measurement capture. Use them for connection diagrams on group headers,
+  measuring guides and test patterns on confirmation steps (e.g. an LCD
+  test pattern with "everything as pictured? yes/no" as a
+  `TEXT(Y=PASS)` step). The step references by name; the bytes travel in
+  `images/` and become plan attachments on import.
 - `row_number` gapless from 1; `test_step` numbers unique, decimal
   sub-numbering (`1`, `1.001`, `1.002`, …) below a group header.
 - A group starts with a step `"test_type": "Header"`; ONLY headers may carry

--- a/scripts/build_pruefplan_manifest.py
+++ b/scripts/build_pruefplan_manifest.py
@@ -17,7 +17,9 @@ Zwei Modi:
       in beide Richtungen (jede Datei gelistet, jeder Listeneintrag
       vorhanden), die Eintrags-Allowlist (kein JRXML, keine Fremdformate,
       Tiefe höchstens 1) und den Kopf von procedure.json
-      (format calserver.procedure, version <= 2). Exit 1 bei Abweichung.
+      (format calserver.procedure, version <= 3) samt Schritt-Bildverweisen
+      (jedes steps[].images-Element muss als images/-Datei existieren).
+      Exit 1 bei Abweichung.
 
 Die verbindliche Lese-Semantik gehört calServer V2
 (laravel/app/Services/Procedure/ProcedurePackageService.php in
@@ -39,7 +41,7 @@ SCHEMA_PATH = REPO_ROOT / "schema" / "procedure-package.schema.json"
 PACKAGE_FORMAT = "calserver.procedure-package"
 PACKAGE_VERSION = 1
 DOCUMENT_FORMAT = "calserver.procedure"
-MAX_DOCUMENT_VERSION = 2
+MAX_DOCUMENT_VERSION = 3
 
 SCHEMA_URL = "https://calhelp.github.io/calServer-reports/schema/procedure-package.schema.json"
 
@@ -112,6 +114,21 @@ def read_document(bundle: Path) -> dict | None:
             f"{bundle.name}/procedure.json: version {version!r} — "
             f"erlaubt sind 1 bis {MAX_DOCUMENT_VERSION}"
         )
+
+    # Schritt-Bildverweise (Dokumentversion 3): jeder Name muss als
+    # images/-Datei im Bundle liegen — sonst verspricht der Schritt ein
+    # Bild, das die Messwertaufnahme nie findet.
+    steps = document.get("test_steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for image in step.get("images") or []:
+                if not isinstance(image, str) or not (bundle / "images" / image).is_file():
+                    fail(
+                        f"{bundle.name}/procedure.json: Schritt {step.get('test_step')!r} "
+                        f"referenziert fehlendes Bild {image!r} (images/)"
+                    )
     return document
 
 


### PR DESCRIPTION
## Was

Die beiden Prüfplan-Bundles bekommen **Schritt-Bilder** (Dokumentversion 3 von `calserver.procedure`, Schwester-PR mit Format + Runtime-Anzeige: calhelp/calServer-yii#3592):

- **`images/`** in beiden Bundles mit schematischen SVGs: Fluke 23 — Anschluss V/Ω, Anschluss mA/A (jeweils 5520A ↔ Prüfling) und ein **LCD-Testbild** (alle Segmente, -1888, Annunciatoren, BAT); Messschieber — Außenmessung (Endmaß zwischen den Messflächen), Innenmessung (Einstellring), Tiefenmaß (Stufe aus Endmaßen).
- **`procedure.json` in Dokumentversion 3**: Die Messgruppen-Köpfe referenzieren ihr Anschlussbild per `images`-Feld, der Fluke-Abschlussschritt zeigt das LCD-Testbild mit der Ja/Nein-Frage „Segmenttest: alles wie auf dem Testbild zu sehen?" (`TEXT(Y=PASS)`). calServer zeigt die Bilder in der Messwertaufnahme direkt am Schritt.
- **`build_pruefplan_manifest.py`**: akzeptiert Dokumentversion 3; `--check` prüft zusätzlich, dass jeder `steps[].images`-Verweis als `images/`-Datei existiert (ein Tippfehler im Namen fällt in CI auf).
- **`robots.md` §0.3**: `images`-Feld dokumentiert, inkl. des Bausteins „Bild anzeigen + Ja/Nein-Bestätigung" als Teil des Ablauf-Skripts.

Hinweis: Bundles in Dokumentversion 3 setzen eine calServer-Version mit der neuen Lesegrenze voraus (Versions-Gate lehnt v3 auf älteren Ständen ab, statt Bilder still zu verlieren).

## Validierung

- `python3 scripts/build_pruefplan_manifest.py --check` grün (beide Bundles, inkl. Bild-Existenzprüfung).
- End-to-End im Schwester-PR: Feature-Test importiert ein Paket mit `images/` + Schritt-Verweis, lädt es in eine Kalibrierung und holt Namen (Wizard + Lauf-Baum) und Bytes (`/calibrations/{ctag}/step-images/{name}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEvPJbMZGfBnrnfdayBJhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEvPJbMZGfBnrnfdayBJhy)_