### PR TITLE
fix(dakks): Messergebnis-Kopf an Datenspalten ausrichten, moderner Kopf als Standard

### DIFF
--- a/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
+++ b/DAKKS-JSON-SAMPLE/main_reports/dakks-json-sample.jrxml
@@ -33,8 +33,8 @@
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ModernResultsHeader" class="java.lang.String">
-		<parameterDescription><![CDATA[Schaltet den modernen Tabellenkopf im Results-Unterbericht ein (Y/N).]]></parameterDescription>
-		<defaultValueExpression><![CDATA["N"]]></defaultValueExpression>
+		<parameterDescription><![CDATA[Tabellenkopf-Stil im Results-Unterbericht: Standard ist der moderne Kopf ohne umlaufende Rahmen; nur ein explizites "N" schaltet auf den klassischen Kopf mit Rahmen zurück.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ReportVariantCode" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionaler Ressourcenname für Layoutvarianten. Wenn die gefundene Ressource report_template = 1 hat, wird Variante 1 aktiviert, sonst Variante 0 (Standard).]]></parameterDescription>

--- a/DAKKS-JSON-SAMPLE/parameters.json
+++ b/DAKKS-JSON-SAMPLE/parameters.json
@@ -283,8 +283,8 @@
         "en": "Modern table header"
       },
       "description": {
-        "de": "„Y“ schaltet die moderne Kopfvariante der Ergebnistabelle ein.",
-        "en": "\"Y\" enables the modern header variant of the results table."
+        "de": "Standard ist der moderne Tabellenkopf ohne umlaufende Rahmen; nur ein explizites „N“ schaltet auf den klassischen Kopf zurück.",
+        "en": "The modern header without surrounding rules is the default; only an explicit \"N\" switches back to the classic header."
       },
       "role": "variable",
       "group": "Ergebnistabelle",
@@ -292,21 +292,21 @@
       "input": "select",
       "options": [
         {
-          "value": "N",
-          "label": {
-            "de": "klassisch",
-            "en": "classic"
-          }
-        },
-        {
           "value": "Y",
           "label": {
             "de": "modern",
             "en": "modern"
           }
+        },
+        {
+          "value": "N",
+          "label": {
+            "de": "klassisch",
+            "en": "classic"
+          }
         }
       ],
-      "default": "N"
+      "default": "Y"
     },
     {
       "name": "ExpUncType",

--- a/DAKKS-JSON-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/Results.jrxml
@@ -13,8 +13,8 @@
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ModernResultsHeader" class="java.lang.String">
-		<parameterDescription><![CDATA[Umschalter für einen modernen Tabellenkopf ohne umlaufende Rahmen (Y/N).]]></parameterDescription>
-		<defaultValueExpression><![CDATA["N"]]></defaultValueExpression>
+		<parameterDescription><![CDATA[Tabellenkopf-Stil: Standard ist der moderne Kopf ohne umlaufende Rahmen; nur ein explizites "N" schaltet auf den klassischen Kopf mit Rahmen zurück.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Results_end_note" class="java.lang.String">
 		<parameterDescription><![CDATA[Textbaustein, der das Ende des Ergebnisberichts markiert.]]></parameterDescription>
@@ -126,6 +126,12 @@
     && !$P{MeasurementDetails}.toString().trim().isEmpty()
     && $P{MeasurementDetails}.toString().trim().matches("^-?\\d+$")
 ) ? Integer.valueOf($P{MeasurementDetails}.toString().trim()) : Integer.valueOf(1)]]></variableExpression>
+	</variable>
+	<variable name="UseModernHeader" class="java.lang.Boolean" resetType="None">
+		<variableExpression><![CDATA[Boolean.valueOf(
+    $P{ModernResultsHeader} == null
+    || !$P{ModernResultsHeader}.toString().trim().equalsIgnoreCase("N")
+)]]></variableExpression>
 	</variable>
 	<variable name="NominalValue" class="java.lang.String">
 		<variableExpression><![CDATA[$F{fixq}==null || $F{fixq}.trim().isEmpty()
@@ -415,34 +421,24 @@
 	<columnHeader>
 		<band height="54">
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="4ed0627d-9fa2-4009-b007-8bec51d8fe39">
-					<printWhenExpression><![CDATA[(
-        $P{ModernResultsHeader} == null
-        || !$P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
-    )
+				<reportElement x="0" y="0" width="535" height="54" uuid="e4a28495-8ada-558b-aa23-c874ef0c282e">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
     && (
         $V{MeasurementDetailsValue} == null
         || $V{MeasurementDetailsValue}.intValue() == 1
     )]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-                                        <reportElement x="0" y="0" width="52" height="21" uuid="eafff26f-da66-47aa-9620-067984e7623d"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="0" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="02d64f75-e9ef-54a7-862a-8bb0c9408112"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="0" y="21" width="52" height="19" uuid="b60abc68-076c-493d-a3f3-9195326664bd"/>
+					<reportElement mode="Opaque" x="0" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="e7ee84d0-1c9b-5d28-b7b5-4487f13847a4"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -450,23 +446,16 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="52" y="0" width="54" height="21" uuid="7880a955-3d0e-47e0-b0ca-86f6808ec459"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="70" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="45a2cc63-30da-506d-9bcb-95aebec49050"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="52" y="21" width="54" height="19" uuid="bd32f354-0a23-4f84-8c54-8742d8eda0a9"/>
+					<reportElement mode="Opaque" x="70" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="44e4cc10-5a27-53b3-bb04-3cee82e34081"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -474,23 +463,16 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="106" y="0" width="54" height="21" uuid="b8aaaf0e-818f-4cb7-bc68-d6f5bccef281"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="124" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="0198a346-988a-5dbe-a4a5-250a38241b7d"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[untere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="106" y="21" width="54" height="19" uuid="e7e8fe51-1d3f-47b4-bac7-4bc5ffdff4cf"/>
+					<reportElement mode="Opaque" x="124" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="8a1ee1de-b8f6-5d94-a68a-bc033b31352e"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -498,23 +480,16 @@
 					<text><![CDATA[Lower Limit]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="160" y="0" width="54" height="21" uuid="ab19233c-cc95-4e62-8907-3b85cd8a99ba"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="178" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="2e172092-c6dd-512d-943d-09fc814e7d4a"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="160" y="21" width="54" height="19" uuid="c2ef9866-31f4-4f4c-a509-99fbbaa5e2a7"/>
+					<reportElement mode="Opaque" x="178" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="80087a0c-aab0-535b-b684-e715979a74c7"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -522,23 +497,16 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="214" y="0" width="54" height="21" uuid="6cfc31ec-8210-4030-ac0b-9345ad984c2a"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="232" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="d7ba22af-af6e-58c3-bc38-7f2500685d9b"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[obere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="214" y="21" width="54" height="19" uuid="c2956eb9-f42e-4a14-aeac-aec17661d608"/>
+					<reportElement mode="Opaque" x="232" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="c9670bb1-4322-5cdf-83a3-33ea7b131973"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -546,23 +514,16 @@
 					<text><![CDATA[Upper Limit]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="270" y="0" width="68" height="21" uuid="94f866dd-148e-41d4-a845-f3e0c1fee329"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="286" y="0" width="68" height="21" backcolor="#F5F7FA" uuid="a138f010-97be-5001-9f8d-beea24126bb4"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="270" y="21" width="68" height="19" uuid="ea02a971-82f0-46b7-ad62-2e39139c7570"/>
+					<reportElement mode="Opaque" x="286" y="21" width="68" height="19" backcolor="#F5F7FA" uuid="6dc00d38-0206-5c1d-a6cd-1f6c689e6bfa"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -570,23 +531,16 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="338" y="0" width="66" height="21" uuid="70528edb-30a7-46d4-af65-e17aa067d645"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="354" y="0" width="77" height="21" backcolor="#F5F7FA" uuid="91de1516-b991-5afa-9b02-1f034c5fd7bd"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="338" y="21" width="66" height="19" uuid="41fa5341-396a-4209-91b3-92c6d3498388"/>
+					<reportElement mode="Opaque" x="354" y="21" width="77" height="19" backcolor="#F5F7FA" uuid="7ce152e9-601a-52a9-87db-b78145c2d0cf"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -594,23 +548,16 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="402" y="0" width="18" height="21" uuid="42b6ddce-c26d-4176-bad0-ad7c5ba311ab"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="431" y="0" width="16" height="21" backcolor="#F5F7FA" uuid="d35b4f24-9e6a-53de-8f18-927f37bdd24c"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="402" y="21" width="18" height="19" uuid="4b7181f7-6f15-4ab7-8366-60e34fa86fda"/>
+					<reportElement mode="Opaque" x="431" y="21" width="16" height="19" backcolor="#F5F7FA" uuid="dc5a1f69-6ca9-5a12-a435-504d73f284f1"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -618,23 +565,16 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="420" y="0" width="115" height="21" uuid="bcbd02e7-375c-458f-b6bf-e7f832f6b5ad"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="447" y="0" width="88" height="21" backcolor="#F5F7FA" uuid="22727bb3-72cc-55de-b5e0-f398ee1e0d12"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="420" y="21" width="115" height="19" uuid="95a9d488-0a25-4f7f-9a41-6b3a566768f6"/>
+					<reportElement mode="Opaque" x="447" y="21" width="88" height="19" backcolor="#F5F7FA" uuid="47bf83d3-97ce-5284-a947-aaa27f1af637"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -643,621 +583,15 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="2a2dbf93-a3a0-4ca8-ac05-3a65f86b9b7c">
-					<printWhenExpression><![CDATA[(
-        $P{ModernResultsHeader} == null
-        || !$P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
-    )
-    && false]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-                                        <reportElement x="0" y="0" width="118" height="21" uuid="a7184f69-9081-4a6c-9b0a-dc3b8504922e"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messbedingungen]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="0" y="21" width="118" height="19" uuid="b46e08e6-1619-412d-8b11-1dd8c9a10da6"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measuring Condition]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="118" y="0" width="80" height="21" uuid="8554890d-19f0-4928-9369-9b1be7df2b5e"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Sollwert]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="118" y="21" width="80" height="19" uuid="310c16ba-55c6-4afe-8ee2-18a0dfb52079"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[True Value]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="198" y="0" width="100" height="21" uuid="7e6864f5-ab6f-4ba6-88ff-51b6b2960a90"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messwert]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="198" y="21" width="100" height="19" uuid="19b8e41c-2d68-4c1b-8614-4c1b5c22dbeb"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measured Value]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="298" y="0" width="70" height="21" uuid="072b0cdb-1d3a-4c08-8b89-d1613d2ff34e"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Abweichung]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="298" y="21" width="70" height="19" uuid="f4573e83-06a5-4f7b-9e46-f7620f4e7be9"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Deviation]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="368" y="0" width="100" height="21" uuid="a812070a-0c7f-45c7-bf57-12d39f1438ba"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[erweiterte Messunsicherheit]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="368" y="21" width="100" height="19" uuid="a6ec4148-796b-45fd-90ff-930936395c5b"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="468" y="0" width="27" height="21" uuid="adce91d0-9b05-462c-93ed-e319e4fb21c9"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="468" y="21" width="27" height="19" uuid="9a00a2a0-9b18-48e7-9a37-ebf44487ee0a"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="495" y="0" width="40" height="21" uuid="417947b5-72b4-4f9e-9019-f080eebd1b9c"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Konformität]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="495" y="21" width="40" height="19" uuid="7e17b356-1dc9-46bf-9d6e-8f4e2bc1c5c9"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Conformity]]></text>
-				</staticText>
-			</frame>
-			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="9b0b621c-5db8-4b1a-a781-fc377ac87c0f">
-					<printWhenExpression><![CDATA[$P{ModernResultsHeader} != null
-    && $P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
+				<reportElement x="0" y="0" width="535" height="54" uuid="69210bf0-eb53-50c4-8de2-6a9b7bc7f93c">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
     && (
         $V{MeasurementDetailsValue} == null
         || $V{MeasurementDetailsValue}.intValue() == 1
     )]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement mode="Opaque" x="0" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="5b6d7c3a-2f5c-4e92-931d-6df20a74e3da"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messbedingungen]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="3675a9a7-f7b7-415a-bb0a-76dbf6058b7c"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measuring Condition]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="70" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="d5b19b41-f28e-4d1d-8fe3-c7d7698a0542"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Sollwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="70" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="7e4f2e87-0aa8-4939-b2a2-b8f0b5ca5426"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[True Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="124" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="5c8289d8-393d-4d04-9d1e-f1c131329dd0"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[untere Spezifikation]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="124" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="d08052e6-32d9-4ed2-9bbf-94fc590e587d"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Lower Limit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="178" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="1162c675-8a4e-472b-a2db-9395966b5e7a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="178" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="98b8e6e7-23d2-46dd-83cd-59721016cc34"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measured Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="232" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="3f2d01d2-cab5-45b6-8604-1a6fe8ab7008"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[obere Spezifikation]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="232" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="1ade2037-51c0-4c2f-a3c2-0f6a32ccfced"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Upper Limit]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="286" y="0" width="68" height="21" backcolor="#F5F7FA" uuid="4a5772b2-d12b-45d0-9ffe-5f44312b2db9"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Abweichung]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="286" y="21" width="68" height="19" backcolor="#F5F7FA" uuid="0d3bc3fa-803f-4b7a-9a87-762f22de8705"/>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Deviation]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="354" y="0" width="77" height="21" backcolor="#F5F7FA" uuid="e9d94aa3-4b24-48e5-8ef0-9c510e4a6265"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[erweiterte Messunsicherheit]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="354" y="21" width="77" height="19" backcolor="#F5F7FA" uuid="1bd63f28-78b3-4d3f-a71a-c1e3afac4c6a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="431" y="0" width="16" height="21" backcolor="#F5F7FA" uuid="c225e56e-5de5-49bb-9344-54f77c85d466"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="431" y="21" width="16" height="19" backcolor="#F5F7FA" uuid="e9e5a2fa-9ce3-42cf-adb8-8a99fe4eb52e"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="447" y="0" width="88" height="21" backcolor="#F5F7FA" uuid="2d22ba99-4dbc-44c7-9c66-1192c427322a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Konformität]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="447" y="21" width="88" height="19" backcolor="#F5F7FA" uuid="f6d1cd56-4510-4a3f-9a78-d8e9da101f13"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Conformity]]></text>
-				</staticText>
-			</frame>
-			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="f7eb2d2b-eb4d-41e5-ae4b-8ab7d1ada9f0">
-					<printWhenExpression><![CDATA[$P{ModernResultsHeader} != null
-    && $P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
-    && (
-        $V{MeasurementDetailsValue} != null
-        && (
-            $V{MeasurementDetailsValue}.intValue() == 3
-            || $V{MeasurementDetailsValue}.intValue() == 4
-        )
-    )]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="0" width="120" height="21" backcolor="#F5F7FA" uuid="ff579e83-5f9a-46eb-8d2f-34260c733efd"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messbedingungen]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="21" width="120" height="19" backcolor="#F5F7FA" uuid="dd2d1c2f-3c44-437d-a13f-6bc134e1e7c7"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measuring Condition]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="120" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="5b1ad1aa-910f-42a8-b37b-5ab64a30bd30"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Sollwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="120" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="69f9fa3b-5cd6-4d23-9def-1508c3883d2b"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[True Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="200" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="71881b62-ac3c-44c8-a0a4-9c687a2d88cd"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="200" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="35139bbf-1a81-4d91-930e-a1277bde443b"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measured Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="280" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="dc02bf9c-08f7-4b5e-951b-514d24c5ef56"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Abweichung]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="280" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="6eac3f8c-8f62-4ea8-8b85-45b5c2a091bd"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Deviation]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="350" y="0" width="100" height="21" backcolor="#F5F7FA" uuid="8c5f36d1-8fb9-4681-88ce-2f6cc0d558a8"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[erweiterte Messunsicherheit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="350" y="21" width="100" height="19" backcolor="#F5F7FA" uuid="15fd5718-0f8d-4bd1-83a8-4b2f0cc80d2c"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="450" y="0" width="25" height="21" backcolor="#F5F7FA" uuid="8c0586b8-5baf-45cb-8f57-05e4ff66b48b"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="450" y="21" width="25" height="19" backcolor="#F5F7FA" uuid="efb2d86c-72c1-4ad4-9fb5-b71a93df6e3a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="475" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="28f8b874-131b-47e8-8c9e-46c13690d8c0"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Konformität]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="475" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="a25f837a-5488-4f0f-9db3-94e89292f961"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Conformity]]></text>
-				</staticText>
-			</frame>
-			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="0e30b70c-1f1a-4a39-b02c-800e348721ba">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 2]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-					<reportElement x="0" y="0" width="110" height="21" uuid="5c5dcb15-89a6-40c4-9cdf-0868be2c0c8a"/>
+					<reportElement x="0" y="0" width="70" height="21" uuid="53f3d85e-de3b-5769-9145-778a6d5af69a"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1269,7 +603,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="110" height="19" uuid="6e7d15e2-3cd1-4ae1-8e94-7ba23d43142d"/>
+					<reportElement x="0" y="21" width="70" height="19" uuid="ff64171c-0874-5d50-ab1b-74e9a88ff414"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1281,7 +615,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="0" width="60" height="21" uuid="78d2b44b-93b7-476f-9e4d-0977ab8f3288"/>
+					<reportElement x="70" y="0" width="54" height="21" uuid="659f4e49-7bf6-5ffc-b373-1057dc373f68"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1293,7 +627,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="21" width="60" height="19" uuid="22c83c66-1520-4047-898d-93d90ce64cfe"/>
+					<reportElement x="70" y="21" width="54" height="19" uuid="ea60a506-f305-5328-b18c-5f18d79c82c7"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1305,7 +639,7 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="0" width="60" height="21" uuid="e7f5bf15-845e-4ada-a4db-53f10781dfc3"/>
+					<reportElement x="124" y="0" width="54" height="21" uuid="f8e76f08-9152-5359-b0b6-9f82c1b9bfe3"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1317,7 +651,7 @@
 					<text><![CDATA[untere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="21" width="60" height="19" uuid="2e920011-3756-43ae-8ad9-053c8bc6756c"/>
+					<reportElement x="124" y="21" width="54" height="19" uuid="25e33ab1-7d7a-5e19-9929-efcbee99e66d"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1329,7 +663,7 @@
 					<text><![CDATA[Lower Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="0" width="60" height="21" uuid="58c100bb-2cab-48b8-bcae-a5d2124b695a"/>
+					<reportElement x="178" y="0" width="54" height="21" uuid="41b63aeb-b3d6-57a3-ae7e-1733fc57f69f"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1341,7 +675,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="21" width="60" height="19" uuid="5d37b9fb-2068-4beb-8350-19757e74c7f9"/>
+					<reportElement x="178" y="21" width="54" height="19" uuid="a5caf027-05f8-5064-bbde-fb0eab2d886f"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1353,7 +687,7 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="0" width="60" height="21" uuid="80726e4e-4fdd-431a-8ab3-a7f649d4bfc4"/>
+					<reportElement x="232" y="0" width="54" height="21" uuid="a5174cc8-35a5-5a91-b79a-af701527fa24"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1365,7 +699,7 @@
 					<text><![CDATA[obere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="21" width="60" height="19" uuid="d0bfc6b8-1f1e-4df9-9d2b-666918f7d1f1"/>
+					<reportElement x="232" y="21" width="54" height="19" uuid="b713ff50-b083-5ff2-b8b8-1f9212944278"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1377,7 +711,7 @@
 					<text><![CDATA[Upper Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="45" height="21" uuid="a59a6dc1-0e2f-4726-83ef-fc6482fec21b"/>
+					<reportElement x="286" y="0" width="68" height="21" uuid="8556ecc1-f3a0-514e-9506-0608f4e55f51"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1389,7 +723,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="45" height="19" uuid="5fbef31c-8da1-4657-94c4-0d7a8ac5e2d7"/>
+					<reportElement x="286" y="21" width="68" height="19" uuid="392bb49c-74a5-55e9-8e0e-97ec8cb0f147"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1401,7 +735,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="0" width="65" height="21" uuid="ddf45851-f50a-4bcc-85c8-d841021c82d5"/>
+					<reportElement x="354" y="0" width="77" height="21" uuid="53b6ea15-afa7-5b2d-b4da-00f270afa7f6"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1413,7 +747,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="21" width="65" height="19" uuid="0df37f3f-5b01-47eb-8f49-3bc63986df21"/>
+					<reportElement x="354" y="21" width="77" height="19" uuid="7be481e4-3ee2-540f-8fc1-290b3a54b767"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1425,7 +759,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="0" width="22" height="21" uuid="5a178f37-3133-41c7-92a7-bf7017b2f9be"/>
+					<reportElement x="431" y="0" width="16" height="21" uuid="9a7801f1-6298-5b5f-a788-bfaa6eece405"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1437,7 +771,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="21" width="22" height="19" uuid="18c6a947-5d89-405a-9d1f-bf6892d666b3"/>
+					<reportElement x="431" y="21" width="16" height="19" uuid="9c007ef3-7a33-54e8-9a76-879e0cb0752c"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1449,7 +783,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="0" width="53" height="21" uuid="2d905001-2e4a-467b-8d27-e270f33a3eaa"/>
+					<reportElement x="447" y="0" width="88" height="21" uuid="64ed73c2-4afa-500a-bc21-33f01fffe8c2"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1461,7 +795,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="21" width="53" height="19" uuid="6f0d9fcb-e50c-40da-a8db-880b8f166c3b"/>
+					<reportElement x="447" y="21" width="88" height="19" uuid="e9ab7383-dc71-508e-bff8-29bad4d59ff6"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1474,11 +808,173 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="9999c849-8077-4df9-8890-26a93be0cd10">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 22]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="253fee68-413e-566b-b37d-c655f51c5988">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 2]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="110" height="21" uuid="9ef57134-a08d-4722-b5dc-88638fd1def8"/>
+					<reportElement mode="Opaque" x="0" y="0" width="110" height="21" backcolor="#F5F7FA" uuid="866346f3-b68b-5c33-a30b-54cfaf65527d"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="110" height="19" backcolor="#F5F7FA" uuid="b33047a2-f576-57a8-b5c4-af8d4e44d2b2"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="110" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="5e8c7e5b-a4e6-51a2-b6b9-445f8bf67f87"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="110" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="ac4fbd39-c95a-5adb-86c6-2f93d9b3bb01"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="170" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="1af0e23d-4c1c-5aab-bae4-8a8f590142bb"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[untere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="170" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="ee66aaac-9a6e-5499-8785-e973a3cc7f95"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Lower Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="230" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="c7f2e052-592d-51fb-941d-e7062062d2e9"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="230" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="a09c5d71-4fae-524d-bd40-6207642fb783"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="290" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="a047f059-7312-59c6-99e4-0d730b74e5f4"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[obere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="290" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="2b259f77-d3ff-53fc-816e-cdd78412d3c1"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Upper Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="45" height="21" backcolor="#F5F7FA" uuid="74129f2a-9c41-5371-9e55-530cea5cbc2a"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="21" width="45" height="19" backcolor="#F5F7FA" uuid="2be7c6f4-9498-50ad-b97b-99c16574a599"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="395" y="0" width="65" height="21" backcolor="#F5F7FA" uuid="33676986-c780-5d92-8e16-f199e149bbbf"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="395" y="21" width="65" height="19" backcolor="#F5F7FA" uuid="13c1e98f-43c4-5995-bb38-a92945e80eb2"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="0" width="22" height="21" backcolor="#F5F7FA" uuid="daa8a397-8cba-5f6a-8957-232a23f99632"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="21" width="22" height="19" backcolor="#F5F7FA" uuid="d2a12efe-0812-5397-a7c5-fd866c90360b"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="0" width="53" height="21" backcolor="#F5F7FA" uuid="b0359af6-5e8b-5290-881d-398cb46afb7e"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="21" width="53" height="19" backcolor="#F5F7FA" uuid="03b07523-9f80-535c-84a0-5b7e3248a7e8"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="32b8979d-74a9-50eb-bc7b-f1aeb1f30579">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 2]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="110" height="21" uuid="3abadd5c-07cf-57c4-a17d-77eb30c226c4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1490,7 +986,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="110" height="19" uuid="77893e8b-d6f5-4e75-832b-3b2cb50db9ef"/>
+					<reportElement x="0" y="21" width="110" height="19" uuid="4901c406-6675-54b5-951a-bf988f237614"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1502,7 +998,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="0" width="60" height="21" uuid="a8728949-aa86-4a38-afc1-d4bce7e957be"/>
+					<reportElement x="110" y="0" width="60" height="21" uuid="d7c73b61-68cf-5028-803f-3ae0fc020e8a"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1514,7 +1010,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="21" width="60" height="19" uuid="d4cb35b8-3639-4104-952f-44afa462c17b"/>
+					<reportElement x="110" y="21" width="60" height="19" uuid="1ca4af54-3ef5-5a84-a73a-62c71e77f0c7"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1526,7 +1022,7 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="0" width="60" height="21" uuid="cf055528-4ca7-4ff8-92f6-adf846768f55"/>
+					<reportElement x="170" y="0" width="60" height="21" uuid="9320fc05-c380-5996-909a-9b43dbf57f88"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1538,7 +1034,7 @@
 					<text><![CDATA[untere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="21" width="60" height="19" uuid="1bc83d75-a21d-4d98-8422-623221a058a1"/>
+					<reportElement x="170" y="21" width="60" height="19" uuid="ab8dd9ed-c9d4-51f7-bbff-5e2e345dfdf8"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1550,7 +1046,7 @@
 					<text><![CDATA[Lower Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="0" width="60" height="21" uuid="140da21a-29e7-4daf-a389-6b3a9340597e"/>
+					<reportElement x="230" y="0" width="60" height="21" uuid="9f368450-0140-5cb8-9a25-22364d915f95"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1562,7 +1058,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="21" width="60" height="19" uuid="b1dec267-7066-4c79-a041-b275d736db0d"/>
+					<reportElement x="230" y="21" width="60" height="19" uuid="b03ca0f7-4db6-5c90-8fa3-f5fcecb0484e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1574,7 +1070,7 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="0" width="60" height="21" uuid="db3ff69a-9ba2-4663-b9c6-8ec76bad9de4"/>
+					<reportElement x="290" y="0" width="60" height="21" uuid="3998bb31-928f-58f9-9868-83aaac6930e7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1586,7 +1082,7 @@
 					<text><![CDATA[obere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="21" width="60" height="19" uuid="e929bc96-9d28-4d6f-9f84-d6b9fc98848b"/>
+					<reportElement x="290" y="21" width="60" height="19" uuid="a346ac1f-b9a9-5fe9-9093-fe2878413ffa"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1598,7 +1094,7 @@
 					<text><![CDATA[Upper Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="45" height="21" uuid="f5392001-2594-410c-a818-73e95f3ad9a4"/>
+					<reportElement x="350" y="0" width="45" height="21" uuid="b7d8336c-bae3-5f47-947d-4fb3e8775ac4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1610,7 +1106,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="45" height="19" uuid="fb55558b-f5ff-4cf8-beae-9cd891914295"/>
+					<reportElement x="350" y="21" width="45" height="19" uuid="96df55e2-b99e-5d97-bcc4-03688b46d09b"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1622,7 +1118,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="0" width="65" height="21" uuid="2595d451-85b6-4540-876a-275db9ce812d"/>
+					<reportElement x="395" y="0" width="65" height="21" uuid="894291ab-77ab-5dab-a640-f3131d281873"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1634,7 +1130,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="21" width="65" height="19" uuid="04d9b7dd-3ed8-4fea-b7ba-22611fffb66e"/>
+					<reportElement x="395" y="21" width="65" height="19" uuid="30dafe36-1f5e-5e6b-871b-2906e80a9aa8"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1646,7 +1142,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="0" width="22" height="21" uuid="65d3c0ae-4b8a-4acd-b1fd-d62dfbe5e4a1"/>
+					<reportElement x="460" y="0" width="22" height="21" uuid="89d8e246-dd82-5021-95b8-8d3832d81ad4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1658,7 +1154,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="21" width="22" height="19" uuid="8bb5a7aa-e956-4c12-a1dd-f4b8a22493dd"/>
+					<reportElement x="460" y="21" width="22" height="19" uuid="7f192254-369a-5aaa-9d9c-567ed957c3b0"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1670,7 +1166,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="0" width="53" height="21" uuid="df372e06-f016-4871-9eeb-1eef21cdaea6"/>
+					<reportElement x="482" y="0" width="53" height="21" uuid="56deb187-f02e-5ea3-984d-761e378f22e4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1682,7 +1178,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="21" width="53" height="19" uuid="2ada51a8-e15a-4d88-a327-f491f3bfb1a4"/>
+					<reportElement x="482" y="21" width="53" height="19" uuid="2b74bf7d-3d09-5242-9b84-06cd5d37cb7e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1695,27 +1191,22 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="9d420c13-973f-44d4-813c-c1940c70e9ec">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 21]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="a7546b88-cb00-52cf-88fd-d996c0c12093">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 22]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="156" height="21" uuid="587b5af0-cabb-4b66-8c9e-e11fead78085"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="0" y="0" width="110" height="21" backcolor="#F5F7FA" uuid="8ac3721b-8491-5fa1-8fb4-3c5ae576b4fb"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="156" height="19" uuid="f2b8402d-cf20-45bd-bf45-6cbadf53cf71"/>
+					<reportElement mode="Opaque" x="0" y="21" width="110" height="19" backcolor="#F5F7FA" uuid="869bd8f0-fb24-505f-88e5-b62093669a73"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1723,23 +1214,16 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="156" y="0" width="96" height="21" uuid="6e6abb9f-0265-4ee0-a99b-fbd2b605ad4f"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="110" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="9eadf1d3-31a9-5617-b757-2d9c3fcc665b"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="156" y="21" width="96" height="19" uuid="c0126df0-95fe-4b42-99e1-8ee6726e8327"/>
+					<reportElement mode="Opaque" x="110" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="b871e6c5-3a9b-5b76-85e1-631303fa3a7f"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1747,23 +1231,33 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="252" y="0" width="96" height="21" uuid="d6f77c33-f5f4-4a53-b2dd-ece15ff66eff"/>
+					<reportElement mode="Opaque" x="170" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="eda83069-23b2-5180-9e77-928d804c5043"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[untere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="170" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="6d63e3da-105d-5685-8c27-fdb4a834d394"/>
 					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Lower Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="230" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="61d85bb5-e133-5544-8c09-0d6ad310054c"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="252" y="21" width="96" height="19" uuid="72d05083-4e0b-424d-a2f8-cd7ccb6f1816"/>
+					<reportElement mode="Opaque" x="230" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="9ae89a77-6e54-5118-abb3-3c5f253a2661"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1771,23 +1265,33 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="348" y="0" width="61" height="21" uuid="d38ab117-a950-45cb-a660-2ad396c13d25"/>
+					<reportElement mode="Opaque" x="290" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="f820f59c-105e-50f1-ad47-438840949f40"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[obere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="290" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="4f131dab-193a-5280-96b3-eadc98d10232"/>
 					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Upper Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="45" height="21" backcolor="#F5F7FA" uuid="f8f84681-beb8-5b82-83f4-533bd3d1ef91"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="348" y="21" width="61" height="19" uuid="ad0eb6cc-b640-47b8-b085-8fb3ca717fa7"/>
+					<reportElement mode="Opaque" x="350" y="21" width="45" height="19" backcolor="#F5F7FA" uuid="59d082f4-e080-5e88-87ba-ac91014178c1"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1795,36 +1299,65 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="409" y="0" width="126" height="21" uuid="abb95ab7-4708-4351-99f6-d16f0ebcb1f8"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="395" y="0" width="65" height="21" backcolor="#F5F7FA" uuid="c4497cdb-7a88-5f3a-b2a5-3a6b0015a940"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="409" y="21" width="126" height="19" uuid="fe39dd0c-f2f2-4fd6-8765-aa78f139924a"/>
+					<reportElement mode="Opaque" x="395" y="21" width="65" height="19" backcolor="#F5F7FA" uuid="0d29bf49-47a0-5d87-ab1a-65fac761465e"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
 					</textElement>
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="0" width="22" height="21" backcolor="#F5F7FA" uuid="42e99d32-aa4b-5416-9a09-14e8855aa0b0"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="21" width="22" height="19" backcolor="#F5F7FA" uuid="3d53e484-1d20-5c8f-bddc-3368bcce7d8c"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="0" width="53" height="21" backcolor="#F5F7FA" uuid="39efeb63-8c60-504f-bf62-99a5bb7cea04"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="21" width="53" height="19" backcolor="#F5F7FA" uuid="e4f58bda-6f48-5d41-b9cf-f0d8c43457a2"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="77c05213-e84f-4b75-8bc6-f427caa33ce1">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 3]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="b4bb5d35-c111-5cef-9e4c-8c750cdcce25">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 22]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="120" height="21" uuid="cd0b237b-3723-4f2c-84cf-4ea5bf4b6858"/>
+					<reportElement x="0" y="0" width="110" height="21" uuid="e1405c5b-25bb-5ad5-88f7-f458a38849a5"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1836,7 +1369,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="120" height="19" uuid="e02858f3-94b4-4016-a0f6-e9560f1a216d"/>
+					<reportElement x="0" y="21" width="110" height="19" uuid="5ca46a76-ad43-5b31-b088-926effed641c"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1848,7 +1381,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="0" width="80" height="21" uuid="683d169b-0024-4f3c-9454-fc1f79d78946"/>
+					<reportElement x="110" y="0" width="60" height="21" uuid="e5d9fc61-25f4-5a15-8cf4-71a354b114b3"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1860,7 +1393,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="21" width="80" height="19" uuid="237226a9-a1e3-408b-aa2d-b59e0cd27f8d"/>
+					<reportElement x="110" y="21" width="60" height="19" uuid="cb1dbcae-4c23-5290-9c1e-94d862110c31"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1872,7 +1405,31 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="0" width="80" height="21" uuid="255afede-fc13-45e4-9c3c-48a72fa1fcc8"/>
+					<reportElement x="170" y="0" width="60" height="21" uuid="449935ff-6a4b-55e6-bdea-7788ec36eeb1"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[untere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="170" y="21" width="60" height="19" uuid="7b5c8fcd-11a5-5b5b-b26d-d368494f2c3b"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Lower Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="230" y="0" width="60" height="21" uuid="ce58a3d6-353b-5df1-904a-7da45b8030f3"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1884,7 +1441,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="21" width="80" height="19" uuid="c2af622d-ebf6-4763-b585-c01af78cbe8f"/>
+					<reportElement x="230" y="21" width="60" height="19" uuid="2022b37d-3a35-5fee-9d2c-c713f871b131"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1896,7 +1453,31 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="0" width="70" height="21" uuid="d741d94b-42f0-414e-a837-cf45bc4d8f5a"/>
+					<reportElement x="290" y="0" width="60" height="21" uuid="3717a6c0-f3dd-53db-b04b-086de76b4307"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[obere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="290" y="21" width="60" height="19" uuid="5aaa0449-c5b5-56a6-ac4d-75d4b155814d"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Upper Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="0" width="45" height="21" uuid="c039a234-25b0-5971-81e7-0fe6040698a7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1908,7 +1489,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="21" width="70" height="19" uuid="0c39272c-0c41-4d4d-b9c4-60c588e4bbfd"/>
+					<reportElement x="350" y="21" width="45" height="19" uuid="43bad4be-9626-599b-be6f-37ed0fd9257a"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1920,7 +1501,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="100" height="21" uuid="8c6894ab-80a7-45eb-9dcc-5b39c939d9c7"/>
+					<reportElement x="395" y="0" width="65" height="21" uuid="7c360d31-5c77-5fe5-92bf-90ab05837f7f"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1932,7 +1513,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="100" height="19" uuid="bdbe7508-292f-463e-b8a3-45c91a07d169"/>
+					<reportElement x="395" y="21" width="65" height="19" uuid="d94fe13f-54aa-5c81-a7d7-3cec2e3116db"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1944,7 +1525,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="0" width="25" height="21" uuid="d5599b28-05ae-41c8-9ff2-6c319f60be39"/>
+					<reportElement x="460" y="0" width="22" height="21" uuid="8bc841ba-67f4-514b-b5d7-9cf2f28e3cd7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1956,7 +1537,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="21" width="25" height="19" uuid="90a651d4-5514-4fd5-8a0a-1723f3d434db"/>
+					<reportElement x="460" y="21" width="22" height="19" uuid="7eab6faf-ec9e-5ed3-b647-e3e2550cf5e6"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1968,7 +1549,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="0" width="60" height="21" uuid="8dbac63f-7c0c-4a6a-a3ab-4b035453deab"/>
+					<reportElement x="482" y="0" width="53" height="21" uuid="92f0a8c4-f371-5c8d-be87-811ab6061050"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1980,7 +1561,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="21" width="60" height="19" uuid="f876b3de-9f36-40e0-beee-3e76efcbd2d5"/>
+					<reportElement x="482" y="21" width="53" height="19" uuid="8606b0d4-0673-55fe-834e-8848543bc09b"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1993,11 +1574,105 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="e68489b7-5b78-45b5-9587-bd87d4db3533">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 4]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="cba31811-ddbe-5438-b070-50fabac0f362">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 21]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="120" height="21" uuid="4eb67baf-b479-45de-9329-2c31681bf56c"/>
+					<reportElement mode="Opaque" x="0" y="0" width="156" height="21" backcolor="#F5F7FA" uuid="e9dcee4f-83f8-5d2f-bf9c-4908e885fa50"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="156" height="19" backcolor="#F5F7FA" uuid="e658b9cc-f4d0-5a74-b1fb-c246fc5958ce"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="156" y="0" width="96" height="21" backcolor="#F5F7FA" uuid="97f065e4-1de8-58f1-91d9-415c36eee795"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="156" y="21" width="96" height="19" backcolor="#F5F7FA" uuid="782cd75a-ef38-5684-a609-1f44cdb8c4f7"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="252" y="0" width="96" height="21" backcolor="#F5F7FA" uuid="472d47f3-b472-5747-947d-29f3ddbab523"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="252" y="21" width="96" height="19" backcolor="#F5F7FA" uuid="d7fa8eb0-ebf3-5cdd-a471-326c8882f084"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="348" y="0" width="61" height="21" backcolor="#F5F7FA" uuid="7b116d5c-e92f-5b65-8ee5-71370c02a121"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="348" y="21" width="61" height="19" backcolor="#F5F7FA" uuid="b8ed44a7-13ac-53a0-b386-dfad6c643f07"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="409" y="0" width="126" height="21" backcolor="#F5F7FA" uuid="e43ba6b3-ef79-5662-baa7-ac8075085b95"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="409" y="21" width="126" height="19" backcolor="#F5F7FA" uuid="2c5d181e-5c30-587f-a197-2a233fa9c349"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="0d623dda-59db-5438-8ef7-c93c805a6828">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 21]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="156" height="21" uuid="99d64120-4143-5356-9b38-0c66601ccbee"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2009,7 +1684,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="120" height="19" uuid="23c83b5d-f6bb-4a20-a59e-025400d93c97"/>
+					<reportElement x="0" y="21" width="156" height="19" uuid="70a5a433-3f1b-5dc8-ba35-76fb747fa796"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2021,7 +1696,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="0" width="80" height="21" uuid="1d05eb27-4901-4a31-9a83-310570eff821"/>
+					<reportElement x="156" y="0" width="96" height="21" uuid="629def18-6cac-5653-9f25-7fb52aedf074"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2033,7 +1708,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="21" width="80" height="19" uuid="20c6d7d7-8940-49d5-8c6c-5ee2250fa003"/>
+					<reportElement x="156" y="21" width="96" height="19" uuid="68ba7331-c656-589d-98d8-4fbd743cdd2b"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2045,7 +1720,7 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="0" width="80" height="21" uuid="d28bf913-25c7-4a49-919e-c7dba3bc625b"/>
+					<reportElement x="252" y="0" width="96" height="21" uuid="8d24450e-cd9a-5898-9f4e-6d4b85d0fa07"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2057,7 +1732,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="21" width="80" height="19" uuid="d0ead348-24ac-4488-872c-df2678296e42"/>
+					<reportElement x="252" y="21" width="96" height="19" uuid="ac107ba0-24a9-5025-a80f-d44d836d9550"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2069,7 +1744,7 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="0" width="70" height="21" uuid="1c101134-389f-4b0a-977f-a9bf15d25e47"/>
+					<reportElement x="348" y="0" width="61" height="21" uuid="c461220d-6cb7-5040-b018-733a3d089c6b"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2081,7 +1756,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="21" width="70" height="19" uuid="79676e0f-72f5-457d-be35-b4884b2e5665"/>
+					<reportElement x="348" y="21" width="61" height="19" uuid="efbe016f-2579-5aed-9404-77138102fa1e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2093,7 +1768,561 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="100" height="21" uuid="d476c93f-d6f4-4e08-86a8-cd51e9bcaaad"/>
+					<reportElement x="409" y="0" width="126" height="21" uuid="2ef4ff88-6bf0-506a-bf9d-26e2ca266575"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="409" y="21" width="126" height="19" uuid="e02e25f5-16db-522f-8213-ae3d6765eb75"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="c9eb67be-fea2-5c16-a4d7-82c5724b17dc">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 3]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="0" width="120" height="21" backcolor="#F5F7FA" uuid="8576f68b-1c6f-5fc4-85ed-c33bdd3864ff"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="120" height="19" backcolor="#F5F7FA" uuid="a4737020-e59a-56ce-8a37-939943f52a32"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="ba03ba42-3a88-5f94-b3a2-c9896444df9b"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="7fd9afef-4aff-577d-8db0-3258e3082e35"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="b8e593a9-0e8c-5475-8d5f-88ecc1714fed"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="d146cb5a-8246-5e99-9283-f92291368f05"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="43827148-d046-5b23-ae48-01ba8fbe8113"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="ca1581c6-f9c2-5be8-8563-dd0d3266cb44"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="100" height="21" backcolor="#F5F7FA" uuid="ca7bde61-5820-52e1-8bc2-e713eaa33598"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="21" width="100" height="19" backcolor="#F5F7FA" uuid="1156b12c-148a-56cd-ab1d-d9ace461d6a0"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="0" width="25" height="21" backcolor="#F5F7FA" uuid="5a41c648-bc55-5313-a9c5-3269e35b7670"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="21" width="25" height="19" backcolor="#F5F7FA" uuid="563ced72-9045-59d4-83bb-3c9e586a0172"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="3a792f26-9bde-591c-b247-d7845cb68dd0"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="16587c47-a093-54ba-996d-82b86d343979"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="f25a2c77-cdbb-56ea-bfe1-54b529bbf07f">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 3]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="120" height="21" uuid="85a58fe9-297b-5486-a8c6-800ede1b5aa1"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="0" y="21" width="120" height="19" uuid="a6ea883e-dd1c-5c18-a6b9-972b7c633c22"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="0" width="80" height="21" uuid="f99351ef-7397-54ed-b815-c7057cb95a6a"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="21" width="80" height="19" uuid="9098e2d5-da02-5cd2-a82a-3179c0545efd"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="0" width="80" height="21" uuid="74907f34-590e-5398-b5d9-d8476d879f83"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="21" width="80" height="19" uuid="554cf588-03ea-507b-bcf1-7c38e6bc0fc7"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="0" width="70" height="21" uuid="9f5d505a-a7e1-547a-b059-a83a411484a8"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="21" width="70" height="19" uuid="c71020a7-ae32-5f59-a59c-f17bcd37a684"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="0" width="100" height="21" uuid="b35470d2-9fea-54aa-9645-81d399f73515"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="21" width="100" height="19" uuid="26b99011-5c2f-5aac-9ab5-51a6f179da62"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="450" y="0" width="25" height="21" uuid="c0d4d52d-0589-5272-9b47-5c0c906ff14f"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="450" y="21" width="25" height="19" uuid="56169287-3275-5b3c-8757-b32b033a927d"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="475" y="0" width="60" height="21" uuid="4dcf386a-4123-5a46-bcdc-330bb3917c4c"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="475" y="21" width="60" height="19" uuid="32ded984-315f-57cb-b2bf-9b6fc430cde1"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="f25ad94b-9051-5949-9318-e7ec0018f75a">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 4]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="0" width="120" height="21" backcolor="#F5F7FA" uuid="aee85479-a4a3-5bf8-af9f-34396b3c1afc"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="120" height="19" backcolor="#F5F7FA" uuid="5fcd488e-6780-514f-949a-5e79160d675c"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="383ddfbb-2e4a-5ffc-a0c8-08d6996ac1ae"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="70247ea9-b06d-5631-ae86-ca1b50c721a3"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="f49488f3-3229-5ec4-b174-7cc1fec07c19"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="4bfefd29-a844-50b3-b934-a5a71605231b"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="711bcdd5-e002-5701-a8c8-d004b7927f6e"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="8dee3a1c-e619-58dd-a658-f18de362c898"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="100" height="21" backcolor="#F5F7FA" uuid="517fbc33-7411-52c2-9852-09bb1e9d1fe1"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit (p)]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="21" width="100" height="19" backcolor="#F5F7FA" uuid="9ecb6fb7-f075-5dc4-b155-d000edac1570"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement (p)]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="0" width="25" height="21" backcolor="#F5F7FA" uuid="a9016fd1-f2d4-5898-90e7-a39c2cc1cc2d"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="21" width="25" height="19" backcolor="#F5F7FA" uuid="0663b6f4-e350-5941-bb6d-f5fa1e51a04e"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="9c07d101-dbb1-51da-839f-955a17374f9c"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="d1c8cf1e-ff05-5029-ba36-950b990adb65"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="b56b5fc8-d52d-5964-aeaf-bd1c124b3600">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 4]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="120" height="21" uuid="40e8a467-108f-5921-b875-0c50d1377021"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="0" y="21" width="120" height="19" uuid="453b5b0d-2186-5411-94f4-adc2c2838610"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="0" width="80" height="21" uuid="05011757-7762-55ab-ac4b-6a1c3c64ebff"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="21" width="80" height="19" uuid="4f2ac022-26b0-504e-ac4a-aed99c0420be"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="0" width="80" height="21" uuid="9e39dc38-5fb7-5a38-af19-96d1fe8a5a1c"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="21" width="80" height="19" uuid="626dbfd6-6287-5d5a-809f-8d647407870f"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="0" width="70" height="21" uuid="faa58751-671b-5442-85fd-1a170fb8445f"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="21" width="70" height="19" uuid="754fd9fd-2ccf-5571-998b-d128356bac99"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="0" width="100" height="21" uuid="0fadfd52-a365-5ab3-b781-e02667c2e469"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2105,7 +2334,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit (p)]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="100" height="19" uuid="a08983ff-45fb-4ddd-b8a7-db8ca7c1150a"/>
+					<reportElement x="350" y="21" width="100" height="19" uuid="f5abfbf7-8c2e-5fa5-8080-d0aa712bd67c"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2117,7 +2346,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement (p)]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="0" width="25" height="21" uuid="3f88d9f3-6661-4500-8778-d8b9c0aa6f3c"/>
+					<reportElement x="450" y="0" width="25" height="21" uuid="0a8a2021-31a0-5bdc-9763-b2156494bee7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2129,7 +2358,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="21" width="25" height="19" uuid="6c3b58f2-240e-461b-af88-a560d42f451e"/>
+					<reportElement x="450" y="21" width="25" height="19" uuid="e27938af-3005-5839-851c-98e1442f2c5e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2141,7 +2370,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="0" width="60" height="21" uuid="37661bdd-0067-4a41-9cd0-f2eebaa57c71"/>
+					<reportElement x="475" y="0" width="60" height="21" uuid="2be03a94-a075-5b22-aa91-ec3e9b1ae358"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2153,7 +2382,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="21" width="60" height="19" uuid="f70e05ff-4b3d-4811-8c70-de0fc2bf98a6"/>
+					<reportElement x="475" y="21" width="60" height="19" uuid="b94c6fef-1253-5d2b-ac37-85256427551f"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>

--- a/DAKKS-SAMPLE/README.md
+++ b/DAKKS-SAMPLE/README.md
@@ -128,7 +128,7 @@ für optionale Parameter.
 | --- | --- | --- | --- |
 | `Cert_field` | ➖ | `""` | Quelle der Zertifikats­nummer und des Kalibrier­kennzeichens. Erlaubte Werte: `C2396`, `C2395`, `C2364` oder `C2356`; andere Werte fallen auf `C2356` zurück. Wird zugleich an den Subreport `Standard` durchgereicht. |
 | `MeasurementDetails` | ➖ | `1` | Wählt eines der vier Messwert-Layouts im Subreport `Results` (`1` Basis­darstellung, `2` formatierte Eingaben, `3` autoformatierte Anzeige, `4` ISO-konforme Unsicherheit). Leere oder nicht-numerische Eingaben werden als `1` behandelt. |
-| `ModernResultsHeader` | ➖ | `N` | Schaltet im `Results`-Unterbericht den modernen Tabellen­kopf ein (`Y`) oder behält den klassischen Kopf bei (`N`). |
+| `ModernResultsHeader` | ➖ | `Y` | Tabellenkopf-Stil im `Results`-Unterbericht. Standard ist der moderne Kopf ohne umlaufende Rahmen (gilt auch für leere oder unbekannte Werte); nur ein explizites `N` schaltet auf den klassischen Kopf mit Rahmen zurück. Beide Stile sind je `MeasurementDetails`-Variante an den Datenspalten ausgerichtet. |
 | `ExpUncType` | ➖ | `""` | Freitext für ergänzende Hinweise zur erweiterten Messunsicherheit (z. B. `k=2`-Anmerkungen). |
 | `environmental_conditions` | ➖ | `""` | Optionaler Freitext für Umgebungs­temperatur und relative Luft­feuchte im Format `Text_Temperatur \| Text_Feuchte`. Ersetzt die Werte aus `C2311`/`C2312`, wenn angegeben. Ist ein Ressourcen­name übergeben, werden Temperatur und Feuchte aus `resource.environment_resources` derselben Zeile übernommen. |
 
@@ -223,6 +223,10 @@ sowie optional `P_Image_Path`. `Cert_field` wird zusätzlich an
   * `SymbolStatus` leitet aus `pass_fail` die Konformitäts­symbolik
     (`iO`, `?`, `!?`, `!`) ab, sofern kein individueller Kommentar (`remark`)
     hinterlegt ist.
+  * Der Tabellenkopf existiert je `MeasurementDetails`-Variante in einer
+    modernen (Standard, ohne umlaufende Rahmen) und einer klassischen
+    Ausführung (`ModernResultsHeader=N`); beide sind an den Datenspalten
+    der jeweiligen Variante ausgerichtet.
 * **Frame-Auswahl über `MeasurementDetails`** – siehe Parameter­tabelle, Abschnitt 4.4.
 
 ### 5.3 Integration & Pflege

--- a/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
+++ b/DAKKS-SAMPLE/main_reports/dakks-sample.jrxml
@@ -33,8 +33,8 @@
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ModernResultsHeader" class="java.lang.String">
-		<parameterDescription><![CDATA[Schaltet den modernen Tabellenkopf im Results-Unterbericht ein (Y/N).]]></parameterDescription>
-		<defaultValueExpression><![CDATA["N"]]></defaultValueExpression>
+		<parameterDescription><![CDATA[Tabellenkopf-Stil im Results-Unterbericht: Standard ist der moderne Kopf ohne umlaufende Rahmen; nur ein explizites "N" schaltet auf den klassischen Kopf mit Rahmen zurück.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ReportVariantCode" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionaler Ressourcenname für Layoutvarianten. Wenn die gefundene Ressource report_template = 1 hat, wird Variante 1 aktiviert, sonst Variante 0 (Standard).]]></parameterDescription>

--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -13,8 +13,8 @@
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ModernResultsHeader" class="java.lang.String">
-		<parameterDescription><![CDATA[Umschalter für einen modernen Tabellenkopf ohne umlaufende Rahmen (Y/N).]]></parameterDescription>
-		<defaultValueExpression><![CDATA["N"]]></defaultValueExpression>
+		<parameterDescription><![CDATA[Tabellenkopf-Stil: Standard ist der moderne Kopf ohne umlaufende Rahmen; nur ein explizites "N" schaltet auf den klassischen Kopf mit Rahmen zurück.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Results_end_note" class="java.lang.String">
 		<parameterDescription><![CDATA[Textbaustein, der das Ende des Ergebnisberichts markiert.]]></parameterDescription>
@@ -100,6 +100,12 @@
     && !$P{MeasurementDetails}.toString().trim().isEmpty()
     && $P{MeasurementDetails}.toString().trim().matches("^-?\\d+$")
 ) ? Integer.valueOf($P{MeasurementDetails}.toString().trim()) : Integer.valueOf(1)]]></variableExpression>
+	</variable>
+	<variable name="UseModernHeader" class="java.lang.Boolean" resetType="None">
+		<variableExpression><![CDATA[Boolean.valueOf(
+    $P{ModernResultsHeader} == null
+    || !$P{ModernResultsHeader}.toString().trim().equalsIgnoreCase("N")
+)]]></variableExpression>
 	</variable>
 	<variable name="NominalValue" class="java.lang.String">
 		<variableExpression><![CDATA[$F{fixq}==null || $F{fixq}.trim().isEmpty()
@@ -389,34 +395,24 @@
 	<columnHeader>
 		<band height="54">
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="4ed0627d-9fa2-4009-b007-8bec51d8fe39">
-					<printWhenExpression><![CDATA[(
-        $P{ModernResultsHeader} == null
-        || !$P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
-    )
+				<reportElement x="0" y="0" width="535" height="54" uuid="e4a28495-8ada-558b-aa23-c874ef0c282e">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
     && (
         $V{MeasurementDetailsValue} == null
         || $V{MeasurementDetailsValue}.intValue() == 1
     )]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-                                        <reportElement x="0" y="0" width="52" height="21" uuid="eafff26f-da66-47aa-9620-067984e7623d"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="0" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="02d64f75-e9ef-54a7-862a-8bb0c9408112"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="0" y="21" width="52" height="19" uuid="b60abc68-076c-493d-a3f3-9195326664bd"/>
+					<reportElement mode="Opaque" x="0" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="e7ee84d0-1c9b-5d28-b7b5-4487f13847a4"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -424,23 +420,16 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="52" y="0" width="54" height="21" uuid="7880a955-3d0e-47e0-b0ca-86f6808ec459"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="70" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="45a2cc63-30da-506d-9bcb-95aebec49050"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="52" y="21" width="54" height="19" uuid="bd32f354-0a23-4f84-8c54-8742d8eda0a9"/>
+					<reportElement mode="Opaque" x="70" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="44e4cc10-5a27-53b3-bb04-3cee82e34081"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -448,23 +437,16 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="106" y="0" width="54" height="21" uuid="b8aaaf0e-818f-4cb7-bc68-d6f5bccef281"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="124" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="0198a346-988a-5dbe-a4a5-250a38241b7d"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[untere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="106" y="21" width="54" height="19" uuid="e7e8fe51-1d3f-47b4-bac7-4bc5ffdff4cf"/>
+					<reportElement mode="Opaque" x="124" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="8a1ee1de-b8f6-5d94-a68a-bc033b31352e"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -472,23 +454,16 @@
 					<text><![CDATA[Lower Limit]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="160" y="0" width="54" height="21" uuid="ab19233c-cc95-4e62-8907-3b85cd8a99ba"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="178" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="2e172092-c6dd-512d-943d-09fc814e7d4a"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="160" y="21" width="54" height="19" uuid="c2ef9866-31f4-4f4c-a509-99fbbaa5e2a7"/>
+					<reportElement mode="Opaque" x="178" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="80087a0c-aab0-535b-b684-e715979a74c7"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -496,23 +471,16 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="214" y="0" width="54" height="21" uuid="6cfc31ec-8210-4030-ac0b-9345ad984c2a"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="232" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="d7ba22af-af6e-58c3-bc38-7f2500685d9b"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[obere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="214" y="21" width="54" height="19" uuid="c2956eb9-f42e-4a14-aeac-aec17661d608"/>
+					<reportElement mode="Opaque" x="232" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="c9670bb1-4322-5cdf-83a3-33ea7b131973"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -520,23 +488,16 @@
 					<text><![CDATA[Upper Limit]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="270" y="0" width="68" height="21" uuid="94f866dd-148e-41d4-a845-f3e0c1fee329"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="286" y="0" width="68" height="21" backcolor="#F5F7FA" uuid="a138f010-97be-5001-9f8d-beea24126bb4"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="270" y="21" width="68" height="19" uuid="ea02a971-82f0-46b7-ad62-2e39139c7570"/>
+					<reportElement mode="Opaque" x="286" y="21" width="68" height="19" backcolor="#F5F7FA" uuid="6dc00d38-0206-5c1d-a6cd-1f6c689e6bfa"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -544,23 +505,16 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="338" y="0" width="66" height="21" uuid="70528edb-30a7-46d4-af65-e17aa067d645"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="354" y="0" width="77" height="21" backcolor="#F5F7FA" uuid="91de1516-b991-5afa-9b02-1f034c5fd7bd"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="338" y="21" width="66" height="19" uuid="41fa5341-396a-4209-91b3-92c6d3498388"/>
+					<reportElement mode="Opaque" x="354" y="21" width="77" height="19" backcolor="#F5F7FA" uuid="7ce152e9-601a-52a9-87db-b78145c2d0cf"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -568,23 +522,16 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="402" y="0" width="18" height="21" uuid="42b6ddce-c26d-4176-bad0-ad7c5ba311ab"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="431" y="0" width="16" height="21" backcolor="#F5F7FA" uuid="d35b4f24-9e6a-53de-8f18-927f37bdd24c"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-                                        <reportElement x="402" y="21" width="18" height="19" uuid="4b7181f7-6f15-4ab7-8366-60e34fa86fda"/>
+					<reportElement mode="Opaque" x="431" y="21" width="16" height="19" backcolor="#F5F7FA" uuid="dc5a1f69-6ca9-5a12-a435-504d73f284f1"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -592,23 +539,16 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="420" y="0" width="115" height="21" uuid="bcbd02e7-375c-458f-b6bf-e7f832f6b5ad"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="447" y="0" width="88" height="21" backcolor="#F5F7FA" uuid="22727bb3-72cc-55de-b5e0-f398ee1e0d12"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="420" y="21" width="115" height="19" uuid="95a9d488-0a25-4f7f-9a41-6b3a566768f6"/>
+					<reportElement mode="Opaque" x="447" y="21" width="88" height="19" backcolor="#F5F7FA" uuid="47bf83d3-97ce-5284-a947-aaa27f1af637"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -617,621 +557,15 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="2a2dbf93-a3a0-4ca8-ac05-3a65f86b9b7c">
-					<printWhenExpression><![CDATA[(
-        $P{ModernResultsHeader} == null
-        || !$P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
-    )
-    && false]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-                                        <reportElement x="0" y="0" width="118" height="21" uuid="a7184f69-9081-4a6c-9b0a-dc3b8504922e"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messbedingungen]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="0" y="21" width="118" height="19" uuid="b46e08e6-1619-412d-8b11-1dd8c9a10da6"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measuring Condition]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="118" y="0" width="80" height="21" uuid="8554890d-19f0-4928-9369-9b1be7df2b5e"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Sollwert]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="118" y="21" width="80" height="19" uuid="310c16ba-55c6-4afe-8ee2-18a0dfb52079"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[True Value]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="198" y="0" width="100" height="21" uuid="7e6864f5-ab6f-4ba6-88ff-51b6b2960a90"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messwert]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="198" y="21" width="100" height="19" uuid="19b8e41c-2d68-4c1b-8614-4c1b5c22dbeb"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measured Value]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="298" y="0" width="70" height="21" uuid="072b0cdb-1d3a-4c08-8b89-d1613d2ff34e"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Abweichung]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="298" y="21" width="70" height="19" uuid="f4573e83-06a5-4f7b-9e46-f7620f4e7be9"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Deviation]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="368" y="0" width="100" height="21" uuid="a812070a-0c7f-45c7-bf57-12d39f1438ba"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[erweiterte Messunsicherheit]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="368" y="21" width="100" height="19" uuid="a6ec4148-796b-45fd-90ff-930936395c5b"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="468" y="0" width="27" height="21" uuid="adce91d0-9b05-462c-93ed-e319e4fb21c9"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement x="468" y="21" width="27" height="19" uuid="9a00a2a0-9b18-48e7-9a37-ebf44487ee0a"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="495" y="0" width="40" height="21" uuid="417947b5-72b4-4f9e-9019-f080eebd1b9c"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Konformität]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="495" y="21" width="40" height="19" uuid="7e17b356-1dc9-46bf-9d6e-8f4e2bc1c5c9"/>
-					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Conformity]]></text>
-				</staticText>
-			</frame>
-			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="9b0b621c-5db8-4b1a-a781-fc377ac87c0f">
-					<printWhenExpression><![CDATA[$P{ModernResultsHeader} != null
-    && $P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
+				<reportElement x="0" y="0" width="535" height="54" uuid="69210bf0-eb53-50c4-8de2-6a9b7bc7f93c">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
     && (
         $V{MeasurementDetailsValue} == null
         || $V{MeasurementDetailsValue}.intValue() == 1
     )]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement mode="Opaque" x="0" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="5b6d7c3a-2f5c-4e92-931d-6df20a74e3da"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messbedingungen]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="3675a9a7-f7b7-415a-bb0a-76dbf6058b7c"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measuring Condition]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="70" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="d5b19b41-f28e-4d1d-8fe3-c7d7698a0542"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Sollwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="70" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="7e4f2e87-0aa8-4939-b2a2-b8f0b5ca5426"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[True Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="124" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="5c8289d8-393d-4d04-9d1e-f1c131329dd0"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[untere Spezifikation]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="124" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="d08052e6-32d9-4ed2-9bbf-94fc590e587d"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Lower Limit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="178" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="1162c675-8a4e-472b-a2db-9395966b5e7a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="178" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="98b8e6e7-23d2-46dd-83cd-59721016cc34"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measured Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="232" y="0" width="54" height="21" backcolor="#F5F7FA" uuid="3f2d01d2-cab5-45b6-8604-1a6fe8ab7008"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[obere Spezifikation]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="232" y="21" width="54" height="19" backcolor="#F5F7FA" uuid="1ade2037-51c0-4c2f-a3c2-0f6a32ccfced"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Upper Limit]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="286" y="0" width="68" height="21" backcolor="#F5F7FA" uuid="4a5772b2-d12b-45d0-9ffe-5f44312b2db9"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Abweichung]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="286" y="21" width="68" height="19" backcolor="#F5F7FA" uuid="0d3bc3fa-803f-4b7a-9a87-762f22de8705"/>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Deviation]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="354" y="0" width="77" height="21" backcolor="#F5F7FA" uuid="e9d94aa3-4b24-48e5-8ef0-9c510e4a6265"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[erweiterte Messunsicherheit]]></text>
-				</staticText>
-				<staticText>
-                                        <reportElement mode="Opaque" x="354" y="21" width="77" height="19" backcolor="#F5F7FA" uuid="1bd63f28-78b3-4d3f-a71a-c1e3afac4c6a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="431" y="0" width="16" height="21" backcolor="#F5F7FA" uuid="c225e56e-5de5-49bb-9344-54f77c85d466"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="431" y="21" width="16" height="19" backcolor="#F5F7FA" uuid="e9e5a2fa-9ce3-42cf-adb8-8a99fe4eb52e"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="447" y="0" width="88" height="21" backcolor="#F5F7FA" uuid="2d22ba99-4dbc-44c7-9c66-1192c427322a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Konformität]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="447" y="21" width="88" height="19" backcolor="#F5F7FA" uuid="f6d1cd56-4510-4a3f-9a78-d8e9da101f13"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Conformity]]></text>
-				</staticText>
-			</frame>
-			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="f7eb2d2b-eb4d-41e5-ae4b-8ab7d1ada9f0">
-					<printWhenExpression><![CDATA[$P{ModernResultsHeader} != null
-    && $P{ModernResultsHeader}.toString().equalsIgnoreCase("Y")
-    && (
-        $V{MeasurementDetailsValue} != null
-        && (
-            $V{MeasurementDetailsValue}.intValue() == 3
-            || $V{MeasurementDetailsValue}.intValue() == 4
-        )
-    )]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="0" width="120" height="21" backcolor="#F5F7FA" uuid="ff579e83-5f9a-46eb-8d2f-34260c733efd"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messbedingungen]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="21" width="120" height="19" backcolor="#F5F7FA" uuid="dd2d1c2f-3c44-437d-a13f-6bc134e1e7c7"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measuring Condition]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="120" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="5b1ad1aa-910f-42a8-b37b-5ab64a30bd30"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Sollwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="120" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="69f9fa3b-5cd6-4d23-9def-1508c3883d2b"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[True Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="200" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="71881b62-ac3c-44c8-a0a4-9c687a2d88cd"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Messwert]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="200" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="35139bbf-1a81-4d91-930e-a1277bde443b"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Measured Value]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="280" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="dc02bf9c-08f7-4b5e-951b-514d24c5ef56"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Abweichung]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="280" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="6eac3f8c-8f62-4ea8-8b85-45b5c2a091bd"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% rel. Deviation]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="350" y="0" width="100" height="21" backcolor="#F5F7FA" uuid="8c5f36d1-8fb9-4681-88ce-2f6cc0d558a8"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[erweiterte Messunsicherheit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="350" y="21" width="100" height="19" backcolor="#F5F7FA" uuid="15fd5718-0f8d-4bd1-83a8-4b2f0cc80d2c"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="450" y="0" width="25" height="21" backcolor="#F5F7FA" uuid="8c0586b8-5baf-45cb-8f57-05e4ff66b48b"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="450" y="21" width="25" height="19" backcolor="#F5F7FA" uuid="efb2d86c-72c1-4ad4-9fb5-b71a93df6e3a"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[% Tol]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="475" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="28f8b874-131b-47e8-8c9e-46c13690d8c0"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="6" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Konformität]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="475" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="a25f837a-5488-4f0f-9db3-94e89292f961"/>
-					<box>
-						<topPen lineWidth="0.0"/>
-						<leftPen lineWidth="0.0"/>
-						<bottomPen lineWidth="0.25" lineColor="#E5E7EB"/>
-						<rightPen lineWidth="0.0"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
-					</textElement>
-					<text><![CDATA[Conformity]]></text>
-				</staticText>
-			</frame>
-			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="0e30b70c-1f1a-4a39-b02c-800e348721ba">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 2]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-					<reportElement x="0" y="0" width="110" height="21" uuid="5c5dcb15-89a6-40c4-9cdf-0868be2c0c8a"/>
+					<reportElement x="0" y="0" width="70" height="21" uuid="53f3d85e-de3b-5769-9145-778a6d5af69a"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1243,7 +577,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="110" height="19" uuid="6e7d15e2-3cd1-4ae1-8e94-7ba23d43142d"/>
+					<reportElement x="0" y="21" width="70" height="19" uuid="ff64171c-0874-5d50-ab1b-74e9a88ff414"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1255,7 +589,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="0" width="60" height="21" uuid="78d2b44b-93b7-476f-9e4d-0977ab8f3288"/>
+					<reportElement x="70" y="0" width="54" height="21" uuid="659f4e49-7bf6-5ffc-b373-1057dc373f68"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1267,7 +601,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="21" width="60" height="19" uuid="22c83c66-1520-4047-898d-93d90ce64cfe"/>
+					<reportElement x="70" y="21" width="54" height="19" uuid="ea60a506-f305-5328-b18c-5f18d79c82c7"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1279,7 +613,7 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="0" width="60" height="21" uuid="e7f5bf15-845e-4ada-a4db-53f10781dfc3"/>
+					<reportElement x="124" y="0" width="54" height="21" uuid="f8e76f08-9152-5359-b0b6-9f82c1b9bfe3"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1291,7 +625,7 @@
 					<text><![CDATA[untere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="21" width="60" height="19" uuid="2e920011-3756-43ae-8ad9-053c8bc6756c"/>
+					<reportElement x="124" y="21" width="54" height="19" uuid="25e33ab1-7d7a-5e19-9929-efcbee99e66d"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1303,7 +637,7 @@
 					<text><![CDATA[Lower Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="0" width="60" height="21" uuid="58c100bb-2cab-48b8-bcae-a5d2124b695a"/>
+					<reportElement x="178" y="0" width="54" height="21" uuid="41b63aeb-b3d6-57a3-ae7e-1733fc57f69f"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1315,7 +649,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="21" width="60" height="19" uuid="5d37b9fb-2068-4beb-8350-19757e74c7f9"/>
+					<reportElement x="178" y="21" width="54" height="19" uuid="a5caf027-05f8-5064-bbde-fb0eab2d886f"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1327,7 +661,7 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="0" width="60" height="21" uuid="80726e4e-4fdd-431a-8ab3-a7f649d4bfc4"/>
+					<reportElement x="232" y="0" width="54" height="21" uuid="a5174cc8-35a5-5a91-b79a-af701527fa24"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1339,7 +673,7 @@
 					<text><![CDATA[obere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="21" width="60" height="19" uuid="d0bfc6b8-1f1e-4df9-9d2b-666918f7d1f1"/>
+					<reportElement x="232" y="21" width="54" height="19" uuid="b713ff50-b083-5ff2-b8b8-1f9212944278"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1351,7 +685,7 @@
 					<text><![CDATA[Upper Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="45" height="21" uuid="a59a6dc1-0e2f-4726-83ef-fc6482fec21b"/>
+					<reportElement x="286" y="0" width="68" height="21" uuid="8556ecc1-f3a0-514e-9506-0608f4e55f51"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1363,7 +697,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="45" height="19" uuid="5fbef31c-8da1-4657-94c4-0d7a8ac5e2d7"/>
+					<reportElement x="286" y="21" width="68" height="19" uuid="392bb49c-74a5-55e9-8e0e-97ec8cb0f147"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1375,7 +709,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="0" width="65" height="21" uuid="ddf45851-f50a-4bcc-85c8-d841021c82d5"/>
+					<reportElement x="354" y="0" width="77" height="21" uuid="53b6ea15-afa7-5b2d-b4da-00f270afa7f6"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1387,7 +721,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="21" width="65" height="19" uuid="0df37f3f-5b01-47eb-8f49-3bc63986df21"/>
+					<reportElement x="354" y="21" width="77" height="19" uuid="7be481e4-3ee2-540f-8fc1-290b3a54b767"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1399,7 +733,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="0" width="22" height="21" uuid="5a178f37-3133-41c7-92a7-bf7017b2f9be"/>
+					<reportElement x="431" y="0" width="16" height="21" uuid="9a7801f1-6298-5b5f-a788-bfaa6eece405"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1411,7 +745,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="21" width="22" height="19" uuid="18c6a947-5d89-405a-9d1f-bf6892d666b3"/>
+					<reportElement x="431" y="21" width="16" height="19" uuid="9c007ef3-7a33-54e8-9a76-879e0cb0752c"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1423,7 +757,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="0" width="53" height="21" uuid="2d905001-2e4a-467b-8d27-e270f33a3eaa"/>
+					<reportElement x="447" y="0" width="88" height="21" uuid="64ed73c2-4afa-500a-bc21-33f01fffe8c2"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1435,7 +769,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="21" width="53" height="19" uuid="6f0d9fcb-e50c-40da-a8db-880b8f166c3b"/>
+					<reportElement x="447" y="21" width="88" height="19" uuid="e9ab7383-dc71-508e-bff8-29bad4d59ff6"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1448,11 +782,173 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="9999c849-8077-4df9-8890-26a93be0cd10">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 22]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="253fee68-413e-566b-b37d-c655f51c5988">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 2]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="110" height="21" uuid="9ef57134-a08d-4722-b5dc-88638fd1def8"/>
+					<reportElement mode="Opaque" x="0" y="0" width="110" height="21" backcolor="#F5F7FA" uuid="866346f3-b68b-5c33-a30b-54cfaf65527d"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="110" height="19" backcolor="#F5F7FA" uuid="b33047a2-f576-57a8-b5c4-af8d4e44d2b2"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="110" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="5e8c7e5b-a4e6-51a2-b6b9-445f8bf67f87"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="110" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="ac4fbd39-c95a-5adb-86c6-2f93d9b3bb01"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="170" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="1af0e23d-4c1c-5aab-bae4-8a8f590142bb"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[untere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="170" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="ee66aaac-9a6e-5499-8785-e973a3cc7f95"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Lower Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="230" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="c7f2e052-592d-51fb-941d-e7062062d2e9"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="230" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="a09c5d71-4fae-524d-bd40-6207642fb783"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="290" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="a047f059-7312-59c6-99e4-0d730b74e5f4"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[obere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="290" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="2b259f77-d3ff-53fc-816e-cdd78412d3c1"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Upper Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="45" height="21" backcolor="#F5F7FA" uuid="74129f2a-9c41-5371-9e55-530cea5cbc2a"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="21" width="45" height="19" backcolor="#F5F7FA" uuid="2be7c6f4-9498-50ad-b97b-99c16574a599"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="395" y="0" width="65" height="21" backcolor="#F5F7FA" uuid="33676986-c780-5d92-8e16-f199e149bbbf"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="395" y="21" width="65" height="19" backcolor="#F5F7FA" uuid="13c1e98f-43c4-5995-bb38-a92945e80eb2"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="0" width="22" height="21" backcolor="#F5F7FA" uuid="daa8a397-8cba-5f6a-8957-232a23f99632"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="21" width="22" height="19" backcolor="#F5F7FA" uuid="d2a12efe-0812-5397-a7c5-fd866c90360b"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="0" width="53" height="21" backcolor="#F5F7FA" uuid="b0359af6-5e8b-5290-881d-398cb46afb7e"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="21" width="53" height="19" backcolor="#F5F7FA" uuid="03b07523-9f80-535c-84a0-5b7e3248a7e8"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="32b8979d-74a9-50eb-bc7b-f1aeb1f30579">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 2]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="110" height="21" uuid="3abadd5c-07cf-57c4-a17d-77eb30c226c4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1464,7 +960,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="110" height="19" uuid="77893e8b-d6f5-4e75-832b-3b2cb50db9ef"/>
+					<reportElement x="0" y="21" width="110" height="19" uuid="4901c406-6675-54b5-951a-bf988f237614"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1476,7 +972,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="0" width="60" height="21" uuid="a8728949-aa86-4a38-afc1-d4bce7e957be"/>
+					<reportElement x="110" y="0" width="60" height="21" uuid="d7c73b61-68cf-5028-803f-3ae0fc020e8a"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1488,7 +984,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="110" y="21" width="60" height="19" uuid="d4cb35b8-3639-4104-952f-44afa462c17b"/>
+					<reportElement x="110" y="21" width="60" height="19" uuid="1ca4af54-3ef5-5a84-a73a-62c71e77f0c7"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1500,7 +996,7 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="0" width="60" height="21" uuid="cf055528-4ca7-4ff8-92f6-adf846768f55"/>
+					<reportElement x="170" y="0" width="60" height="21" uuid="9320fc05-c380-5996-909a-9b43dbf57f88"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1512,7 +1008,7 @@
 					<text><![CDATA[untere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="170" y="21" width="60" height="19" uuid="1bc83d75-a21d-4d98-8422-623221a058a1"/>
+					<reportElement x="170" y="21" width="60" height="19" uuid="ab8dd9ed-c9d4-51f7-bbff-5e2e345dfdf8"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1524,7 +1020,7 @@
 					<text><![CDATA[Lower Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="0" width="60" height="21" uuid="140da21a-29e7-4daf-a389-6b3a9340597e"/>
+					<reportElement x="230" y="0" width="60" height="21" uuid="9f368450-0140-5cb8-9a25-22364d915f95"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1536,7 +1032,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="230" y="21" width="60" height="19" uuid="b1dec267-7066-4c79-a041-b275d736db0d"/>
+					<reportElement x="230" y="21" width="60" height="19" uuid="b03ca0f7-4db6-5c90-8fa3-f5fcecb0484e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1548,7 +1044,7 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="0" width="60" height="21" uuid="db3ff69a-9ba2-4663-b9c6-8ec76bad9de4"/>
+					<reportElement x="290" y="0" width="60" height="21" uuid="3998bb31-928f-58f9-9868-83aaac6930e7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1560,7 +1056,7 @@
 					<text><![CDATA[obere Spezifikation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="290" y="21" width="60" height="19" uuid="e929bc96-9d28-4d6f-9f84-d6b9fc98848b"/>
+					<reportElement x="290" y="21" width="60" height="19" uuid="a346ac1f-b9a9-5fe9-9093-fe2878413ffa"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1572,7 +1068,7 @@
 					<text><![CDATA[Upper Limit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="45" height="21" uuid="f5392001-2594-410c-a818-73e95f3ad9a4"/>
+					<reportElement x="350" y="0" width="45" height="21" uuid="b7d8336c-bae3-5f47-947d-4fb3e8775ac4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1584,7 +1080,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="45" height="19" uuid="fb55558b-f5ff-4cf8-beae-9cd891914295"/>
+					<reportElement x="350" y="21" width="45" height="19" uuid="96df55e2-b99e-5d97-bcc4-03688b46d09b"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1596,7 +1092,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="0" width="65" height="21" uuid="2595d451-85b6-4540-876a-275db9ce812d"/>
+					<reportElement x="395" y="0" width="65" height="21" uuid="894291ab-77ab-5dab-a640-f3131d281873"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1608,7 +1104,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="395" y="21" width="65" height="19" uuid="04d9b7dd-3ed8-4fea-b7ba-22611fffb66e"/>
+					<reportElement x="395" y="21" width="65" height="19" uuid="30dafe36-1f5e-5e6b-871b-2906e80a9aa8"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1620,7 +1116,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="0" width="22" height="21" uuid="65d3c0ae-4b8a-4acd-b1fd-d62dfbe5e4a1"/>
+					<reportElement x="460" y="0" width="22" height="21" uuid="89d8e246-dd82-5021-95b8-8d3832d81ad4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1632,7 +1128,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="460" y="21" width="22" height="19" uuid="8bb5a7aa-e956-4c12-a1dd-f4b8a22493dd"/>
+					<reportElement x="460" y="21" width="22" height="19" uuid="7f192254-369a-5aaa-9d9c-567ed957c3b0"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1644,7 +1140,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="0" width="53" height="21" uuid="df372e06-f016-4871-9eeb-1eef21cdaea6"/>
+					<reportElement x="482" y="0" width="53" height="21" uuid="56deb187-f02e-5ea3-984d-761e378f22e4"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1656,7 +1152,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="482" y="21" width="53" height="19" uuid="2ada51a8-e15a-4d88-a327-f491f3bfb1a4"/>
+					<reportElement x="482" y="21" width="53" height="19" uuid="2b74bf7d-3d09-5242-9b84-06cd5d37cb7e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1669,27 +1165,22 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="9d420c13-973f-44d4-813c-c1940c70e9ec">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 21]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="a7546b88-cb00-52cf-88fd-d996c0c12093">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 22]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="156" height="21" uuid="587b5af0-cabb-4b66-8c9e-e11fead78085"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="0" y="0" width="110" height="21" backcolor="#F5F7FA" uuid="8ac3721b-8491-5fa1-8fb4-3c5ae576b4fb"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="156" height="19" uuid="f2b8402d-cf20-45bd-bf45-6cbadf53cf71"/>
+					<reportElement mode="Opaque" x="0" y="21" width="110" height="19" backcolor="#F5F7FA" uuid="869bd8f0-fb24-505f-88e5-b62093669a73"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1697,23 +1188,16 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="156" y="0" width="96" height="21" uuid="6e6abb9f-0265-4ee0-a99b-fbd2b605ad4f"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="110" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="9eadf1d3-31a9-5617-b757-2d9c3fcc665b"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="156" y="21" width="96" height="19" uuid="c0126df0-95fe-4b42-99e1-8ee6726e8327"/>
+					<reportElement mode="Opaque" x="110" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="b871e6c5-3a9b-5b76-85e1-631303fa3a7f"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1721,23 +1205,33 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="252" y="0" width="96" height="21" uuid="d6f77c33-f5f4-4a53-b2dd-ece15ff66eff"/>
+					<reportElement mode="Opaque" x="170" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="eda83069-23b2-5180-9e77-928d804c5043"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[untere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="170" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="6d63e3da-105d-5685-8c27-fdb4a834d394"/>
 					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Lower Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="230" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="61d85bb5-e133-5544-8c09-0d6ad310054c"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="252" y="21" width="96" height="19" uuid="72d05083-4e0b-424d-a2f8-cd7ccb6f1816"/>
+					<reportElement mode="Opaque" x="230" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="9ae89a77-6e54-5118-abb3-3c5f253a2661"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1745,23 +1239,33 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="348" y="0" width="61" height="21" uuid="d38ab117-a950-45cb-a660-2ad396c13d25"/>
+					<reportElement mode="Opaque" x="290" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="f820f59c-105e-50f1-ad47-438840949f40"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[obere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="290" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="4f131dab-193a-5280-96b3-eadc98d10232"/>
 					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Upper Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="45" height="21" backcolor="#F5F7FA" uuid="f8f84681-beb8-5b82-83f4-533bd3d1ef91"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="348" y="21" width="61" height="19" uuid="ad0eb6cc-b640-47b8-b085-8fb3ca717fa7"/>
+					<reportElement mode="Opaque" x="350" y="21" width="45" height="19" backcolor="#F5F7FA" uuid="59d082f4-e080-5e88-87ba-ac91014178c1"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
@@ -1769,36 +1273,65 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="409" y="0" width="126" height="21" uuid="abb95ab7-4708-4351-99f6-d16f0ebcb1f8"/>
-					<box>
-						<topPen lineWidth="0.75"/>
-						<leftPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
-					</box>
+					<reportElement mode="Opaque" x="395" y="0" width="65" height="21" backcolor="#F5F7FA" uuid="c4497cdb-7a88-5f3a-b2a5-3a6b0015a940"/>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="6" isBold="true"/>
 					</textElement>
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="409" y="21" width="126" height="19" uuid="fe39dd0c-f2f2-4fd6-8765-aa78f139924a"/>
+					<reportElement mode="Opaque" x="395" y="21" width="65" height="19" backcolor="#F5F7FA" uuid="0d29bf49-47a0-5d87-ab1a-65fac761465e"/>
 					<box>
-						<leftPen lineWidth="0.75"/>
-						<bottomPen lineWidth="0.75"/>
-						<rightPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
 					</box>
 					<textElement textAlignment="Center" verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
 					</textElement>
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="0" width="22" height="21" backcolor="#F5F7FA" uuid="42e99d32-aa4b-5416-9a09-14e8855aa0b0"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="460" y="21" width="22" height="19" backcolor="#F5F7FA" uuid="3d53e484-1d20-5c8f-bddc-3368bcce7d8c"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="0" width="53" height="21" backcolor="#F5F7FA" uuid="39efeb63-8c60-504f-bf62-99a5bb7cea04"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="482" y="21" width="53" height="19" backcolor="#F5F7FA" uuid="e4f58bda-6f48-5d41-b9cf-f0d8c43457a2"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="77c05213-e84f-4b75-8bc6-f427caa33ce1">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 3]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="b4bb5d35-c111-5cef-9e4c-8c750cdcce25">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 22]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="120" height="21" uuid="cd0b237b-3723-4f2c-84cf-4ea5bf4b6858"/>
+					<reportElement x="0" y="0" width="110" height="21" uuid="e1405c5b-25bb-5ad5-88f7-f458a38849a5"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1810,7 +1343,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="120" height="19" uuid="e02858f3-94b4-4016-a0f6-e9560f1a216d"/>
+					<reportElement x="0" y="21" width="110" height="19" uuid="5ca46a76-ad43-5b31-b088-926effed641c"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1822,7 +1355,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="0" width="80" height="21" uuid="683d169b-0024-4f3c-9454-fc1f79d78946"/>
+					<reportElement x="110" y="0" width="60" height="21" uuid="e5d9fc61-25f4-5a15-8cf4-71a354b114b3"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1834,7 +1367,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="21" width="80" height="19" uuid="237226a9-a1e3-408b-aa2d-b59e0cd27f8d"/>
+					<reportElement x="110" y="21" width="60" height="19" uuid="cb1dbcae-4c23-5290-9c1e-94d862110c31"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1846,7 +1379,31 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="0" width="80" height="21" uuid="255afede-fc13-45e4-9c3c-48a72fa1fcc8"/>
+					<reportElement x="170" y="0" width="60" height="21" uuid="449935ff-6a4b-55e6-bdea-7788ec36eeb1"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[untere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="170" y="21" width="60" height="19" uuid="7b5c8fcd-11a5-5b5b-b26d-d368494f2c3b"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Lower Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="230" y="0" width="60" height="21" uuid="ce58a3d6-353b-5df1-904a-7da45b8030f3"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1858,7 +1415,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="21" width="80" height="19" uuid="c2af622d-ebf6-4763-b585-c01af78cbe8f"/>
+					<reportElement x="230" y="21" width="60" height="19" uuid="2022b37d-3a35-5fee-9d2c-c713f871b131"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1870,7 +1427,31 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="0" width="70" height="21" uuid="d741d94b-42f0-414e-a837-cf45bc4d8f5a"/>
+					<reportElement x="290" y="0" width="60" height="21" uuid="3717a6c0-f3dd-53db-b04b-086de76b4307"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[obere Spezifikation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="290" y="21" width="60" height="19" uuid="5aaa0449-c5b5-56a6-ac4d-75d4b155814d"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Upper Limit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="0" width="45" height="21" uuid="c039a234-25b0-5971-81e7-0fe6040698a7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1882,7 +1463,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="21" width="70" height="19" uuid="0c39272c-0c41-4d4d-b9c4-60c588e4bbfd"/>
+					<reportElement x="350" y="21" width="45" height="19" uuid="43bad4be-9626-599b-be6f-37ed0fd9257a"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1894,7 +1475,7 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="100" height="21" uuid="8c6894ab-80a7-45eb-9dcc-5b39c939d9c7"/>
+					<reportElement x="395" y="0" width="65" height="21" uuid="7c360d31-5c77-5fe5-92bf-90ab05837f7f"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1906,7 +1487,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="100" height="19" uuid="bdbe7508-292f-463e-b8a3-45c91a07d169"/>
+					<reportElement x="395" y="21" width="65" height="19" uuid="d94fe13f-54aa-5c81-a7d7-3cec2e3116db"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1918,7 +1499,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="0" width="25" height="21" uuid="d5599b28-05ae-41c8-9ff2-6c319f60be39"/>
+					<reportElement x="460" y="0" width="22" height="21" uuid="8bc841ba-67f4-514b-b5d7-9cf2f28e3cd7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1930,7 +1511,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="21" width="25" height="19" uuid="90a651d4-5514-4fd5-8a0a-1723f3d434db"/>
+					<reportElement x="460" y="21" width="22" height="19" uuid="7eab6faf-ec9e-5ed3-b647-e3e2550cf5e6"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1942,7 +1523,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="0" width="60" height="21" uuid="8dbac63f-7c0c-4a6a-a3ab-4b035453deab"/>
+					<reportElement x="482" y="0" width="53" height="21" uuid="92f0a8c4-f371-5c8d-be87-811ab6061050"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1954,7 +1535,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="21" width="60" height="19" uuid="f876b3de-9f36-40e0-beee-3e76efcbd2d5"/>
+					<reportElement x="482" y="21" width="53" height="19" uuid="8606b0d4-0673-55fe-834e-8848543bc09b"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1967,11 +1548,105 @@
 				</staticText>
 			</frame>
 			<frame>
-				<reportElement x="0" y="0" width="535" height="54" uuid="e68489b7-5b78-45b5-9587-bd87d4db3533">
-					<printWhenExpression><![CDATA[$V{MeasurementDetailsValue} != null && $V{MeasurementDetailsValue}.intValue() == 4]]></printWhenExpression>
+				<reportElement x="0" y="0" width="535" height="54" uuid="cba31811-ddbe-5438-b070-50fabac0f362">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 21]]></printWhenExpression>
 				</reportElement>
 				<staticText>
-					<reportElement x="0" y="0" width="120" height="21" uuid="4eb67baf-b479-45de-9329-2c31681bf56c"/>
+					<reportElement mode="Opaque" x="0" y="0" width="156" height="21" backcolor="#F5F7FA" uuid="e9dcee4f-83f8-5d2f-bf9c-4908e885fa50"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="156" height="19" backcolor="#F5F7FA" uuid="e658b9cc-f4d0-5a74-b1fb-c246fc5958ce"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="156" y="0" width="96" height="21" backcolor="#F5F7FA" uuid="97f065e4-1de8-58f1-91d9-415c36eee795"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="156" y="21" width="96" height="19" backcolor="#F5F7FA" uuid="782cd75a-ef38-5684-a609-1f44cdb8c4f7"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="252" y="0" width="96" height="21" backcolor="#F5F7FA" uuid="472d47f3-b472-5747-947d-29f3ddbab523"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="252" y="21" width="96" height="19" backcolor="#F5F7FA" uuid="d7fa8eb0-ebf3-5cdd-a471-326c8882f084"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="348" y="0" width="61" height="21" backcolor="#F5F7FA" uuid="7b116d5c-e92f-5b65-8ee5-71370c02a121"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="348" y="21" width="61" height="19" backcolor="#F5F7FA" uuid="b8ed44a7-13ac-53a0-b386-dfad6c643f07"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="409" y="0" width="126" height="21" backcolor="#F5F7FA" uuid="e43ba6b3-ef79-5662-baa7-ac8075085b95"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="409" y="21" width="126" height="19" backcolor="#F5F7FA" uuid="2c5d181e-5c30-587f-a197-2a233fa9c349"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="0d623dda-59db-5438-8ef7-c93c805a6828">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 21]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="156" height="21" uuid="99d64120-4143-5356-9b38-0c66601ccbee"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -1983,7 +1658,7 @@
 					<text><![CDATA[Messbedingungen]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="0" y="21" width="120" height="19" uuid="23c83b5d-f6bb-4a20-a59e-025400d93c97"/>
+					<reportElement x="0" y="21" width="156" height="19" uuid="70a5a433-3f1b-5dc8-ba35-76fb747fa796"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -1995,7 +1670,7 @@
 					<text><![CDATA[Measuring Condition]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="0" width="80" height="21" uuid="1d05eb27-4901-4a31-9a83-310570eff821"/>
+					<reportElement x="156" y="0" width="96" height="21" uuid="629def18-6cac-5653-9f25-7fb52aedf074"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2007,7 +1682,7 @@
 					<text><![CDATA[Sollwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="120" y="21" width="80" height="19" uuid="20c6d7d7-8940-49d5-8c6c-5ee2250fa003"/>
+					<reportElement x="156" y="21" width="96" height="19" uuid="68ba7331-c656-589d-98d8-4fbd743cdd2b"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2019,7 +1694,7 @@
 					<text><![CDATA[True Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="0" width="80" height="21" uuid="d28bf913-25c7-4a49-919e-c7dba3bc625b"/>
+					<reportElement x="252" y="0" width="96" height="21" uuid="8d24450e-cd9a-5898-9f4e-6d4b85d0fa07"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2031,7 +1706,7 @@
 					<text><![CDATA[Messwert]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="200" y="21" width="80" height="19" uuid="d0ead348-24ac-4488-872c-df2678296e42"/>
+					<reportElement x="252" y="21" width="96" height="19" uuid="ac107ba0-24a9-5025-a80f-d44d836d9550"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2043,7 +1718,7 @@
 					<text><![CDATA[Measured Value]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="0" width="70" height="21" uuid="1c101134-389f-4b0a-977f-a9bf15d25e47"/>
+					<reportElement x="348" y="0" width="61" height="21" uuid="c461220d-6cb7-5040-b018-733a3d089c6b"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2055,7 +1730,7 @@
 					<text><![CDATA[% rel. Abweichung]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="280" y="21" width="70" height="19" uuid="79676e0f-72f5-457d-be35-b4884b2e5665"/>
+					<reportElement x="348" y="21" width="61" height="19" uuid="efbe016f-2579-5aed-9404-77138102fa1e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2067,7 +1742,561 @@
 					<text><![CDATA[% rel. Deviation]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="0" width="100" height="21" uuid="d476c93f-d6f4-4e08-86a8-cd51e9bcaaad"/>
+					<reportElement x="409" y="0" width="126" height="21" uuid="2ef4ff88-6bf0-506a-bf9d-26e2ca266575"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="409" y="21" width="126" height="19" uuid="e02e25f5-16db-522f-8213-ae3d6765eb75"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="c9eb67be-fea2-5c16-a4d7-82c5724b17dc">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 3]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="0" width="120" height="21" backcolor="#F5F7FA" uuid="8576f68b-1c6f-5fc4-85ed-c33bdd3864ff"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="120" height="19" backcolor="#F5F7FA" uuid="a4737020-e59a-56ce-8a37-939943f52a32"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="ba03ba42-3a88-5f94-b3a2-c9896444df9b"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="7fd9afef-4aff-577d-8db0-3258e3082e35"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="b8e593a9-0e8c-5475-8d5f-88ecc1714fed"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="d146cb5a-8246-5e99-9283-f92291368f05"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="43827148-d046-5b23-ae48-01ba8fbe8113"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="ca1581c6-f9c2-5be8-8563-dd0d3266cb44"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="100" height="21" backcolor="#F5F7FA" uuid="ca7bde61-5820-52e1-8bc2-e713eaa33598"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="21" width="100" height="19" backcolor="#F5F7FA" uuid="1156b12c-148a-56cd-ab1d-d9ace461d6a0"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="0" width="25" height="21" backcolor="#F5F7FA" uuid="5a41c648-bc55-5313-a9c5-3269e35b7670"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="21" width="25" height="19" backcolor="#F5F7FA" uuid="563ced72-9045-59d4-83bb-3c9e586a0172"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="3a792f26-9bde-591c-b247-d7845cb68dd0"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="16587c47-a093-54ba-996d-82b86d343979"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="f25a2c77-cdbb-56ea-bfe1-54b529bbf07f">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 3]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="120" height="21" uuid="85a58fe9-297b-5486-a8c6-800ede1b5aa1"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="0" y="21" width="120" height="19" uuid="a6ea883e-dd1c-5c18-a6b9-972b7c633c22"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="0" width="80" height="21" uuid="f99351ef-7397-54ed-b815-c7057cb95a6a"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="21" width="80" height="19" uuid="9098e2d5-da02-5cd2-a82a-3179c0545efd"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="0" width="80" height="21" uuid="74907f34-590e-5398-b5d9-d8476d879f83"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="21" width="80" height="19" uuid="554cf588-03ea-507b-bcf1-7c38e6bc0fc7"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="0" width="70" height="21" uuid="9f5d505a-a7e1-547a-b059-a83a411484a8"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="21" width="70" height="19" uuid="c71020a7-ae32-5f59-a59c-f17bcd37a684"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="0" width="100" height="21" uuid="b35470d2-9fea-54aa-9645-81d399f73515"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="21" width="100" height="19" uuid="26b99011-5c2f-5aac-9ab5-51a6f179da62"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="450" y="0" width="25" height="21" uuid="c0d4d52d-0589-5272-9b47-5c0c906ff14f"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="450" y="21" width="25" height="19" uuid="56169287-3275-5b3c-8757-b32b033a927d"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="475" y="0" width="60" height="21" uuid="4dcf386a-4123-5a46-bcdc-330bb3917c4c"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="475" y="21" width="60" height="19" uuid="32ded984-315f-57cb-b2bf-9b6fc430cde1"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="f25ad94b-9051-5949-9318-e7ec0018f75a">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 4]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="0" width="120" height="21" backcolor="#F5F7FA" uuid="aee85479-a4a3-5bf8-af9f-34396b3c1afc"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="0" y="21" width="120" height="19" backcolor="#F5F7FA" uuid="5fcd488e-6780-514f-949a-5e79160d675c"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="383ddfbb-2e4a-5ffc-a0c8-08d6996ac1ae"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="120" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="70247ea9-b06d-5631-ae86-ca1b50c721a3"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="0" width="80" height="21" backcolor="#F5F7FA" uuid="f49488f3-3229-5ec4-b174-7cc1fec07c19"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="200" y="21" width="80" height="19" backcolor="#F5F7FA" uuid="4bfefd29-a844-50b3-b934-a5a71605231b"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="0" width="70" height="21" backcolor="#F5F7FA" uuid="711bcdd5-e002-5701-a8c8-d004b7927f6e"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="280" y="21" width="70" height="19" backcolor="#F5F7FA" uuid="8dee3a1c-e619-58dd-a658-f18de362c898"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="0" width="100" height="21" backcolor="#F5F7FA" uuid="517fbc33-7411-52c2-9852-09bb1e9d1fe1"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[erweiterte Messunsicherheit (p)]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="350" y="21" width="100" height="19" backcolor="#F5F7FA" uuid="9ecb6fb7-f075-5dc4-b155-d000edac1570"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Expanded Uncertainty of Measurement (p)]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="0" width="25" height="21" backcolor="#F5F7FA" uuid="a9016fd1-f2d4-5898-90e7-a39c2cc1cc2d"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="450" y="21" width="25" height="19" backcolor="#F5F7FA" uuid="0663b6f4-e350-5941-bb6d-f5fa1e51a04e"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% Tol]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="0" width="60" height="21" backcolor="#F5F7FA" uuid="9c07d101-dbb1-51da-839f-955a17374f9c"/>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Konformität]]></text>
+				</staticText>
+				<staticText>
+					<reportElement mode="Opaque" x="475" y="21" width="60" height="19" backcolor="#F5F7FA" uuid="d1c8cf1e-ff05-5029-ba36-950b990adb65"/>
+					<box>
+						<bottomPen lineWidth="0.5" lineColor="#9CA3AF"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Conformity]]></text>
+				</staticText>
+			</frame>
+			<frame>
+				<reportElement x="0" y="0" width="535" height="54" uuid="b56b5fc8-d52d-5964-aeaf-bd1c124b3600">
+					<printWhenExpression><![CDATA[!Boolean.TRUE.equals($V{UseModernHeader})
+    && $V{MeasurementDetailsValue} != null
+    && $V{MeasurementDetailsValue}.intValue() == 4]]></printWhenExpression>
+				</reportElement>
+				<staticText>
+					<reportElement x="0" y="0" width="120" height="21" uuid="40e8a467-108f-5921-b875-0c50d1377021"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messbedingungen]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="0" y="21" width="120" height="19" uuid="453b5b0d-2186-5411-94f4-adc2c2838610"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measuring Condition]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="0" width="80" height="21" uuid="05011757-7762-55ab-ac4b-6a1c3c64ebff"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Sollwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="120" y="21" width="80" height="19" uuid="4f2ac022-26b0-504e-ac4a-aed99c0420be"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[True Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="0" width="80" height="21" uuid="9e39dc38-5fb7-5a38-af19-96d1fe8a5a1c"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Messwert]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="200" y="21" width="80" height="19" uuid="626dbfd6-6287-5d5a-809f-8d647407870f"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[Measured Value]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="0" width="70" height="21" uuid="faa58751-671b-5442-85fd-1a170fb8445f"/>
+					<box>
+						<topPen lineWidth="0.75"/>
+						<leftPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="6" isBold="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Abweichung]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="280" y="21" width="70" height="19" uuid="754fd9fd-2ccf-5571-998b-d128356bac99"/>
+					<box>
+						<leftPen lineWidth="0.75"/>
+						<bottomPen lineWidth="0.75"/>
+						<rightPen lineWidth="0.75"/>
+					</box>
+					<textElement textAlignment="Center" verticalAlignment="Middle">
+						<font fontName="DejaVu Sans" size="5" isItalic="true"/>
+					</textElement>
+					<text><![CDATA[% rel. Deviation]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="350" y="0" width="100" height="21" uuid="0fadfd52-a365-5ab3-b781-e02667c2e469"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2079,7 +2308,7 @@
 					<text><![CDATA[erweiterte Messunsicherheit (p)]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="350" y="21" width="100" height="19" uuid="a08983ff-45fb-4ddd-b8a7-db8ca7c1150a"/>
+					<reportElement x="350" y="21" width="100" height="19" uuid="f5abfbf7-8c2e-5fa5-8080-d0aa712bd67c"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2091,7 +2320,7 @@
 					<text><![CDATA[Expanded Uncertainty of Measurement (p)]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="0" width="25" height="21" uuid="3f88d9f3-6661-4500-8778-d8b9c0aa6f3c"/>
+					<reportElement x="450" y="0" width="25" height="21" uuid="0a8a2021-31a0-5bdc-9763-b2156494bee7"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2103,7 +2332,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="450" y="21" width="25" height="19" uuid="6c3b58f2-240e-461b-af88-a560d42f451e"/>
+					<reportElement x="450" y="21" width="25" height="19" uuid="e27938af-3005-5839-851c-98e1442f2c5e"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>
@@ -2115,7 +2344,7 @@
 					<text><![CDATA[% Tol]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="0" width="60" height="21" uuid="37661bdd-0067-4a41-9cd0-f2eebaa57c71"/>
+					<reportElement x="475" y="0" width="60" height="21" uuid="2be03a94-a075-5b22-aa91-ec3e9b1ae358"/>
 					<box>
 						<topPen lineWidth="0.75"/>
 						<leftPen lineWidth="0.75"/>
@@ -2127,7 +2356,7 @@
 					<text><![CDATA[Konformität]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="475" y="21" width="60" height="19" uuid="f70e05ff-4b3d-4811-8c70-de0fc2bf98a6"/>
+					<reportElement x="475" y="21" width="60" height="19" uuid="b94c6fef-1253-5d2b-ac37-85256427551f"/>
 					<box>
 						<leftPen lineWidth="0.75"/>
 						<bottomPen lineWidth="0.75"/>


### PR DESCRIPTION
## Problem

Im Standard-DAkkS-Bericht sitzen die Kopfbeschriftungen der Messergebnis-Tabelle versetzt über den Werten: Der klassische Kopf der Standardvariante (`MeasurementDetails=1`) hat andere Spaltenkanten (52/106/160/214/268/…) als die Datenzeilen (70/124/178/232/286/…). Ein Messwert steht dadurch z. B. unter „obere Spezifikation" statt unter „Messwert". Dazu wirkt der voll umrahmte Kopf schwer und altbacken.

Beim Vermessen kamen zwei weitere Fehler ans Licht:

- Bei `ModernResultsHeader=Y` und `MeasurementDetails=3/4` druckten **zwei Köpfe übereinander** (der moderne und der nicht gegen den Stil abgesicherte klassische).
- Für die Varianten 2/21/22 gab es **keine moderne Kopfvariante**, und die gemeinsame moderne 3/4-Variante verlor das „(p)"-Label von Variante 4.

## Änderung

- `columnHeader` von `DAKKS-SAMPLE/subreports/Results.jrxml` neu aufgebaut: je Variante (1/2/21/22/3/4) ein **moderner und ein klassischer Kopf**, beide exakt an den Datenspalten der jeweiligen Variante ausgerichtet. Der tote Frame (`printWhen … && false`) ist raus.
- **Moderner Kopf ist Standard:** heller Streifen (`#F5F7FA`), keine umlaufenden Rahmen, eine feine Linie (`0.5pt #9CA3AF`) unter dem Kopf. Nur ein explizites `ModernResultsHeader=N` (case-insensitiv, getrimmt) schaltet auf den klassischen Kopf zurück – leere Werte aus `params.properties` bzw. der calServer-Parametermaske ergeben damit ebenfalls modern. Die Stil-Weiche liegt in der neuen Variable `UseModernHeader`.
- Datenbänder, Summary, Felder und SQL sind **unverändert** (Diff ohne `columnHeader`, Parameterblock und neue Variable ist XML-identisch zu `main`).
- JSON-Zwilling per `scripts/build_dakks_json_clone.py --write` regeneriert (`--check` grün); `README` und `parameters.json` (Default `Y`, Beschreibung, Optionsreihenfolge) nachgezogen.

## Verifikation

- Geometrie-Abgleich Header↔Datenspalten für alle 6 Varianten in beiden Stilen (Skript, grün in beiden Bundles).
- `xmllint`, `scripts/check_jasper_version.sh`, `scripts/check_parameters_manifest.py`, `scripts/build_dakks_json_clone.py --check` grün.
- Alle fünf Templates mit JasperReports **6.20.6** (gepinnte Version) kompiliert; der JSON-Zwilling mit den Beispieldaten gefüllt und die Ergebnisseite vorher/nachher gerendert – nachher stehen alle Werte exakt unter ihren Beschriftungen.
- Adversariale Prüfung (drei unabhängige Refutationsversuche): printWhen-Bedingungen paarweise disjunkt für alle Parameterkombinationen inkl. Randfälle, Default-Semantik konsistent über alle sechs Dateien, UUIDs eindeutig, Bänder ohne Überlauf, Spalten lückenlos 0–535 pt.

## Bewusst nicht enthalten

- **DCC-Bundle:** `DCC/subreports/DCC-Results.jrxml` hat denselben verschobenen klassischen Kopf und noch die alte `ModernResultsHeader`-Semantik (Default `N`). Gleiches Muster, eigener Bericht – Folgearbeit, falls gewünscht.
- `DAKKS-SAMPLE/preview.jpg` zeigt noch den alten Kopf; ein Neurendern braucht die volle SQL-Umgebung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nJknW3PG9vu4J1p6QnyJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013nJknW3PG9vu4J1p6QnyJq)_