### PR TITLE
Prüfplan-Bundles: READMEs zeigen die Schritt-Bilder

### DIFF
--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -147,6 +147,23 @@ jobs:
             cp -R schema "${SITE_DIR}/schema"
           fi
 
+          # Bundle-Bilder der Prüfpläne unter downloads/info/images/ ablegen:
+          # die READMEs betten sie relativ als images/… ein, und derselbe Pfad
+          # muss im entpackten ZIP, auf GitHub und auf der Info-Seite tragen.
+          # Flach (Namen sind je Bundle eindeutig vergeben) — eine Kollision
+          # überschriebe still, deshalb schlägt sie hier fehl.
+          mkdir -p "${DOWNLOADS_DIR}/info/images"
+          for bundle_image in PRUEFPLAN-*/images/*; do
+            if [ -f "${bundle_image}" ]; then
+              target="${DOWNLOADS_DIR}/info/images/$(basename "${bundle_image}")"
+              if [ -e "${target}" ]; then
+                echo "Bildname doppelt über Bundles hinweg: $(basename "${bundle_image}")" >&2
+                exit 1
+              fi
+              cp "${bundle_image}" "${target}"
+            fi
+          done
+
           : > "${METADATA_FILE}"
           shopt -s nullglob
 

--- a/PRUEFPLAN-FLUKE-23/README.md
+++ b/PRUEFPLAN-FLUKE-23/README.md
@@ -2,8 +2,8 @@
 
 Vollständiger Prüfablauf für ein **Fluke 23 Series II** Digitalmultimeter
 (3200 Digits) gegen einen **Fluke 5520A** Kalibrator — 76 Schritte in
-14 Gruppen, im kanonischen calServer-Vorlagenformat
-(`calserver.procedure`, Version 2), paketiert als
+14 Messgruppen, im kanonischen calServer-Vorlagenformat
+(`calserver.procedure`, Version 3), paketiert als
 `calserver.procedure-package`.
 
 ## Paketinhalt
@@ -11,8 +11,11 @@ Vollständiger Prüfablauf für ein **Fluke 23 Series II** Digitalmultimeter
 | Datei | Zweck |
 | --- | --- |
 | `manifest.json` | Manifest: jede Datei mit SHA-256-Prüfsumme und Größe |
-| `procedure.json` | Der Prüfplan (76 Schritte, 14 Gruppen) |
+| `procedure.json` | Der Prüfplan (76 Schritte, 14 Messgruppen) |
 | `README.md` | Diese Beschreibung |
+| `images/fluke-23-anschluss-v-ohm.svg` | Anschlussbild V/Ω/Diode (5520A ↔ Prüfling) |
+| `images/fluke-23-anschluss-a.svg` | Anschlussbild mA/A (5520A ↔ Prüfling) |
+| `images/fluke-23-lcd-testbild.svg` | LCD-Testbild für den Segmenttest |
 
 Das Manifest ist der Manipulationsanker des Formats: calServer lehnt beim
 Import jedes Paket ab, dessen Inhalt vom Manifest abweicht — in beide
@@ -28,7 +31,21 @@ Richtungen. Das maschinenlesbare Schema:
 3. Über das Ketten-Symbol der Prozedur zuordnen, dann wie gewohnt
    genehmigen, freigeben, in eine Kalibrierung laden
 
-Alternativ nimmt derselbe Import-Knopf auch das nackte `procedure.json`.
+Alternativ nimmt derselbe Import-Knopf auch das nackte `procedure.json` —
+dann allerdings ohne die Bilder, die nur das Paket mitbringt.
+
+## Schritt-Bilder (Dokumentversion 3)
+
+Die Schritte referenzieren die Bilder aus `images/` per `images`-Feld;
+calServer zeigt sie in der Messwertaufnahme und im Probelauf direkt am
+Schritt. Die Messgruppen-Köpfe tragen ihr Anschlussbild, der
+Abschlussschritt den Segmenttest als Ja/Nein-Frage (`TEXT(Y=PASS)`):
+
+![Anschluss V/Ω/Diode: 5520A NORMAL an V/Ω und COM des Prüflings](images/fluke-23-anschluss-v-ohm.svg)
+
+![Anschluss mA/A: 5520A AUX an mA bzw. A und COM des Prüflings](images/fluke-23-anschluss-a.svg)
+
+![LCD-Testbild: alle Segmente, -1888, Annunciatoren und BAT sichtbar](images/fluke-23-lcd-testbild.svg)
 
 ## Was die Gruppenebene hier trägt
 

--- a/PRUEFPLAN-FLUKE-23/manifest.json
+++ b/PRUEFPLAN-FLUKE-23/manifest.json
@@ -23,8 +23,8 @@
     },
     {
       "path": "README.md",
-      "sha256": "bfcd3ac7b8558b5a7c703cb4804c7ae296e35ff592b67ef08e74c761eee667d9",
-      "size_bytes": 2636
+      "sha256": "887733aef68348f2a9f15d87c4b2008a7cbf61ce7fadcf9de96294a06e594964",
+      "size_bytes": 3580
     },
     {
       "path": "images/fluke-23-anschluss-a.svg",

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/README.md
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/README.md
@@ -2,8 +2,8 @@
 
 Vollständiger Prüfablauf für einen **Messschieber 0–150 mm**
 (Ziffernschrittwert 0,01 mm) gegen einen **Endmaßsatz nach DIN EN ISO 3650
-Klasse 1** — 34 Schritte in 3 Gruppen, im kanonischen
-calServer-Vorlagenformat (`calserver.procedure`, Version 2), paketiert als
+Klasse 1** — 34 Schritte in 3 Messgruppen, im kanonischen
+calServer-Vorlagenformat (`calserver.procedure`, Version 3), paketiert als
 `calserver.procedure-package`.
 
 ## Paketinhalt
@@ -11,8 +11,11 @@ calServer-Vorlagenformat (`calserver.procedure`, Version 2), paketiert als
 | Datei | Zweck |
 | --- | --- |
 | `manifest.json` | Manifest: jede Datei mit SHA-256-Prüfsumme und Größe |
-| `procedure.json` | Der Prüfplan (34 Schritte, 3 Gruppen) |
+| `procedure.json` | Der Prüfplan (34 Schritte, 3 Messgruppen) |
 | `README.md` | Diese Beschreibung |
+| `images/messschieber-aussenmessung.svg` | Messanleitung Außenmessung (Endmaß zwischen den Messflächen) |
+| `images/messschieber-innenmessung.svg` | Messanleitung Innenmessung (Einstellring) |
+| `images/messschieber-tiefenmass.svg` | Messanleitung Tiefenmaß (Stufe aus Endmaßen) |
 
 Das Manifest ist der Manipulationsanker des Formats: calServer lehnt beim
 Import jedes Paket ab, dessen Inhalt vom Manifest abweicht — in beide
@@ -28,7 +31,20 @@ Richtungen. Das maschinenlesbare Schema:
 3. Über das Ketten-Symbol der Prozedur zuordnen, dann wie gewohnt
    genehmigen, freigeben, in eine Kalibrierung laden
 
-Alternativ nimmt derselbe Import-Knopf auch das nackte `procedure.json`.
+Alternativ nimmt derselbe Import-Knopf auch das nackte `procedure.json` —
+dann allerdings ohne die Bilder, die nur das Paket mitbringt.
+
+## Schritt-Bilder (Dokumentversion 3)
+
+Jeder Messgruppen-Kopf referenziert seine Messanleitung aus `images/` per
+`images`-Feld; calServer zeigt sie in der Messwertaufnahme und im
+Probelauf direkt am Schritt — wie messen, nicht nur was:
+
+![Außenmessung: Endmaß zwischen den Messflächen, Schnabel nah am Balken](images/messschieber-aussenmessung.svg)
+
+![Innenmessung: Einstellring mit den Innenmessschneiden antasten](images/messschieber-innenmessung.svg)
+
+![Tiefenmaß: Stufe aus Endmaßen, Tiefenmaßstab auf der Planfläche](images/messschieber-tiefenmass.svg)
 
 ## Der TUR ist hier Absicht
 

--- a/PRUEFPLAN-MESSSCHIEBER-150MM/manifest.json
+++ b/PRUEFPLAN-MESSSCHIEBER-150MM/manifest.json
@@ -23,8 +23,8 @@
     },
     {
       "path": "README.md",
-      "sha256": "343713f397d202adf6a0c3b7edf121a18e2eb27e12608b3848d8591319a6dd2a",
-      "size_bytes": 2259
+      "sha256": "34de591a426a486e7181c7f4645ff059d11469a0fd0283d8ed00d09a8066dd50",
+      "size_bytes": 3187
     },
     {
       "path": "images/messschieber-aussenmessung.svg",


### PR DESCRIPTION
## Was

Anwender-Feedback: Am Download war von den Schritt-Bildern nichts zu sehen. Die ZIPs selbst sind vollständig (geprüft: beide veröffentlichten Pakete enthalten `images/` und `procedure.json` in Dokumentversion 3) — aber die READMEs nannten noch „Version 2", listeten die Bilder nicht im Paketinhalt und zeigten sie nirgends.

- **Beide READMEs:** Dokumentversion 3, `images/`-Dateien in der Paketinhalt-Tabelle, neuer Abschnitt „Schritt-Bilder" mit eingebetteten SVGs (Anschlussbilder + LCD-Testbild beim Fluke, Messanleitungen beim Messschieber), Hinweis dass das nackte `procedure.json` ohne Bilder importiert
- **Eingebettet mit relativen Pfaden** (`images/…`): tragen im entpackten ZIP, in der GitHub-Ansicht und auf der Download-Info-Seite
- **`publish-downloads.yml`:** legt die Bundle-Bilder unter `downloads/info/images/` ab, damit die relativen Pfade auch auf der gerenderten Info-Seite auflösen; eine Namenskollision zwischen Bundles bricht den Publish ab statt still zu überschreiben
- **Manifeste** per `--write` regeneriert (README-Prüfsummen)

## Validierung

- `python3 scripts/build_pruefplan_manifest.py --check` grün (beide Bundles, je 5 Dateien konsistent)

## Verwandt

- Schwester-PR (Bilder auch in der Editor-Vorschau von calServer): calhelp/calServer-yii#3615

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEvPJbMZGfBnrnfdayBJhy)_