### PR TITLE
Sticker: Barcode aus dem Datensatz, Stapeldruck ohne zweite Vorlage

### DIFF
--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md
@@ -15,12 +15,52 @@ DB-agnostisch, keine V1-Codespalten.
 
 ## Felder
 
-`device.asset_number` (QR + Text), `device.cost_center`, `device.active_location.location_1/2`,
+`barcode.value` + `barcode.type` (der Code), `device.asset_number` (Text),
+`device.cost_center`, `device.active_location.location_1/2`,
 `device.last_calibration_date`, `device.next_calibration_date`, `customer.name`
 (OE-Bezeichnung/Gruppe). Dataset-Builder: Laravel `InventoryReportDataBuilder`.
 
-> Der QR wird runner-seitig aus dem Feldwert gerendert (`<jr:QRCode>`, ZXing) — kein
-> vorgeneriertes Bild, kein `Barcode`-Model, DB-agnostisch.
+> **Der Code kommt aus `barcode`, nicht aus `device.asset_number`.** Welches Feld
+> codiert wird und in welcher Symbologie, entscheiden die Regeln
+> (*Grundeinstellungen > Barcode & Etikett*); der Datensatz liefert beides fertig
+> aufgelöst. Deshalb passt diese eine Datei auch beim Kunden, der eine Hausnummer
+> aus einem Zusatzfeld codiert — sonst bräuchte er einen Fork.
+>
+> Die Symbologie schaltet über `printWhenExpression` gegen `barcode.type`:
+> `qrcode` (ZXing), `datamatrix`, `code128`, `code39` (barcode4j). Ein Wert, für
+> den keine Komponente da ist, druckt schlicht keinen Code — das Etikett bleibt
+> lesbar.
+>
+> Gerendert wird runner-seitig aus dem Feldwert — kein vorgeneriertes Bild, kein
+> `Barcode`-Model, DB-agnostisch.
+
+## Systembericht-Platzhalter und Stapeldruck (ab calServer V2)
+
+Dieses Bundle gehört auf den Platzhalter **Geräteetikett** in
+**Administration > Berichtsverwaltung** (Grid `inventory`/Ordner `inventories`). Der Platzhalter ist
+ab Werk da, trägt das Kennzeichen *Systembericht* und ist als Etikett markiert —
+das ist, was **„Etikett drucken"** an die Grid-Zeile hängt.
+
+Der Contract wird am Bundle erkannt; eine Report-Variable `data_contract` ist auf
+dem Platzhalter **nicht nötig** (der Grid-Standard ist bereits
+`inventory-datasheet`). Nötig bleibt sie nur, wenn das Bundle auf einer anders
+konfigurierten Zeile liegt.
+
+**Stapeldruck.** Werden im Grid mehrere Zeilen markiert, druckt calServer sie in
+*einem* Lauf in eine PDF. Dafür schickt es statt eines Dokuments
+
+```json
+{ "meta": { "count": 40 }, "stickers": [ <dokument>, <dokument>, … ] }
+```
+
+und lässt den Runner `stickers` durchlaufen. Jedes Element ist ein
+**vollständiges Dokument** in genau der Form, die `sample-data.json` zeigt —
+deshalb funktioniert diese Vorlage in beiden Fällen unverändert. **Es ist keine
+Stapel-Fassung der Vorlage nötig und keine gewünscht**: Wer hier auf ein Array
+umbaut, bricht den Einzeldruck.
+
+Entwurf und Vorschau laufen weiter gegen `sample-data.json`, also gegen einen
+einzelnen Datensatz.
 
 ## ⚠️ Leeres Blatt = fehlende Datenquelle
 

--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/cal-inv-zebra-json-sample.jrxml
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/cal-inv-zebra-json-sample.jrxml
@@ -18,14 +18,47 @@
 	<field name="loc_building" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_1]]></fieldDescription></field>
 	<field name="loc_room" class="java.lang.String"><fieldDescription><![CDATA[device.active_location.location_2]]></fieldDescription></field>
 	<field name="org_unit" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<!-- Was codiert wird und in welcher Symbologie, entscheiden die Regeln
+	     (Grundeinstellungen > Barcode & Etikett). Der Datensatz liefert sie
+	     fertig aufgeloest, damit dieselbe Vorlage bei jedem Mandanten passt. -->
+	<field name="barcode_value" class="java.lang.String"><fieldDescription><![CDATA[barcode.value]]></fieldDescription></field>
+	<field name="barcode_type" class="java.lang.String"><fieldDescription><![CDATA[barcode.type]]></fieldDescription></field>
+	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[$F{barcode_value} == null ? ($F{asset_number} == null ? "" : $F{asset_number}) : $F{barcode_value}]]></variableExpression></variable>
+	<variable name="symbology" class="java.lang.String"><variableExpression><![CDATA[$F{barcode_type} == null ? "datamatrix" : $F{barcode_type}]]></variableExpression></variable>
 	<detail>
 		<band height="120">
 			<!-- QR of the inventory/asset number -->
 			<componentElement>
-				<reportElement x="6" y="20" width="80" height="80"/>
+				<reportElement x="6" y="20" width="80" height="80">
+					<printWhenExpression><![CDATA[$V{symbology}.equals("qrcode")]]></printWhenExpression>
+				</reportElement>
 				<jr:QRCode>
-					<jr:codeExpression><![CDATA[$F{asset_number} == null ? "" : $F{asset_number}]]></jr:codeExpression>
+					<jr:codeExpression><![CDATA[$V{code}]]></jr:codeExpression>
 				</jr:QRCode>
+			</componentElement>
+			<componentElement>
+				<reportElement x="6" y="20" width="80" height="80">
+					<printWhenExpression><![CDATA[$V{symbology}.equals("datamatrix")]]></printWhenExpression>
+				</reportElement>
+				<jr:DataMatrix>
+					<jr:codeExpression><![CDATA[$V{code}]]></jr:codeExpression>
+				</jr:DataMatrix>
+			</componentElement>
+			<componentElement>
+				<reportElement x="6" y="34" width="80" height="52">
+					<printWhenExpression><![CDATA[$V{symbology}.equals("code128")]]></printWhenExpression>
+				</reportElement>
+				<jr:Code128>
+					<jr:codeExpression><![CDATA[$V{code}]]></jr:codeExpression>
+				</jr:Code128>
+			</componentElement>
+			<componentElement>
+				<reportElement x="6" y="34" width="80" height="52">
+					<printWhenExpression><![CDATA[$V{symbology}.equals("code39")]]></printWhenExpression>
+				</reportElement>
+				<jr:Code39>
+					<jr:codeExpression><![CDATA[$V{code}]]></jr:codeExpression>
+				</jr:Code39>
 			</componentElement>
 			<staticText><reportElement x="6" y="102" width="80" height="10"/><textElement textAlignment="Center"><font size="6"/></textElement><text><![CDATA[Inventar-Nr.]]></text></staticText>
 			<!-- Right info column -->

--- a/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "inventory-datasheet",
-    "schema_version": "1.1",
+    "schema_version": "1.3",
     "generated_at": "2026-07-15T10:00:00+00:00",
     "locale": "de-DE"
   },
@@ -27,6 +27,7 @@
     "next_calibration_date": "2027-06-30",
     "custom_fields": { "customer_tag": "KND-DMM-7" }
   },
+  "barcode": { "type": "datamatrix", "field": "asset_number", "value": "INV-9001" },
   "customer": {
     "name": "Muster GmbH",
     "customer_number": "K-1001",

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/README.md
@@ -17,6 +17,34 @@ V2-Nachbildung des **DAkkS-Kalibrieraufklebers 12 mm** (Phase C). Micro-Label
 `accreditation.mark_number_1` (+ `mark_number_2`), `calibration.calibration_date`.
 Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
 
+## Systembericht-Platzhalter und Stapeldruck (ab calServer V2)
+
+Dieses Bundle gehört auf den Platzhalter **Kalibrieraufkleber** in
+**Administration > Berichtsverwaltung** (Grid `calibration`/Ordner `calibrations`). Der Platzhalter ist
+ab Werk da, trägt das Kennzeichen *Systembericht* und ist als Etikett markiert —
+das ist, was **„Etikett drucken"** an die Grid-Zeile hängt.
+
+Der Contract wird am Bundle erkannt; eine Report-Variable `data_contract` ist auf
+dem Platzhalter **nicht nötig** (der Grid-Standard ist bereits
+`calibration-certificate`). Nötig bleibt sie nur, wenn das Bundle auf einer anders
+konfigurierten Zeile liegt.
+
+**Stapeldruck.** Werden im Grid mehrere Zeilen markiert, druckt calServer sie in
+*einem* Lauf in eine PDF. Dafür schickt es statt eines Dokuments
+
+```json
+{ "meta": { "count": 40 }, "stickers": [ <dokument>, <dokument>, … ] }
+```
+
+und lässt den Runner `stickers` durchlaufen. Jedes Element ist ein
+**vollständiges Dokument** in genau der Form, die `sample-data.json` zeigt —
+deshalb funktioniert diese Vorlage in beiden Fällen unverändert. **Es ist keine
+Stapel-Fassung der Vorlage nötig und keine gewünscht**: Wer hier auf ein Array
+umbaut, bricht den Einzeldruck.
+
+Entwurf und Vorschau laufen weiter gegen `sample-data.json`, also gegen einen
+einzelnen Datensatz.
+
 ## ⚠️ Leeres Blatt = fehlende Datenquelle
 
 Ohne JSON-Datenquelle rendert das Label leer. Vorschau: mitgelieferter Adapter

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/README.md
@@ -17,6 +17,34 @@ Landscape (≈ 18×24,7 mm), gefüllt aus einem **JSON-Datensatz** (Contract
 `accreditation.mark_number_1` (+ `mark_number_2`), `calibration.calibration_date`,
 `calibration.next_calibration_date`. Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
 
+## Systembericht-Platzhalter und Stapeldruck (ab calServer V2)
+
+Dieses Bundle gehört auf den Platzhalter **Kalibrieraufkleber** in
+**Administration > Berichtsverwaltung** (Grid `calibration`/Ordner `calibrations`). Der Platzhalter ist
+ab Werk da, trägt das Kennzeichen *Systembericht* und ist als Etikett markiert —
+das ist, was **„Etikett drucken"** an die Grid-Zeile hängt.
+
+Der Contract wird am Bundle erkannt; eine Report-Variable `data_contract` ist auf
+dem Platzhalter **nicht nötig** (der Grid-Standard ist bereits
+`calibration-certificate`). Nötig bleibt sie nur, wenn das Bundle auf einer anders
+konfigurierten Zeile liegt.
+
+**Stapeldruck.** Werden im Grid mehrere Zeilen markiert, druckt calServer sie in
+*einem* Lauf in eine PDF. Dafür schickt es statt eines Dokuments
+
+```json
+{ "meta": { "count": 40 }, "stickers": [ <dokument>, <dokument>, … ] }
+```
+
+und lässt den Runner `stickers` durchlaufen. Jedes Element ist ein
+**vollständiges Dokument** in genau der Form, die `sample-data.json` zeigt —
+deshalb funktioniert diese Vorlage in beiden Fällen unverändert. **Es ist keine
+Stapel-Fassung der Vorlage nötig und keine gewünscht**: Wer hier auf ein Array
+umbaut, bricht den Einzeldruck.
+
+Entwurf und Vorschau laufen weiter gegen `sample-data.json`, also gegen einen
+einzelnen Datensatz.
+
 ## ⚠️ Leeres Blatt = fehlende Datenquelle
 
 Ohne JSON-Datenquelle rendert das Label leer. Vorschau: mitgelieferter Adapter


### PR DESCRIPTION
Begleitender PR zu [calServer-yii#3647](https://github.com/calhelp/calServer-yii/pull/3647), der Geräteetikett und Kalibrieraufkleber als Systemberichte einführt.

## Was sich ändert

**Der Zebra-Sticker codierte `device.asset_number` fest.** Damit passt er beim ersten Kunden, der etwas anderes codiert, nicht mehr — und der musste bisher forken. Ab calServer V2 liefert der Datensatz einen Block `barcode`:

```json
{ "type": "datamatrix", "field": "asset_number", "value": "INV-9001" }
```

`type` und `field` kommen aus den Grundeinstellungen (**Barcode-Typ**, **Barcode-Feld**), `value` ist der bereits aufgelöste Feldwert. Die Vorlage liest jetzt den und schaltet die Symbologie über `printWhenExpression`: QR und DataMatrix wie bisher, dazu Code 128 und Code 39.

**Code 128/39 kommen als barcode4j-Komponenten** (`jr:Code128`, `jr:Code39`), nicht als `jr:barbecue`. Die Barbecue-Bibliothek liegt nicht im Runner-JAR — ein solches Etikett bliebe leer. (Vier `jr:barbecue`-Vorkommen in älteren Vorlagen dieses Repos haben dasselbe Problem; hier nicht angefasst.)

## Stapeldruck: bitte nicht auf ein Array umbauen

Markiert der Anwender mehrere Grid-Zeilen, schickt calServer

```json
{ "meta": { "count": 40 }, "stickers": [ <dokument>, <dokument>, … ] }
```

und lässt den Runner `stickers` durchlaufen. Jedes Element ist ein **vollständiges Dokument** in genau der Form, die `sample-data.json` zeigt. Deshalb druckt dieselbe unveränderte Datei ein Etikett und vierzig — eine Stapel-Fassung der Vorlage ist nicht nötig und nicht gewünscht. Wer hier auf ein Array umbaut, bricht den Einzeldruck.

Für den Entwurf heißt das: weiter gegen `sample-data.json` bauen, also gegen einen einzelnen Datensatz.

## READMEs

Alle drei Sticker-Bundles halten jetzt fest, auf welchen Systembericht-Platzhalter sie gehören (**Geräteetikett** bzw. **Kalibrieraufkleber**) und dass sie dort **keine** `data_contract`-Variable brauchen — der Grid-Standard ist bereits der richtige Contract.

## Prüfung

Die Vorlage wurde gegen den echten Runner-Klassenpfad kompiliert und gefüllt:

- Einzeldokument → 1 Seite, PDF erzeugt
- Dasselbe Dokument dreimal im `stickers`-Array → 3 Seiten, aus derselben Datei
- Alle vier angebotenen Symbologien (`qrcode`, `datamatrix`, `code128`, `code39`) rendern, d. h. jeder Encoder liegt im JAR

Der entsprechende Test liegt als `LabelBatchRenderTest` im Runner (PR calServer-yii#3647) und läuft dort in CI mit.

**Nicht geprüft:** der tatsächliche Ausdruck auf einem Zebra ZD621. Dass die Vorlage rendert, ist gezeigt; ob die 30×15-mm-Bahn sauber durchläuft, zeigt erst ein Drucker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6g2U6VkntGspE8t5jQq4V

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6g2U6VkntGspE8t5jQq4V)_