### PR TITLE
PRICE-LIST-JSON-SAMPLE: zweisprachig drucken (Contract 1.1)

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/README.md
+++ b/PRICE-LIST-JSON-SAMPLE/README.md
@@ -3,8 +3,8 @@
 Die **Preisliste**, wie ein Labor sie seinem Kunden übergibt: Kategoriebaum mit
 den geltenden Kalibrierpreisen (Typausnahmen eingerückt), Zusatzleistungen mit
 Mengenstaffel, Standardartikel und die Konditions-Fußnoten. Gefüllt aus einem
-**JSON-Datensatz** (Contract `price-list` v1.0) statt aus SQL — DB-agnostisch,
-keine V1-Codespalten.
+**JSON-Datensatz** (Contract `price-list` v1.1) statt aus SQL — DB-agnostisch,
+keine V1-Codespalten. **Zweisprachig**, wenn der Datensatz es ist.
 
 ## Der Briefkopf steht nicht in dieser Vorlage
 
@@ -33,17 +33,51 @@ ist ein Layout-Eingriff und gehört in die Vorlage.
 | `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.0) |
 | `main_reports/price-list-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
-## Contract `price-list` (v1.0)
+## Zweisprachig, ohne Fallunterscheidung in der Vorlage
+
+Eine Preisliste geht an einen deutschen und an einen ausländischen Kunden.
+calServer führt dafür je Preiskategorie und je Katalogartikel einen **zweiten
+Namen**; welche Sprache das ist, entscheidet eine Einstellung des Mandanten.
+
+**Die Vorlage entscheidet nichts davon.** Der Datensatz-Builder löst die
+angeforderte Fassung auf, bevor er den Datensatz herausgibt:
+
+| Fassung (`list.language.mode`) | `name` | `name_secondary` |
+|---|---|---|
+| `primary` | der gepflegte Name | `null` |
+| `secondary` | der Name in der Zweitsprache (fehlt er: der gepflegte) | `null` |
+| `both` | der gepflegte Name | der Name in der Zweitsprache, sonst `null` |
+
+Damit folgt **jede** Vorlage der Sprachwahl, die nur `name` liest — auch eine
+selbst gebaute aus der Zeit vor 1.1. Die mitgelieferten Subreports drucken
+zusätzlich `name_secondary` als eingerückte zweite Zeile; ist das Feld leer,
+fällt die Zeile weg (`isRemoveLineWhenBlank`) und das Layout ist Punkt für
+Punkt dasselbe wie zuvor. Der Kopf nennt die Fassung („Sprache: Deutsch /
+English"), sobald sie nicht die erste ist — sonst sieht man einem Blatt auf dem
+Schreibtisch nicht an, welche Liste man in der Hand hält.
+
+Eine Fallunterscheidung in JRXML wäre der teuerste Ort dafür: drei Fassungen in
+einer Vorlage sind drei Vorlagen in einer, und jede Änderung müsste sie alle
+treffen.
+
+## Contract `price-list` (v1.1)
 
 Dataset-Builder: Laravel `PriceListReportDataBuilder`; derselbe Aufbau, den die
 Preislisten-Seite liest (`PriceListService`). Datensatz zum Vorlagenbau:
 `GET /api/v2/price-list/reports/dataset`.
 
 Der Umschlag trägt `meta` (Contract, Schema-Version, Erzeugungszeit, Locale) und
-`list` mit `group`, `date`, `currency`, `derivation`, `surcharges[]`,
-`calibration[]` (je Kategorie `number`, `name`, `depth`, `amount`, `derived`,
-`inherited_from`, `exceptions[]`, `scales[]`), `services[]`, `articles[]` und
-`counts`.
+`list` mit `group`, `date`, `currency`, `language`, `derivation`, `surcharges[]`,
+`calibration[]` (je Kategorie `number`, `name`, `name_secondary`, `depth`,
+`amount`, `derived`, `inherited_from`, `exceptions[]`, `scales[]`), `services[]`,
+`articles[]` und `counts`.
+
+`list.language` trägt `mode` (`primary` / `secondary` / `both`), `primary`,
+`primary_label`, `secondary` und `secondary_label`. `secondary` ist `null`,
+wenn der Mandant nur eine Sprache führt — dann ist `mode` immer `primary`.
+
+**Neu in 1.1** (additiv, 1.0-Vorlagen laufen unverändert weiter):
+`list.language` und `name_secondary` an jeder benannten Zeile.
 
 Zwei Feinheiten, die man beim Lesen des Datensatzes leicht übersieht:
 
@@ -52,6 +86,8 @@ Zwei Feinheiten, die man beim Lesen des Datensatzes leicht übersieht:
 - **`derived` heißt abgeleitet, nicht geschätzt.** Der Betrag entsteht aus der
   Kondition der Preisgruppe auf dem Listenpreis; er ist so verbindlich wie ein
   eingetragener.
+- **Gerätetypen tragen keinen Zweitnamen.** „Fluke 87V" heißt in jeder Sprache
+  so; die Typausnahmen bleiben deshalb einsprachig, auch in der Fassung `both`.
 
 ### Bewusst nicht gedruckt
 
@@ -90,5 +126,15 @@ Alle sieben JRXML übersetzen mit JasperReports 6.20.6, und der Hauptbericht
 füllt gegen `sample-data.json` durch (eine Seite). Geprüft wurde dabei auch,
 dass die zweistufige Auflösung `subDataSource("exceptions")` innerhalb des
 Kategorie-Subreports wirklich greift — die Typausnahme erscheint eingerückt
-unter ihrer Kategorie. Die pixelgenaue Abnahme des Layouts (report-runner)
-bleibt wie gehabt maßgeblich.
+unter ihrer Kategorie.
+
+Für 1.1 kam ein zweiter Lauf dazu: derselbe Datensatz einmal mit und einmal
+ohne Zweitnamen. **Ohne** sind Inhalt und Position jedes Textelements
+identisch mit der Ausgabe der 1.0-Vorlage — die zweite Zeile kostet eine
+einsprachige Liste also keinen Millimeter. Der mitgelieferte
+`sample-data.json` steht bewusst auf `mode: both` und lässt zwei Zeilen
+unübersetzt (`Klimaschrank / Ofen`, `Express-Bearbeitung`), damit beide Fälle
+in der Vorschau sichtbar sind.
+
+Die pixelgenaue Abnahme des Layouts (report-runner) bleibt wie gehabt
+maßgeblich.

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 Preisliste (customer-facing), Contract "price-list" v1.0. Gefüllt aus einem
+  V2 Preisliste (customer-facing), Contract "price-list" v1.1. Gefüllt aus einem
   JSON-Datensatz — kein SQL, keine V1-Codespalten.
 
   DER BRIEFKOPF STEHT NICHT IN DIESER VORLAGE. Er kommt je Mandant über das
@@ -14,6 +14,13 @@
   Kalibrierpreise (Kategoriebaum mit Typausnahmen) → Zusatzleistungen →
   Standardartikel → Konditions-Fußnoten. Alle Abschnitte verschwinden
   vollständig, wenn ihr Array leer ist.
+
+  ZWEISPRACHIG (Contract 1.1): Welche der beiden Sprachen gedruckt wird,
+  entscheidet der Datensatz-Builder — `name` trägt bereits die angeforderte,
+  `name_secondary` ist nur in der Fassung "beide" gefüllt. Die Vorlage druckt,
+  was sie bekommt; eine Vorlage, die selbst zwischen drei Fassungen
+  unterscheidet, wäre drei Vorlagen in einer. Der Kopf nennt die Fassung, damit
+  man einem ausgedruckten Blatt ansieht, welche Liste man in der Hand hält.
 
   Bewusst NICHT gedruckt: `list.other_type_prices`. Das ist die gekappte Liste
   der Typpreise ohne Kategorie (Obergrenze 200) — ein Übergangsbestand auf dem
@@ -45,6 +52,9 @@
 	<field name="count_categories" class="java.lang.Integer"><fieldDescription><![CDATA[list.counts.categories]]></fieldDescription></field>
 	<field name="count_services" class="java.lang.Integer"><fieldDescription><![CDATA[list.counts.services]]></fieldDescription></field>
 	<field name="count_articles" class="java.lang.Integer"><fieldDescription><![CDATA[list.counts.articles]]></fieldDescription></field>
+	<field name="language_mode" class="java.lang.String"><fieldDescription><![CDATA[list.language.mode]]></fieldDescription></field>
+	<field name="language_primary_label" class="java.lang.String"><fieldDescription><![CDATA[list.language.primary_label]]></fieldDescription></field>
+	<field name="language_secondary_label" class="java.lang.String"><fieldDescription><![CDATA[list.language.secondary_label]]></fieldDescription></field>
 	<!--
 		Die oberen 128 pt (≈ 45 mm) des Titelbandes bleiben leer: dort stempelt
 		das PDF-Overlay den Briefkopf des Mandanten. Der Freiraum ist bewusst
@@ -73,6 +83,19 @@
 				</reportElement>
 				<textElement><font size="7" isItalic="true"/></textElement>
 				<textFieldExpression><![CDATA["Diese Gruppe leitet vom Listenpreis ab: " + ($F{derivation_value} != null && $F{derivation_value}.signum() >= 0 ? "+" : "") + ($F{derivation_value} == null ? "" : new java.text.DecimalFormat("#,##0.##").format($F{derivation_value})) + ("absolute".equals($F{derivation_mode}) ? " " + ($F{currency} == null ? "" : $F{currency}) : " %") + "."]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement style="Label" x="380" y="210" width="90" height="10">
+					<printWhenExpression><![CDATA[$F{language_mode} != null && !"primary".equals($F{language_mode})]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Sprache]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement style="Value" x="470" y="210" width="91" height="10">
+					<printWhenExpression><![CDATA[$F{language_mode} != null && !"primary".equals($F{language_mode})]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right"><font size="8"/></textElement>
+				<textFieldExpression><![CDATA["both".equals($F{language_mode}) ? ($F{language_primary_label} == null ? "" : $F{language_primary_label}) + " / " + ($F{language_secondary_label} == null ? "" : $F{language_secondary_label}) : ($F{language_secondary_label} == null ? "" : $F{language_secondary_label})]]></textFieldExpression>
 			</textField>
 			<line><reportElement x="0" y="218" width="561" height="1"/></line>
 		</band>

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,15 +1,28 @@
 {
   "meta": {
     "contract": "price-list",
-    "schema_version": "1.0",
+    "schema_version": "1.1",
     "generated_at": "2026-08-10T09:00:00+02:00",
     "locale": "de-DE"
   },
   "list": {
-    "group": { "id": "g-1", "name": "Händler" },
+    "group": {
+      "id": "g-1",
+      "name": "Händler"
+    },
     "date": "2026-08-10",
     "currency": "EUR",
-    "derivation": { "mode": "percent", "value": -15 },
+    "language": {
+      "mode": "both",
+      "primary": "de",
+      "primary_label": "Deutsch",
+      "secondary": "en",
+      "secondary_label": "English"
+    },
+    "derivation": {
+      "mode": "percent",
+      "value": -15
+    },
     "surcharges": [
       {
         "reference_id": "DAkkS",
@@ -31,6 +44,7 @@
         "id": "pk-100",
         "number": "PK100",
         "name": "Elektrische Messgeräte",
+        "name_secondary": "Electrical instruments",
         "parent_id": null,
         "depth": 0,
         "amount": null,
@@ -43,6 +57,7 @@
         "id": "pk-100-01",
         "number": "PK100.01",
         "name": "Multimeter handheld",
+        "name_secondary": "Handheld multimeter",
         "parent_id": "pk-100",
         "depth": 1,
         "amount": 84.15,
@@ -63,18 +78,26 @@
         "id": "pk-100-02",
         "number": "PK100.02",
         "name": "Multimeter Tischgerät",
+        "name_secondary": "Benchtop multimeter",
         "parent_id": "pk-100",
         "depth": 1,
         "amount": 101.15,
         "derived": true,
         "inherited_from": null,
         "exceptions": [],
-        "scales": [{ "min_quantity": 5, "price": null, "discount": 10 }]
+        "scales": [
+          {
+            "min_quantity": 5,
+            "price": null,
+            "discount": 10
+          }
+        ]
       },
       {
         "id": "pk-200",
         "number": "PK200",
         "name": "Temperatur",
+        "name_secondary": "Temperature",
         "parent_id": null,
         "depth": 0,
         "amount": null,
@@ -87,6 +110,7 @@
         "id": "pk-200-01",
         "number": "PK200.01",
         "name": "Temperaturfühler",
+        "name_secondary": "Temperature sensor",
         "parent_id": "pk-200",
         "depth": 1,
         "amount": 50.15,
@@ -99,38 +123,69 @@
         "id": "pk-200-02",
         "number": "PK200.02",
         "name": "Klimaschrank / Ofen",
+        "name_secondary": null,
         "parent_id": "pk-200",
         "depth": 1,
         "amount": 296.65,
         "derived": false,
-        "inherited_from": { "id": "pk-200", "name": "Temperatur" },
+        "inherited_from": {
+          "id": "pk-200",
+          "name": "Temperatur",
+          "name_secondary": "Temperature"
+        },
         "exceptions": [],
         "scales": []
       }
     ],
-    "other_type_prices": { "count": 0, "truncated": false, "entries": [] },
+    "other_type_prices": {
+      "count": 0,
+      "truncated": false,
+      "entries": []
+    },
     "services": [
       {
         "id": "sv-1",
         "name": "Zusätzlicher Messpunkt",
+        "name_secondary": "Additional measuring point",
         "amount": 25.0,
         "variants": [],
         "scales": [
-          { "min_quantity": 5, "price": null, "discount": 10 },
-          { "min_quantity": 10, "price": null, "discount": 20 }
+          {
+            "min_quantity": 5,
+            "price": null,
+            "discount": 10
+          },
+          {
+            "min_quantity": 10,
+            "price": null,
+            "discount": 20
+          }
         ]
       },
       {
         "id": "sv-2",
         "name": "Express-Bearbeitung",
+        "name_secondary": null,
         "amount": 60.0,
         "variants": [],
         "scales": []
       }
     ],
     "articles": [
-      { "id": "a-1", "name": "Gerät reinigen", "amount": 12.0, "unit": "EA" },
-      { "id": "a-2", "name": "Versandpauschale", "amount": 9.5, "unit": "EA" }
+      {
+        "id": "a-1",
+        "name": "Gerät reinigen",
+        "name_secondary": "Device cleaning",
+        "amount": 12.0,
+        "unit": "EA"
+      },
+      {
+        "id": "a-2",
+        "name": "Versandpauschale",
+        "name_secondary": "Shipping flat rate",
+        "amount": 9.5,
+        "unit": "EA"
+      }
     ],
     "counts": {
       "categories": 6,

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-articles.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-articles.jrxml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  Standardartikel der Preisliste, Contract "price-list" v1.0 (`list.articles`).
+  Standardartikel der Preisliste, Contract "price-list" v1.1 (`list.articles`).
   Eine Zeile je Artikel: Bezeichnung, Betrag, Einheit.
+
+  ZWEISPRACHIG (Contract 1.1): `name` trägt die angeforderte Sprache,
+  `name_secondary` ist nur in der Fassung "beide" gefüllt und fällt sonst als
+  Zeile weg.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-articles" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0005-4000-8000-000000000005">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="name_secondary" class="java.lang.String"><fieldDescription><![CDATA[name_secondary]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
 	<field name="unit" class="java.lang.String"><fieldDescription><![CDATA[unit]]></fieldDescription></field>
 	<detail>
-		<band height="13">
+		<band height="23">
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="404" height="12"/>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
@@ -26,6 +31,11 @@
 					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
 				</reportElement>
 				<textFieldExpression><![CDATA[$P{Currency} + ($F{unit} != null ? " / " + $F{unit} : "")]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement positionType="Float" x="12" y="12" width="392" height="10" isRemoveLineWhenBlank="true"/>
+				<textElement><font size="8" isItalic="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{name_secondary}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  Kategoriebaum der Preisliste, Contract "price-list" v1.0. Eine Zeile je
+  Kategoriebaum der Preisliste, Contract "price-list" v1.1. Eine Zeile je
   Preiskategorie aus `list.calibration`; die Baumtiefe steckt als Zahl in
   `depth` und wird als Einrückung gerechnet (der Datensatz ist bereits in
   Baumreihenfolge sortiert — hier wird nicht umsortiert).
@@ -11,6 +11,13 @@
 
   Typausnahmen hängen als Array `exceptions` an der Kategorie und laufen über
   einen eingebetteten Subreport — die einzige zweistufige Stelle des Bündels.
+
+  ZWEISPRACHIG (Contract 1.1): `name` trägt bereits die angeforderte Sprache —
+  der Datensatz-Builder löst das auf, nicht diese Vorlage. `name_secondary` ist
+  nur in der Fassung "beide" gefüllt und erscheint dann als zweite Zeile unter
+  der Bezeichnung; sonst fällt die Zeile weg (isRemoveLineWhenBlank) und die
+  Vorlage druckt wie zuvor. Deshalb steht hier keine Fallunterscheidung: JRXML
+  ist der teuerste Ort dafür.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-categories" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0001-4000-8000-000000000001">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
@@ -18,12 +25,13 @@
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
 	<field name="number" class="java.lang.String"><fieldDescription><![CDATA[number]]></fieldDescription></field>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="name_secondary" class="java.lang.String"><fieldDescription><![CDATA[name_secondary]]></fieldDescription></field>
 	<field name="depth" class="java.lang.Integer"><fieldDescription><![CDATA[depth]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
 	<field name="derived" class="java.lang.Boolean"><fieldDescription><![CDATA[derived]]></fieldDescription></field>
 	<field name="inherited_from_name" class="java.lang.String"><fieldDescription><![CDATA[inherited_from.name]]></fieldDescription></field>
 	<detail>
-		<band height="15">
+		<band height="25">
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="70" height="12">
 					<printWhenExpression><![CDATA[$F{depth} != null && $F{depth}.intValue() == 0]]></printWhenExpression>
@@ -67,8 +75,13 @@
 				<textElement textAlignment="Right"><font size="6"/></textElement>
 				<textFieldExpression><![CDATA[($F{derived} != null && $F{derived}.booleanValue() ? "abgel." : "") + ($F{inherited_from_name} != null ? " geerbt" : "")]]></textFieldExpression>
 			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement positionType="Float" x="86" y="12" width="318" height="10" isRemoveLineWhenBlank="true"/>
+				<textElement><font size="8" isItalic="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{name_secondary}]]></textFieldExpression>
+			</textField>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="12" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="22" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$P{Currency}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("exceptions")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-exceptions.jasper"]]></subreportExpression>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  Zusatzleistungen der Preisliste, Contract "price-list" v1.0 (`list.services`).
+  Zusatzleistungen der Preisliste, Contract "price-list" v1.1 (`list.services`).
 
   Die Mengenstaffel steht nicht als eigene Tabelle, sondern als Zusatz hinter
   dem Betrag ("ab 5: −10 %") — auf einer Kundenliste ist sie eine Kondition,
   keine zweite Preiszeile. Gerendert aus `scales` über einen eingebetteten
   Subreport, damit beliebig viele Stufen mitlaufen.
+
+  ZWEISPRACHIG (Contract 1.1): `name` trägt die angeforderte Sprache,
+  `name_secondary` ist nur in der Fassung "beide" gefüllt und fällt sonst als
+  Zeile weg. Aufgelöst wird das im Datensatz-Builder, nicht hier.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-services" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0003-4000-8000-000000000003">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Reportpath" class="java.lang.String"/>
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
+	<field name="name_secondary" class="java.lang.String"><fieldDescription><![CDATA[name_secondary]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
 	<detail>
-		<band height="15">
+		<band height="25">
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="404" height="12"/>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
@@ -31,8 +36,13 @@
 				</reportElement>
 				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
 			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement positionType="Float" x="12" y="12" width="392" height="10" isRemoveLineWhenBlank="true"/>
+				<textElement><font size="8" isItalic="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{name_secondary}]]></textFieldExpression>
+			</textField>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="12" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="22" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$P{Currency}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("scales")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-scales.jasper"]]></subreportExpression>


### PR DESCRIPTION
Die Preisliste kann in calServer jetzt zweisprachig geführt werden: je Preiskategorie und je Katalogartikel gibt es einen zweiten Namen. Dieses Bündel druckt ihn.

## Die Vorlage entscheidet nichts über die Sprache

Der Datensatz-Builder löst die angeforderte Fassung auf, **bevor** er den Datensatz herausgibt:

| Fassung (`list.language.mode`) | `name` | `name_secondary` |
|---|---|---|
| `primary` | der gepflegte Name | `null` |
| `secondary` | der Name in der Zweitsprache (fehlt er: der gepflegte) | `null` |
| `both` | der gepflegte Name | der Name in der Zweitsprache, sonst `null` |

Damit folgt **jede** Vorlage der Sprachwahl, die nur `name` liest — auch eine selbst gebaute aus der Zeit vor 1.1. Drei Fassungen im JRXML wären drei Vorlagen in einer gewesen.

## Was sich im Bündel ändert

- `price-list-categories`, `price-list-services` und `price-list-articles` drucken `name_secondary` als eingerückte, kursive zweite Zeile. Ist das Feld leer, fällt die Zeile weg (`isRemoveLineWhenBlank`).
- Der Kopf nennt die Fassung („Sprache: Deutsch / English"), sobald sie nicht die erste ist — sonst sieht man einem Blatt auf dem Schreibtisch nicht an, welche Liste man in der Hand hält.
- Typausnahmen bleiben einsprachig: „Fluke 87V" heißt in jeder Sprache so.
- `sample-data.json` steht auf `mode: both` und lässt zwei Zeilen bewusst unübersetzt, damit beide Fälle in der Vorschau sichtbar sind.
- README: Contract-Beschreibung auf 1.1, Abschnitt zur Zweisprachigkeit.

Keine neuen Parameter — die Sprachangaben kommen als Felder aus `list.language`, `parameters.json` bleibt unverändert.

## Geprüft

Mit JasperReports 6.20.6: alle sieben JRXML übersetzen, der Hauptbericht füllt gegen `sample-data.json` einseitig durch.

Dazu ein zweiter Lauf mit demselben Datensatz **ohne** Zweitnamen: Inhalt und Position jedes Textelements sind identisch mit der Ausgabe der 1.0-Vorlage. Die zweite Zeile kostet eine einsprachige Liste also keinen Millimeter.

`scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` laufen fehlerfrei durch.

Passender Backend-/Frontend-PR: calhelp/calServer-yii (Branch `claude/bilingual-price-list-3kja2m`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5WyrU1fypDTPUD7D33ou8

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5WyrU1fypDTPUD7D33ou8)_