### PR TITLE
docs(dakks): Konformitätsspalte liest nur pass_fail, und nur vier Schreibweisen

### DIFF
--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -109,6 +109,30 @@ python3 scripts/dcc330_writer.py \
 > `dcc330_writer.py` ist der PTB-3.3.0-Nachfolger des einfacheren
 > `dcc_xml_writer.py` (calhelp-Format).
 
+## Konformitätsspalte: welche Werte die Vorlage liest
+
+Die Spalte „Konformität" hängt an **einem** Feld: `results[].pass_fail`.
+`Results.jrxml` vergleicht den Wert (case-insensitiv, getrimmt) gegen genau
+vier Schreibweisen — MET/TEAMs `Points.cPointPassFailStatus`:
+
+| `pass_fail` | Druck | Bedeutung laut Legende |
+|-------------|-------|------------------------|
+| `Pass` | `i.T.` | in Toleranz |
+| `Fail` | `!` | außerhalb der Spezifikation |
+| `Pass Indeterminate` | `?` | innerhalb, aber mit Messunsicherheit keine Konformitätsaussage möglich |
+| `Fail Indeterminate` | `!?` | außerhalb, aber keine negative Konformitätsaussage möglich |
+
+Alles andere — auch leer, auch `P`/`F`, auch `Conditional` — druckt eine leere
+Zelle. In der Variante `MeasurementDetails=1` kommt ein zweites Gatter dazu:
+gedruckt wird nur, wenn `fsc` „EVAL" oder „PICE" enthält.
+
+Die Felder `conformity`, `test_status` und `guardband_meth` des Contracts sind
+**nicht** gebunden: das Bundle ist die byte-genaue Kopie des V1-Originals, und
+das kannte sie nicht. calServer normalisiert deshalb backendseitig nach
+`pass_fail` (`CalibrationReportDataBuilder`), bevor der Datensatz hier ankommt —
+eine Zeile, deren Entscheidung nur in `test_status` steht (MET/TRACK, alte
+V1-Laufzeit), erscheint dadurch mit Konformität statt mit leerer Spalte.
+
 ## ⚠️ Leeres/weißes Blatt?
 
 Das Bundle ist datenquellenlos. Ohne JSON-Datenquelle (Studio-Preview ohne


### PR DESCRIPTION
Begleitet [calServer-yii#3679](https://github.com/calhelp/calServer-yii/pull/3679). Keine Änderung an einer Vorlage — die Bundles bleiben byte-genaue Kopien des akkreditierten V1-Originals.

Auf Kalibrierscheinen übernommener Messwerte blieb die Spalte „Konformität" leer. Der Grund steckt in `Results.jrxml`, stand aber nirgends geschrieben:

- Die Spalte hängt an **einem** Feld, `results[].pass_fail`.
- Sie druckt nur bei vier Werten (MET/TEAMs `cPointPassFailStatus`): `Pass` → `i.T.`, `Fail` → `!`, `Pass Indeterminate` → `?`, `Fail Indeterminate` → `!?`. Alles andere, auch `P`/`F`, auch `Conditional`, auch leer, druckt eine leere Zelle.
- In der Variante `MeasurementDetails=1` kommt ein zweites Gatter dazu: gedruckt wird nur, wenn `fsc` „EVAL" oder „PICE" enthält.
- `conformity`, `test_status` und `guardband_meth` des Contracts sind **nicht** gebunden — das V1-Original kannte sie nicht, und die byte-genaue Ableitung ist mehr wert als die Bindung.

Deshalb normalisiert calServer backendseitig nach `pass_fail`, bevor der Datensatz hier ankommt. Der README-Abschnitt hält beides fest, damit die nächste Fehlersuche nicht wieder bei der Schriftart anfängt.

---
_Generated by [Claude Code](https://claude.ai/code/session_018z6e5cT6VG73pwXAn9rCEg)_