### PR TITLE
feat(order): Contract 1.8 und der Auftragsbeleg als Systembericht

### DIFF
--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -23,12 +23,12 @@ andere den Auftraggeber. Das Template verzweigt nur noch auf `document.type`.
 | `subreports/positions-delivery.jrxml` | Positionen **ohne Preise** für Lieferscheine (Pos/Beschreibung/Menge/Einheit); wird bei `document.type = delivery_note` automatisch gewählt. Dieselbe Gruppierung |
 | `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz — § 14 UStG-Aufschlüsselung) |
 | `subreports/custom-fields.jrxml` | Zusatzfelder (W41xx); `document.custom_fields_list`-Array via `subDataSource("document.custom_fields_list")` — Label/Wert je konfiguriertem Feld, generisch |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.7), gewöhnlicher Auftrag |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.8), gewöhnlicher Auftrag |
 | `main_reports/sample-data-collective.json` | Beispiel-Datensatz **Sammelrechnung**: Positionen aus zwei Aufträgen, `collective.is_collective = true` |
 | `main_reports/order-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 | `main_reports/order-json-sample-collective_adapter.xml` | Data-Adapter für die Vorschau des Sammelfalls (im Studio umschalten) |
 
-## Contract `order-document` (v1.7)
+## Contract `order-document` (v1.8)
 
 Wurzelobjekt mit `meta`, `document` (Nummer/Datum/Status/**Typ**/Kommentar/
 Rechtstext, `delivery_condition`/`delivery_costs`, `custom_fields` als Objekt
@@ -85,11 +85,12 @@ Zeilen aus (durchgängig `isBlankWhenNull` — es wird nie „null" gedruckt).
 > offer/order/billing/delivery) sowie die Blöcke `supplier` und `recipient`.
 > Bestehende v1.0/v1.1-Bindungen bleiben unverändert.
 >
-> **Ausblick ZUGFeRD:** Für Rechnungen ist eine optionale hybride
-> ZUGFeRD-/Factur-X-Ausgabe (PDF/A-3 + EN-16931-XML) geplant — Konzept siehe
+> **ZUGFeRD ist da (v1.8):** Für Rechnungen erzeugt calServer optional die
+> hybride ZUGFeRD-/Factur-X-Ausgabe (PDF/A-3b + eingebettetes EN-16931-XML) —
+> aus **diesem** Datensatz, nicht aus einer zweiten Abfrage. Siehe Abschnitt
+> „E-Rechnung" unten und
 > [`docs/konzept-zugferd-rechnung.md`](https://github.com/calhelp/calServer-yii/blob/develop/docs/konzept-zugferd-rechnung.md)
-> im calServer-yii-Repo. Der v1.2-Datensatz (supplier/recipient/tax_groups)
-> liefert dafür bereits die wesentlichen EN-16931-Felder.
+> im calServer-yii-Repo.
 
 > **Auftragsrabatt (W4114):** Die Muster sind rabattfrei, damit die Summen
 > eindeutig sind. Die exakte V1-Rabatt-Steuer-Arithmetik bei mehreren Steuersätzen
@@ -136,6 +137,50 @@ Zum Ansehen: `sample-data-collective.json` mit dem Adapter
 > `source_order.delivery_recipient` (der Subreport kommt während der Iteration
 > über `positions` nicht an `collective.source_orders` heran). Bestehende
 > Bindungen bleiben unverändert.
+
+### E-Rechnung nach ZUGFeRD / EN 16931 (v1.8)
+
+Dieses Bundle ist der **Systembericht „Auftragsbeleg"** — die feste, nicht
+löschbare Zeile, die calServer auf jeder Installation für den Auftragsbeleg
+anlegt. Das ist nicht nur Ordnung in der Berichtsverwaltung: die E-Rechnung
+hängt daran. Ihre Aktivierung und die Feldzuordnungen sitzen als
+Report-Variablen an genau dieser Zeile, und ein rechtsverbindlicher Beleg
+kann nicht an „irgendeinem Auftragsbericht, den jemand mal angelegt hat"
+hängen.
+
+**Einschalten:** Report-Variable `zugferd` an diesem Bericht auf `en16931`
+(Empfehlung), `basic` oder `extended`. Nicht gesetzt heißt aus — dann bleibt
+alles reines PDF. Die Ausgabe greift **nur** bei `document.type = invoice`
+und Format PDF; Angebot, Auftragsbestätigung und Lieferschein bleiben
+unberührt.
+
+**Was v1.8 an Feldern dazulegt** (alle additiv, kein Wert ändert sich):
+
+| Feld | EN 16931 | Herkunft |
+|---|---|---|
+| `document.invoice_number` | BT-1 | Auftragsnummer, oder das W41xx-Feld aus `zugferd_invoice_number_field` |
+| `document.due_date` | BT-9 | Belegdatum + `company_payment_due_days` |
+| `document.delivery_date` | BT-72 | W41xx-Feld aus `zugferd_delivery_date_field` (§ 14 UStG Leistungsdatum) |
+| `document.buyer_reference` | BT-10 | W41xx-Feld aus `zugferd_buyer_reference_field` (B2G: Leitweg-ID) |
+| `supplier.country_code`, `*.country_code` | BT-40 / BT-55 | `country` normalisiert auf ISO 3166-1 alpha-2 |
+| `positions[].unit_code` | BT-130 | `unit` übersetzt nach UN/ECE Rec 20 („Stk" → `H87`, „Std" → `HUR`, sonst `C62`) |
+
+**Fürs Template heißt das: nichts muss sich ändern.** `unit` bleibt der
+Freitext, der gedruckt wird; `country` bleibt der Klartext im Adressblock.
+Die Codes stehen daneben und sind für die Maschine. Wer will, druckt
+Leistungs- und Fälligkeitsdatum jetzt aus dem Datensatz, statt wie bisher
+einen Hinweistext zu setzen.
+
+**Prüfen vor dem Scharfschalten:**
+`GET /api/v2/bookings/{id}/reports/{reportId}/einvoice` liefert das reine
+CII-XML — oder 422 mit der Liste dessen, was noch fehlt (Steuernummer,
+Ländercode, Rechnungsnummer). Derselbe Endpunkt bedient XRechnung-Empfänger,
+die kein Hybrid-PDF nehmen.
+
+**Grenzen, bewusst:** Steuerkategorien nur `S` (Regelsatz) und `Z` (0 %).
+§ 19 UStG (Kleinunternehmer), Reverse Charge und innergemeinschaftliche
+Lieferung brauchen zusätzlich Befreiungsgründe und andere Kategorie-Codes —
+das ist Ausbaustufe. Gutschrift/Storno (BT-3 = 381) ebenso.
 
 ## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
 

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data-collective.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data-collective.json
@@ -1,13 +1,17 @@
 {
   "meta": {
     "contract": "order-document",
-    "schema_version": "1.7",
+    "schema_version": "1.8",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE"
   },
   "document": {
     "number": "SR-2026-0001",
     "date": "2026-07-15",
+    "invoice_number": "RE-2026-0118",
+    "due_date": "2026-08-14",
+    "delivery_date": "2026-07-10",
+    "buyer_reference": "BST-2026-9911",
     "status": "Auftrag",
     "type": "order_confirmation",
     "type_label": "Auftragsbestätigung",
@@ -55,7 +59,8 @@
     "bank_name": "Musterbank",
     "iban": "DE02 1203 0000 0000 2020 51",
     "bic": "BYLADEM1001",
-    "payment_terms": "Zahlbar innerhalb von 14 Tagen ohne Abzug."
+    "payment_terms": "Zahlbar innerhalb von 14 Tagen ohne Abzug.",
+    "country_code": "DE"
   },
   "customer": {
     "name": "Muster GmbH",
@@ -71,7 +76,8 @@
       "city": "Beispielstadt",
       "email": "erika@muster.example",
       "phone": "+49 30 1234500"
-    }
+    },
+    "country_code": "DE"
   },
   "delivery": {
     "name": "Muster GmbH – Wareneingang",
@@ -79,7 +85,8 @@
     "street": "Wareneingang, Tor 3",
     "zip": "54322",
     "city": "Beispielstadt-Industriegebiet",
-    "country": "DE"
+    "country": "DE",
+    "country_code": "DE"
   },
   "invoice": {
     "name": "Muster GmbH – Buchhaltung",
@@ -87,7 +94,8 @@
     "street": "Rechnungsstelle, Postfach 90",
     "zip": "54320",
     "city": "Beispielstadt",
-    "country": "DE"
+    "country": "DE",
+    "country_code": "DE"
   },
   "recipient": {
     "role": "customer",
@@ -104,7 +112,8 @@
       "city": "Beispielstadt",
       "email": "erika@muster.example",
       "phone": "+49 30 1234500"
-    }
+    },
+    "country_code": "DE"
   },
   "collective": {
     "is_collective": true,
@@ -150,6 +159,7 @@
       "article_type": "article",
       "quantity": 2,
       "unit": "Stk",
+      "unit_code": "H87",
       "price": 100.0,
       "discount": 0.0,
       "tax": 19.0,
@@ -167,6 +177,7 @@
       "article_type": "article",
       "quantity": 1,
       "unit": "Stk",
+      "unit_code": "H87",
       "price": 50.0,
       "discount": 10.0,
       "tax": 7.0,
@@ -184,6 +195,7 @@
       "article_type": "article",
       "quantity": 1,
       "unit": "Stk",
+      "unit_code": "H87",
       "price": 80.0,
       "discount": 0.0,
       "tax": 19.0,

--- a/ORDER-JSON-SAMPLE/main_reports/sample-data.json
+++ b/ORDER-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,13 +1,17 @@
 {
   "meta": {
     "contract": "order-document",
-    "schema_version": "1.7",
+    "schema_version": "1.8",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE"
   },
   "document": {
     "number": "AU-2026-0042",
     "date": "2026-07-15",
+    "invoice_number": "RE-2026-0117",
+    "due_date": "2026-08-14",
+    "delivery_date": "2026-07-10",
+    "buyer_reference": "BST-2026-9911",
     "status": "Auftrag",
     "type": "order_confirmation",
     "type_label": "Auftragsbestätigung",
@@ -55,7 +59,8 @@
     "bank_name": "Musterbank",
     "iban": "DE02 1203 0000 0000 2020 51",
     "bic": "BYLADEM1001",
-    "payment_terms": "Zahlbar innerhalb von 14 Tagen ohne Abzug."
+    "payment_terms": "Zahlbar innerhalb von 14 Tagen ohne Abzug.",
+    "country_code": "DE"
   },
   "customer": {
     "name": "Muster GmbH",
@@ -71,7 +76,8 @@
       "city": "Beispielstadt",
       "email": "erika@muster.example",
       "phone": "+49 30 1234500"
-    }
+    },
+    "country_code": "DE"
   },
   "delivery": {
     "name": "Muster GmbH – Wareneingang",
@@ -79,7 +85,8 @@
     "street": "Wareneingang, Tor 3",
     "zip": "54322",
     "city": "Beispielstadt-Industriegebiet",
-    "country": "DE"
+    "country": "DE",
+    "country_code": "DE"
   },
   "invoice": {
     "name": "Muster GmbH – Buchhaltung",
@@ -87,7 +94,8 @@
     "street": "Rechnungsstelle, Postfach 90",
     "zip": "54320",
     "city": "Beispielstadt",
-    "country": "DE"
+    "country": "DE",
+    "country_code": "DE"
   },
   "recipient": {
     "role": "customer",
@@ -104,7 +112,8 @@
       "city": "Beispielstadt",
       "email": "erika@muster.example",
       "phone": "+49 30 1234500"
-    }
+    },
+    "country_code": "DE"
   },
   "collective": {
     "is_collective": false,
@@ -119,6 +128,7 @@
       "article_type": "article",
       "quantity": 2,
       "unit": "Stk",
+      "unit_code": "H87",
       "price": 100.0,
       "discount": 0.0,
       "tax": 19.0,
@@ -136,6 +146,7 @@
       "article_type": "article",
       "quantity": 1,
       "unit": "Stk",
+      "unit_code": "H87",
       "price": 50.0,
       "discount": 10.0,
       "tax": 7.0,

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ calServer V2 verwendet ein neues Datenbankschema mit **lesbaren Feldnamen** (`se
   | Systembericht | Bundle | Wann calServer ihn erzeugt |
   |---------------|--------|-----------------------------|
   | Leihschein | [`LOCATION-JSON-SAMPLE`](LOCATION-JSON-SAMPLE/) | Beim Buchen einer Ausleihe, als Anhang der Leihschein-E-Mail |
+  | Preisliste | [`PRICE-LIST-JSON-SAMPLE`](PRICE-LIST-JSON-SAMPLE/) | Auf der Preislisten-Seite, je Preisgruppe und Stichtag |
+  | Auftragsbeleg | [`ORDER-JSON-SAMPLE`](ORDER-JSON-SAMPLE/) | Angebot, Auftragsbestätigung, Lieferschein und Rechnung aus dem Auftrag — und die Quelle der E-Rechnung nach ZUGFeRD/EN 16931 |
 
   Details: [Systemberichte](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/admin/berichte/systemberichte.md).
 - Bestehende Vorlagen bitte **nicht** auf das V2-Schema-SQL umschreiben — die Strategie und der Migrationspfad sind hier dokumentiert: [Evaluierung: JasperReports-Strategie für calServer V2](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md).


### PR DESCRIPTION
Gegenstück zum PR in `calhelp/calServer-yii` (ZUGFeRD/E-Rechnung). Hier
liegt nur das, was die Vorlagen betrifft.

## Was sich ändert

**`ORDER-JSON-SAMPLE` ist jetzt das Referenz-Bundle eines Systemberichts.**
calServer V2 legt für den Auftragsbeleg eine feste, nicht löschbare Zeile
in der Berichtsverwaltung an — den Platzhalter, der auf dieses Bundle
wartet. An dieser Zeile hängt die E-Rechnung nach ZUGFeRD/EN 16931.

**Contract `order-document` v1.7 → v1.8**, rein additiv:

| Feld | EN 16931 | Herkunft |
|---|---|---|
| `document.invoice_number` | BT-1 | Auftragsnummer, oder ein W41xx-Feld |
| `document.due_date` | BT-9 | Belegdatum + Zahlungsziel |
| `document.delivery_date` | BT-72 | W41xx-Feld (§ 14 UStG Leistungsdatum) |
| `document.buyer_reference` | BT-10 | W41xx-Feld (B2G: Leitweg-ID) |
| `supplier.country_code`, `*.country_code` | BT-40 / BT-55 | `country` normalisiert auf ISO 3166-1 alpha-2 |
| `positions[].unit_code` | BT-130 | `unit` übersetzt nach UN/ECE Rec 20 |

## Für die Vorlagen ändert sich nichts

`unit` bleibt der Freitext, der gedruckt wird („Stk"), `country` der
Klartext im Adressblock („Deutschland"). Die Codes stehen daneben und
sind für die Maschine. Keine bestehende Bindung bricht, kein Wert ändert
sich.

Was neu möglich wird: Leistungs- und Fälligkeitsdatum lassen sich jetzt
aus dem Datensatz drucken, statt wie bisher als Hinweistext im Template
zu stehen.

## Dateien

- `ORDER-JSON-SAMPLE/README.md` — Contract-Version, neuer Abschnitt
  „E-Rechnung nach ZUGFeRD / EN 16931" (Einschalten, Stammdaten, Prüfen,
  Grenzen)
- `ORDER-JSON-SAMPLE/main_reports/sample-data.json` und
  `sample-data-collective.json` — beide Beispieldatensätze tragen die
  neuen Felder, damit sich das Bundle im Studio gegen einen vollständigen
  Contract bauen lässt
- `README.md` — in der Systembericht-Tabelle fehlten bisher **sowohl die
  Preisliste als auch der Auftragsbeleg**; beide nachgetragen

## Grenzen (bewusst)

Steuerkategorien nur `S` (Regelsatz) und `Z` (0 %). § 19 UStG,
Reverse Charge und innergemeinschaftliche Lieferung brauchen zusätzliche
Befreiungsgründe — Ausbaustufe. Gutschrift/Storno (BT-3 = 381) ebenso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnE5duV3B9Xw3rN2HE9jnU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnE5duV3B9Xw3rN2HE9jnU)_