### PR TITLE
feat(config-pakete): Kategorie- und Statusvorlagen als eigene Bundle-Klassen

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -264,6 +264,30 @@ jobs:
             PRICE-LIST-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
+      # Konfigurationspakete (calserver.category-package /
+      # calserver.status-package, robots.md §0.5): eigene Bundle-Klasse ohne
+      # JRXML, der ganze Ordner ist das Paket.
+      - name: Upload CATEGORY-INVENTORY-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CATEGORY-INVENTORY-DAKKS
+          path: CATEGORY-INVENTORY-DAKKS
+          if-no-files-found: error
+
+      - name: Upload STATUS-CALIBRATION-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STATUS-CALIBRATION-DAKKS
+          path: STATUS-CALIBRATION-DAKKS
+          if-no-files-found: error
+
+      - name: Upload STATUS-INVENTORY-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STATUS-INVENTORY-DAKKS
+          path: STATUS-INVENTORY-DAKKS
+          if-no-files-found: error
+
       # Prüfplan-Pakete (calserver.procedure-package, robots.md §0.3):
       # eigene Bundle-Klasse ohne JRXML — der ganze Ordner ist das Paket.
       - name: Upload PRUEFPLAN-FLUKE-23 as artifact
@@ -491,6 +515,36 @@ jobs:
 
           create_wiki_zip "WIKI-ISO-17025" "wiki-iso-17025"
 
+          # Konfigurationspakete (calserver.category-package /
+          # calserver.status-package): manifest.json + Dokument + README.md,
+          # keine Unterordner. Eigene Funktion aus demselben Grund wie beim
+          # Prüfplan — kein JRXML, andere Pflichtdateien.
+          create_config_zip() {
+            local sample="$1"
+            local zip_name="$2"
+            local document="$3"
+            local stage_dir="staging/${zip_name}"
+
+            rm -rf "${stage_dir}"
+            mkdir -p "${stage_dir}"
+
+            for required in manifest.json "${document}" README.md; do
+              if [ ! -f "${sample}/${required}" ]; then
+                echo "❌ ${sample}/${required} fehlt" >&2
+                exit 1
+              fi
+              cp "${sample}/${required}" "${stage_dir}/"
+            done
+
+            pushd "${stage_dir}" >/dev/null
+            zip -r "../../zip_output/${zip_name}.zip" .
+            popd >/dev/null
+          }
+
+          create_config_zip "CATEGORY-INVENTORY-DAKKS" "category-inventory-dakks" "categories.json"
+          create_config_zip "STATUS-CALIBRATION-DAKKS" "status-calibration-dakks" "statuses.json"
+          create_config_zip "STATUS-INVENTORY-DAKKS" "status-inventory-dakks" "statuses.json"
+
           # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL)
           create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"
           create_zip "INVENTORY-JSON-SAMPLE" "inventory-json-sample"
@@ -534,6 +588,9 @@ jobs:
           unzip -l zip_output/pruefplan-fluke-23.zip
           unzip -l zip_output/pruefplan-messschieber-150mm.zip
           unzip -l zip_output/wiki-iso-17025.zip
+          unzip -l zip_output/category-inventory-dakks.zip
+          unzip -l zip_output/status-calibration-dakks.zip
+          unzip -l zip_output/status-inventory-dakks.zip
 
       - name: Send DAKKS-SAMPLE ZIP to API
         env:

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -111,6 +111,9 @@ jobs:
           get_last_modified "REPAIR-JSON-SAMPLE" "repair-json-sample"
           get_last_modified "LOCATION-JSON-SAMPLE" "location-json-sample"
           get_last_modified "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
+          get_last_modified "CATEGORY-INVENTORY-DAKKS" "category-inventory-dakks"
+          get_last_modified "STATUS-CALIBRATION-DAKKS" "status-calibration-dakks"
+          get_last_modified "STATUS-INVENTORY-DAKKS" "status-inventory-dakks"
           get_last_modified "PRUEFPLAN-FLUKE-23" "pruefplan-fluke-23"
           get_last_modified "PRUEFPLAN-MESSSCHIEBER-150MM" "pruefplan-messschieber-150mm"
           get_last_modified "WIKI-ISO-17025" "wiki-iso-17025"
@@ -220,6 +223,9 @@ jobs:
               "pruefplan-fluke-23":                 "PRUEFPLAN-FLUKE-23/README.md",
               "pruefplan-messschieber-150mm":       "PRUEFPLAN-MESSSCHIEBER-150MM/README.md",
               "wiki-iso-17025":                     "WIKI-ISO-17025/README.md",
+              "category-inventory-dakks":           "CATEGORY-INVENTORY-DAKKS/README.md",
+              "status-calibration-dakks":           "STATUS-CALIBRATION-DAKKS/README.md",
+              "status-inventory-dakks":             "STATUS-INVENTORY-DAKKS/README.md",
           }
 
           SCHEMA_MAP = {
@@ -255,6 +261,9 @@ jobs:
               "pruefplan-fluke-23":                 "Prüfplan: Fluke 23 Series II mit Fluke 5520A",
               "pruefplan-messschieber-150mm":       "Prüfplan: Messschieber 150 mm mit Endmaßsatz",
               "wiki-iso-17025":                     "Wiki: QM-Handbuch nach ISO/IEC 17025 (Startvorlage)",
+              "category-inventory-dakks":           "Kategorien: Inventar für Kalibrierlabore (DAkkS)",
+              "status-calibration-dakks":           "Status: Kalibrierung für akkreditierte Labore",
+              "status-inventory-dakks":             "Status: Geräte-Lebenszyklus für Kalibrierlabore",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/.github/workflows/validate-reports.yml
+++ b/.github/workflows/validate-reports.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Check Wiki package manifests
         run: python3 scripts/build_wiki_manifest.py --check
 
+      # Konfigurationspakete (calserver.category-package /
+      # calserver.status-package, CATEGORY-*/STATUS-*): Manifest gegen das
+      # jeweilige Schema, sha256-Parität in beide Richtungen,
+      # Eintrags-Allowlist sowie inhaltliche Prüfungen (Schlüssel eindeutig,
+      # parent_key aufloesbar, Folgeaktionen zeigen auf Status des Pakets).
+      - name: Check config package manifests
+        run: python3 scripts/build_config_manifest.py --check
+
       # DCC 3.3.0 Export: xmlschema erlaubt echte Validierung gegen dcc-v3.3.0.xsd
       # (mit remote SI-/dsig-Imports). Der Check überspringt die XSD-Prüfung
       # anstandslos, falls das Schema offline nicht ladbar ist.

--- a/CATEGORY-INVENTORY-DAKKS/README.md
+++ b/CATEGORY-INVENTORY-DAKKS/README.md
@@ -1,0 +1,76 @@
+# Inventarkategorien für Kalibrierlabore (DAkkS-Zuschnitt)
+
+Startvorlage für den Inventar-Kategoriebaum eines akkreditierten
+Kalibrierlabors. Oberste Ebene ist die **Messgröße**, darunter steht die
+**Normalstufe** — dieselbe Gliederung, nach der auch der Akkreditierungsumfang
+geschnitten ist, sodass sich Bestand und Umfang nebeneinanderlegen lassen.
+
+## Was drin ist
+
+```
+Elektrische Messgrößen          Länge und Winkel
+├── Bezugsnormale               ├── Bezugsnormale
+├── Gebrauchsnormale            ├── Gebrauchsnormale
+└── Prüfmittel                  └── Prüfmittel
+Temperatur und Feuchte          Druck und Vakuum
+Masse und Waagen                Kraft, Drehmoment und Härte
+Volumen und Durchfluss          Zeit und Frequenz
+Hilfs- und Betriebsmittel
+├── Adapter und Leitungen
+├── Klimaüberwachung
+└── Prüfvorrichtungen
+```
+
+36 Kategorien: acht Messgrößen mit je drei Normalstufen, dazu ein Ast für
+Ausstattung ohne eigene Messfunktion.
+
+| Stufe | Bedeutung | Pflichtfelder |
+|-------|-----------|---------------|
+| Bezugsnormale | Höchste Rückführungsstufe des Labors, extern kalibriert | Seriennummer, Hersteller, Kalibrierintervall |
+| Gebrauchsnormale | Tägliche Arbeit, gegen die Bezugsnormale kalibriert | Seriennummer, Kalibrierintervall |
+| Prüfmittel | Messmittel ohne Normalcharakter | Seriennummer sichtbar, nicht pflichtig |
+| Hilfs- und Betriebsmittel | Nicht kalibrierpflichtig | keine |
+
+Die Pflichtfelder sind **Kategoriefelder** (`additional_field`): Sie wirken nur
+für Geräte dieser Kategorie und lassen den Rest des Bestands unberührt. Ein
+Bezugsnormal ohne Seriennummer ist nicht rückführbar — deshalb steht die
+Pflicht dort und nicht global in der Feldverwaltung.
+
+## Import
+
+Berichtsverwaltung ist der falsche Ort; Kategorien gehören in die
+**Administration → Kategorien**. Dort öffnet die Schaltfläche **Paket** den
+Import (Berechtigung `category_import`).
+
+Der Import ist **idempotent**: Wiedererkannt wird eine Kategorie über Typ,
+übergeordnete Kategorie und Name. Ein zweiter Import legt keine Zwillinge an.
+Im Modus „Bestehende behalten" (Vorgabe) bleiben vorhandene Kategorien
+unverändert, es kommt nur dazu, was fehlt.
+
+**Nicht im Paket:** Zuordnungen. Welches Gerät in welcher Kategorie hängt, ist
+Bestand der Installation und wird durch den Import nicht angefasst.
+
+## Anpassen
+
+Die Datei `categories.json` lässt sich direkt bearbeiten und ohne Archiv
+hochladen — calServer liest auch das nackte Dokument. Wer das ZIP anpasst, muss
+danach das Manifest neu schreiben:
+
+```bash
+python3 scripts/build_config_manifest.py --write CATEGORY-INVENTORY-DAKKS
+python3 scripts/build_config_manifest.py --check
+```
+
+Ohne passende Prüfsummen lehnt calServer das Archiv ab. Das ist der Grund,
+warum ein Paket von einer Download-Seite überhaupt vertrauenswürdig ist.
+
+## Grenzen
+
+- **Kategorien sind einsprachig.** Dieses Paket ist deutsch; für eine andere
+  Sprache ein eigenes Paket pflegen.
+- **Die Messgrößen sind ein Vorschlag, kein Umfang.** Welche Größen ein Labor
+  führt, steht in seiner Akkreditierungsurkunde. Nicht benötigte Äste vor dem
+  Import löschen oder danach in calServer entfernen.
+- **Keine Vererbung.** Kategoriefelder wirken je Kategorie, nicht auf
+  Unterkategorien. Wer eine Pflicht für den ganzen Ast braucht, trägt sie in
+  jede betroffene Kategorie ein.

--- a/CATEGORY-INVENTORY-DAKKS/categories.json
+++ b/CATEGORY-INVENTORY-DAKKS/categories.json
@@ -1,0 +1,823 @@
+{
+  "format": "calserver.categories",
+  "version": 1,
+  "generator": "calserver-reports",
+  "types": [
+    "inventory"
+  ],
+  "categories": [
+    {
+      "key": "elektrisch",
+      "type": "inventory",
+      "name": "Elektrische Messgrößen",
+      "short_name": "ELEK",
+      "parent_key": null,
+      "sort_num": 10,
+      "color": "#1D4ED8",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Gleich- und Wechselspannung, Strom, Widerstand, Kapazität, Induktivität."
+    },
+    {
+      "key": "elektrisch-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "ELEK-BEZ",
+      "parent_key": "elektrisch",
+      "sort_num": 10,
+      "color": "#1D4ED8",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Elektrische Messgrößen)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "elektrisch-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "ELEK-GEB",
+      "parent_key": "elektrisch",
+      "sort_num": 20,
+      "color": "#1D4ED8",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Elektrische Messgrößen)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "elektrisch-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "ELEK-PRF",
+      "parent_key": "elektrisch",
+      "sort_num": 30,
+      "color": "#1D4ED8",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Elektrische Messgrößen)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "laenge",
+      "type": "inventory",
+      "name": "Länge und Winkel",
+      "short_name": "LAEN",
+      "parent_key": null,
+      "sort_num": 20,
+      "color": "#0F766E",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Dimensionelle Messtechnik: Endmaße, Messschieber, Messuhren, Winkelnormale."
+    },
+    {
+      "key": "laenge-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "LAEN-BEZ",
+      "parent_key": "laenge",
+      "sort_num": 10,
+      "color": "#0F766E",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Länge und Winkel)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "laenge-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "LAEN-GEB",
+      "parent_key": "laenge",
+      "sort_num": 20,
+      "color": "#0F766E",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Länge und Winkel)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "laenge-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "LAEN-PRF",
+      "parent_key": "laenge",
+      "sort_num": 30,
+      "color": "#0F766E",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Länge und Winkel)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "temperatur",
+      "type": "inventory",
+      "name": "Temperatur und Feuchte",
+      "short_name": "TEMP",
+      "parent_key": null,
+      "sort_num": 30,
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Thermometer, Fühler, Kalibrierbäder, Klimasensoren."
+    },
+    {
+      "key": "temperatur-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "TEMP-BEZ",
+      "parent_key": "temperatur",
+      "sort_num": 10,
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Temperatur und Feuchte)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "temperatur-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "TEMP-GEB",
+      "parent_key": "temperatur",
+      "sort_num": 20,
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Temperatur und Feuchte)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "temperatur-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "TEMP-PRF",
+      "parent_key": "temperatur",
+      "sort_num": 30,
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Temperatur und Feuchte)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "druck",
+      "type": "inventory",
+      "name": "Druck und Vakuum",
+      "short_name": "DRCK",
+      "parent_key": null,
+      "sort_num": 40,
+      "color": "#6D28D9",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Manometer, Druckwaagen, Drucksensoren, Vakuummesstechnik."
+    },
+    {
+      "key": "druck-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "DRCK-BEZ",
+      "parent_key": "druck",
+      "sort_num": 10,
+      "color": "#6D28D9",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Druck und Vakuum)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "druck-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "DRCK-GEB",
+      "parent_key": "druck",
+      "sort_num": 20,
+      "color": "#6D28D9",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Druck und Vakuum)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "druck-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "DRCK-PRF",
+      "parent_key": "druck",
+      "sort_num": 30,
+      "color": "#6D28D9",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Druck und Vakuum)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "masse",
+      "type": "inventory",
+      "name": "Masse und Waagen",
+      "short_name": "MASS",
+      "parent_key": null,
+      "sort_num": 50,
+      "color": "#BE123C",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Gewichtstücke, Waagen, Wägezellen."
+    },
+    {
+      "key": "masse-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "MASS-BEZ",
+      "parent_key": "masse",
+      "sort_num": 10,
+      "color": "#BE123C",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Masse und Waagen)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "masse-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "MASS-GEB",
+      "parent_key": "masse",
+      "sort_num": 20,
+      "color": "#BE123C",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Masse und Waagen)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "masse-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "MASS-PRF",
+      "parent_key": "masse",
+      "sort_num": 30,
+      "color": "#BE123C",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Masse und Waagen)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "kraft",
+      "type": "inventory",
+      "name": "Kraft, Drehmoment und Härte",
+      "short_name": "KRAF",
+      "parent_key": null,
+      "sort_num": 60,
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Kraftaufnehmer, Drehmomentschlüssel und -prüfgeräte, Härteprüfmittel."
+    },
+    {
+      "key": "kraft-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "KRAF-BEZ",
+      "parent_key": "kraft",
+      "sort_num": 10,
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Kraft, Drehmoment und Härte)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "kraft-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "KRAF-GEB",
+      "parent_key": "kraft",
+      "sort_num": 20,
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Kraft, Drehmoment und Härte)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "kraft-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "KRAF-PRF",
+      "parent_key": "kraft",
+      "sort_num": 30,
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Kraft, Drehmoment und Härte)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "volumen",
+      "type": "inventory",
+      "name": "Volumen und Durchfluss",
+      "short_name": "VOLU",
+      "parent_key": null,
+      "sort_num": 70,
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Kolbenhubpipetten, Volumenmessgeräte, Durchflussnormale."
+    },
+    {
+      "key": "volumen-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "VOLU-BEZ",
+      "parent_key": "volumen",
+      "sort_num": 10,
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Volumen und Durchfluss)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "volumen-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "VOLU-GEB",
+      "parent_key": "volumen",
+      "sort_num": 20,
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Volumen und Durchfluss)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "volumen-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "VOLU-PRF",
+      "parent_key": "volumen",
+      "sort_num": 30,
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Volumen und Durchfluss)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "zeit",
+      "type": "inventory",
+      "name": "Zeit und Frequenz",
+      "short_name": "ZEIT",
+      "parent_key": null,
+      "sort_num": 80,
+      "color": "#4338CA",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Frequenznormale, Zeitzähler, Stoppuhren."
+    },
+    {
+      "key": "zeit-bezugsnormale",
+      "type": "inventory",
+      "name": "Bezugsnormale",
+      "short_name": "ZEIT-BEZ",
+      "parent_key": "zeit",
+      "sort_num": 10,
+      "color": "#4338CA",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Höchste Rückführungsstufe des Labors, extern kalibriert. (Zeit und Frequenz)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "manufacturer",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        }
+      ]
+    },
+    {
+      "key": "zeit-gebrauchsnormale",
+      "type": "inventory",
+      "name": "Gebrauchsnormale",
+      "short_name": "ZEIT-GEB",
+      "parent_key": "zeit",
+      "sort_num": 20,
+      "color": "#4338CA",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Für die tägliche Arbeit, gegen die Bezugsnormale kalibriert. (Zeit und Frequenz)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_interval",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "zeit-pruefmittel",
+      "type": "inventory",
+      "name": "Prüfmittel",
+      "short_name": "ZEIT-PRF",
+      "parent_key": "zeit",
+      "sort_num": 30,
+      "color": "#4338CA",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Messmittel ohne Normalcharakter: Adapter, Vorrichtungen, Hilfsgeräte der Messgröße. (Zeit und Frequenz)",
+      "field_rules": [
+        {
+          "field": "serial_number",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "hilfsmittel",
+      "type": "inventory",
+      "name": "Hilfs- und Betriebsmittel",
+      "short_name": "HILF",
+      "parent_key": null,
+      "sort_num": 90,
+      "color": "#475569",
+      "text_color": "#FFFFFF",
+      "rentable": false,
+      "description": "Ausstattung ohne eigene Messfunktion; nicht kalibrierpflichtig, aber inventarisiert."
+    },
+    {
+      "key": "hilfsmittel-adapter",
+      "type": "inventory",
+      "name": "Adapter und Leitungen",
+      "short_name": "HILF-ADP",
+      "parent_key": "hilfsmittel",
+      "sort_num": 10,
+      "color": "#475569",
+      "text_color": "#FFFFFF",
+      "rentable": false
+    },
+    {
+      "key": "hilfsmittel-klima",
+      "type": "inventory",
+      "name": "Klimaüberwachung",
+      "short_name": "HILF-KLI",
+      "parent_key": "hilfsmittel",
+      "sort_num": 20,
+      "color": "#475569",
+      "text_color": "#FFFFFF",
+      "rentable": false
+    },
+    {
+      "key": "hilfsmittel-vorrichtungen",
+      "type": "inventory",
+      "name": "Prüfvorrichtungen",
+      "short_name": "HILF-VOR",
+      "parent_key": "hilfsmittel",
+      "sort_num": 30,
+      "color": "#475569",
+      "text_color": "#FFFFFF",
+      "rentable": false
+    }
+  ]
+}

--- a/CATEGORY-INVENTORY-DAKKS/manifest.json
+++ b/CATEGORY-INVENTORY-DAKKS/manifest.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/category-package.schema.json",
+  "format": "calserver.category-package",
+  "format_version": 1,
+  "name": "Kategorien: Inventar für Kalibrierlabore (DAkkS)",
+  "document": {
+    "format": "calserver.categories",
+    "version": 1
+  },
+  "content": {
+    "categories": 36,
+    "field_rules": 48,
+    "types": [
+      "inventory"
+    ]
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "categories.json",
+      "sha256": "a134568ac0a180ec8de083df75d11d3fe9ab7c1582dc9c4c4ef6a84ff027f426",
+      "size_bytes": 23256
+    },
+    {
+      "path": "README.md",
+      "sha256": "d61503add9a3dfb98f2ab5fc7e49b93a6c095dc5da620487f926f3f72fbea4ea",
+      "size_bytes": 3418
+    }
+  ],
+  "description": "Inventar-Kategoriebaum nach Messgrößen mit den Normalstufen Bezugsnormale, Gebrauchsnormale und Prüfmittel darunter; Pflichtfelder je Normalstufe.",
+  "created_at": "2026-08-15T12:00:00+00:00",
+  "locale": "de"
+}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ TRACE-BACKWARD/
 STICKERS/
 └── ...                 # Aufkleber- und Etikettenvorlagen (versch. Formate)
 
+CATEGORY-INVENTORY-DAKKS/
+├── categories.json     # Inventar-Kategoriebaum (Messgröße → Normalstufe)
+├── manifest.json       # sha256 je Datei
+└── README.md
+
+STATUS-CALIBRATION-DAKKS/, STATUS-INVENTORY-DAKKS/
+├── statuses.json       # Statusmodell samt Feldfunktionen je Status
+├── manifest.json
+└── README.md
+
 PRUEFPLAN-*/
 └── ...                 # Prüfplan-Pakete für calServer V2 — kein Jasper
                         # (calserver.procedure-package, robots.md §0.3)
@@ -102,11 +112,14 @@ pages/
 schema/
 ├── report-parameters.schema.json   # JSON-Schema für parameters.json (V2-JSON-Bundles)
 ├── procedure-package.schema.json   # Manifest-Schema der Prüfplan-Pakete
+├── category-package.schema.json    # Manifest-Schema der Kategorie-Pakete
+├── status-package.schema.json      # Manifest-Schema der Status-Pakete
 └── wiki-package.schema.json        # Manifest-Schema der Wiki-Vorlagen
 
 scripts/
 ├── check_jasper_version.sh         # Prüft JRXML-Versionen auf 6.20.6
 ├── check_parameters_manifest.py    # CI-Validator für parameters.json-Manifeste
+├── build_config_manifest.py        # Manifest-Werkzeug der Kategorie-/Status-Pakete (--write/--check)
 ├── generate_parameters_manifest.py # Erzeugt ein parameters.json-Gerüst aus dem Haupt-JRXML
 ├── dakks_upload_sample.bat         # Beispielskript für den automatisierten Report-Upload
 ├── dcc_upload_sample.bat           # Upload-Beispiel für DCC-Reports
@@ -247,7 +260,7 @@ Das Skript erstellt automatisch ein ZIP-Archiv und lädt es via `curl` zur API d
 
 ## 📦 Download der aktuellen Vorlagenpakete
 
-Die [Downloads-Seite](https://calhelp.github.io/calServer-reports/downloads/) ist die Vorlagenseite für calServer: Berichte sind ein Teil davon, daneben stehen dort Sticker und Etiketten, Prüfpläne und Wiki-Vorlagen. Sortiert wird thematisch. calServer V2 ist der Standard und wird nicht eigens gekennzeichnet; die V1-Vorlagen mit eingebettetem SQL stehen gesammelt in der Kategorie **„calServer V1 (Legacy)"** am Ende der Seite.
+Die [Downloads-Seite](https://calhelp.github.io/calServer-reports/downloads/) ist die Vorlagenseite für calServer: Berichte sind ein Teil davon, daneben stehen dort Sticker und Etiketten, Prüfpläne, Kategoriebäume, Statusmodelle und Wiki-Vorlagen. Sortiert wird thematisch. calServer V2 ist der Standard und wird nicht eigens gekennzeichnet; die V1-Vorlagen mit eingebettetem SQL stehen gesammelt in der Kategorie **„calServer V1 (Legacy)"** am Ende der Seite.
 
 Alle aktuellen und früheren ZIP-Archive stehen zusätzlich als Release-Pakete zur Verfügung:
 

--- a/STATUS-CALIBRATION-DAKKS/README.md
+++ b/STATUS-CALIBRATION-DAKKS/README.md
@@ -1,0 +1,76 @@
+# Kalibrierstatus für akkreditierte Labore
+
+Startvorlage für das Statusmodell des Kalibrierbereichs. Sechs Status entlang
+des Auftragswegs, dazu die Feldfunktionen, die dafür sorgen, dass ein Auftrag
+nicht ohne Ergebnis abgeschlossen werden kann.
+
+## Der Ablauf
+
+| Reihenfolge | Status | Pflichtfelder in diesem Status |
+|-------------|--------|-------------------------------|
+| 10 | Geplant | — |
+| 20 | In Arbeit | — |
+| 30 | Messung abgeschlossen | Kalibrierdatum, Techniker |
+| 40 | Freigabe ausstehend | — |
+| 50 | Abgeschlossen | **Prüfentscheid**, Kalibrierdatum, Kalibrierscheinnummer |
+| 60 | Storniert | Bemerkung |
+
+Dazu eine Zeitvariable **Durchlaufzeit Kalibrierung**, die von „Geplant" bis
+„Abgeschlossen" misst (Format `d:h:m`).
+
+## Warum der Prüfentscheid erst am Ende Pflicht ist
+
+Das Feld `cal_result` (bestanden / nicht bestanden / mit Einschränkung) ist der
+Kern dieser Vorlage. Es steht **nicht** global auf Pflicht, sondern nur im
+Status „Abgeschlossen":
+
+- Früher im Ablauf gibt es die Angabe schlicht noch nicht. Eine globale Pflicht
+  hieße, beim Anlegen etwas einzutragen, das erst die Messung ergibt — und was
+  einmal eingetragen ist, wird selten korrigiert.
+- Am Ende ist sie unverzichtbar. calServer lässt den Übergang nach
+  „Abgeschlossen" nicht zu, solange das Feld leer ist; ein Kalibrierschein ohne
+  Konformitätsaussage entsteht damit gar nicht erst.
+
+Dasselbe gilt für die Kalibrierscheinnummer: Sie entsteht bei der Ausstellung,
+nicht bei der Auftragsannahme.
+
+**„Nicht bestanden" ist kein Status.** Ein durchgefallenes Gerät durchläuft
+denselben Weg, der Unterschied steht im Prüfentscheid. Ein eigener Status
+dafür würde die Auswertung zerreißen: Der Auftrag wäre je nach Ergebnis in
+einem anderen Zustand, obwohl er in beiden Fällen fertig bearbeitet ist.
+
+## Import
+
+**Administration → Statusverwaltung**, Schaltfläche **Paket** (Berechtigung
+`status_import`). Wiedererkannt wird ein Status über Bereich und Titel; ein
+zweiter Import legt keine Zwillinge an.
+
+Die Feldfunktionen werden in beiden Modi geschrieben — auch dann, wenn es den
+Status schon gibt. Genau deshalb spielt man die Vorlage ein.
+
+**Feldnamen:** Im Paket stehen die lesbaren Namen (`cal_result`,
+`certificate_number`, `technician`). Beim Import legt calServer sie auf die
+Spalte, die die jeweilige Installation verwendet — auf einer Installation mit
+V1-Codes also auf `C2323`, `C2306`, `C2307`. Ein Feld, das es dort nicht gibt,
+wird übersprungen und im Bericht genannt, statt den Import abzubrechen.
+
+## Anpassen
+
+`statuses.json` lässt sich direkt bearbeiten und ohne Archiv hochladen. Nach
+Änderungen am Bundle das Manifest neu schreiben:
+
+```bash
+python3 scripts/build_config_manifest.py --write STATUS-CALIBRATION-DAKKS
+python3 scripts/build_config_manifest.py --check
+```
+
+## Grenzen
+
+- **Keine Folgeaktionen im Paket.** E-Mail-Benachrichtigungen beim
+  Statuswechsel hängen an Mailvorlagen, die je Installation anders heißen; die
+  Vorlage bringt deshalb keine mit. Sie lassen sich nach dem Import in den
+  Statusregeln ergänzen.
+- **Die Freigabestufe ersetzt keine Rechteprüfung.** Dass die technische
+  Prüfung eine zweite Person macht, regelt die Rollenverteilung, nicht der
+  Status.
+- **Einsprachig (deutsch).** Für eine andere Sprache ein eigenes Paket pflegen.

--- a/STATUS-CALIBRATION-DAKKS/manifest.json
+++ b/STATUS-CALIBRATION-DAKKS/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/status-package.schema.json",
+  "format": "calserver.status-package",
+  "format_version": 1,
+  "name": "Status: Kalibrierung für akkreditierte Labore",
+  "document": {
+    "format": "calserver.statuses",
+    "version": 1
+  },
+  "content": {
+    "statuses": 6,
+    "field_rules": 7,
+    "types": [
+      "calibration"
+    ],
+    "transitions": 0,
+    "processing_times": 1
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "statuses.json",
+      "sha256": "ba828e9b81fa2e6635805c97c8c0b0b5d00cfa6a472ae66c38026ea0f73b9788",
+      "size_bytes": 3989
+    },
+    {
+      "path": "README.md",
+      "sha256": "56e45a642ca0f590d5351f4b5694d9fd79be64580bfff48f57c203f0e36f7e33",
+      "size_bytes": 3341
+    }
+  ],
+  "description": "Statusmodell des Kalibrierbereichs mit Prüfentscheid, Kalibrierdatum und Scheinnummer als Pflichtfelder im Status „Abgeschlossen“.",
+  "created_at": "2026-08-15T12:00:00+00:00",
+  "locale": "de"
+}

--- a/STATUS-CALIBRATION-DAKKS/statuses.json
+++ b/STATUS-CALIBRATION-DAKKS/statuses.json
@@ -1,0 +1,153 @@
+{
+  "format": "calserver.statuses",
+  "version": 1,
+  "generator": "calserver-reports",
+  "types": [
+    "calibration"
+  ],
+  "statuses": [
+    {
+      "key": "calibration-geplant",
+      "type": "calibration",
+      "title": "Geplant",
+      "short_title": "GEP",
+      "description": "Auftrag angenommen, Messung steht aus.",
+      "color": "#64748B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-calendar",
+      "sort_order": 10,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "calibration-in-arbeit",
+      "type": "calibration",
+      "title": "In Arbeit",
+      "short_title": "ARB",
+      "description": "Messung läuft.",
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-cog",
+      "sort_order": 20,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "calibration-messung-abgeschlossen",
+      "type": "calibration",
+      "title": "Messung abgeschlossen",
+      "short_title": "MES",
+      "description": "Messwerte erfasst, technische Prüfung steht aus.",
+      "color": "#7C3AED",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check-square",
+      "sort_order": 30,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "calibration_date",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "technician",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "calibration-freigabe",
+      "type": "calibration",
+      "title": "Freigabe ausstehend",
+      "short_title": "FRG",
+      "description": "Technische Prüfung durch eine zweite Person nach ISO/IEC 17025 Abschnitt 7.8.",
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-eye",
+      "sort_order": 40,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "calibration-abgeschlossen",
+      "type": "calibration",
+      "title": "Abgeschlossen",
+      "short_title": "ABG",
+      "description": "Kalibrierschein erstellt und freigegeben.",
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check",
+      "sort_order": 50,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "cal_result",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "calibration_date",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        },
+        {
+          "field": "certificate_number",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 30
+        },
+        {
+          "field": "next_calibration_date",
+          "edit_visible": true,
+          "edit_mandatory": false,
+          "view_visible": true,
+          "display_order": 40
+        }
+      ]
+    },
+    {
+      "key": "calibration-storniert",
+      "type": "calibration",
+      "title": "Storniert",
+      "short_title": "STO",
+      "description": "Auftrag zurückgezogen; kein Kalibrierschein.",
+      "color": "#991B1B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-times",
+      "sort_order": 60,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "notes",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    }
+  ],
+  "transitions": [],
+  "processing_times": [
+    {
+      "variable_name": "Durchlaufzeit Kalibrierung",
+      "table_name": "calibration",
+      "start_key": "calibration-geplant",
+      "stop_key": "calibration-abgeschlossen",
+      "format": "d:h:m"
+    }
+  ]
+}

--- a/STATUS-INVENTORY-DAKKS/README.md
+++ b/STATUS-INVENTORY-DAKKS/README.md
@@ -1,0 +1,73 @@
+# Gerätestatus für Kalibrierlabore
+
+Startvorlage für das Statusmodell des Inventarbereichs: der Lebenszyklus eines
+Messmittels vom Betrieb bis zur Aussonderung, samt der Regel, dass eine
+Sperrung begründet werden muss.
+
+## Die Zustände
+
+| Reihenfolge | Status | Im Umlauf | Pflichtfeld |
+|-------------|--------|-----------|-------------|
+| 10 | In Betrieb | ja | — |
+| 20 | Eingelagert | ja | — |
+| 30 | In Kalibrierung | nein | — |
+| 40 | In Reparatur | nein | — |
+| 50 | Gesperrt | nein | siehe unten |
+| 60 | Ausgesondert | nein, ausgeblendet | siehe unten |
+
+„Im Umlauf" ist keine Beschriftung, sondern Verhalten: calServer bietet Geräte
+in Status mit `active = false` oder `hide = true` im Leihmodul nicht an und
+zählt sie nicht als blockierenden Teil eines Sets. Ein Gerät in Kalibrierung
+oder Reparatur ist damit für die Ausleihe unsichtbar, ohne dass jemand es
+manuell sperren muss.
+
+## Kein Pflichtfeld ab Werk — und warum nicht
+
+Naheliegend wäre, im Status „Gesperrt" eine Begründung zu verlangen: Warum
+stand das Gerät still, ab wann, wer hat entschieden? Genau so ist das
+[Kalibrierstatus-Paket](../STATUS-CALIBRATION-DAKKS/) geschnitten.
+
+Der Inventarbereich führt werksseitig aber **kein freies Bemerkungsfeld** — die
+Werksregistry kennt nur `description`, und das ist die Gerätebezeichnung, nicht
+der Sperrgrund. Eine Feldfunktion auf ein nicht vorhandenes Feld würde beim
+Import stillschweigend übersprungen (mit Warnung im Bericht) und wäre damit
+eine Zusage, die die Vorlage nicht hält.
+
+**So rüstet ein Labor sie nach:** In der Feldverwaltung ein Textfeld für den
+Bereich Inventar anlegen (etwa `blocking_reason`), dann in der
+Statusverwaltung beim Status „Gesperrt" als Zusatzfeld auf Pflicht setzen —
+oder vor dem Import in `statuses.json` eintragen:
+
+```json
+"field_rules": [
+  { "field": "blocking_reason", "edit_visible": true, "edit_mandatory": true, "view_visible": true }
+]
+```
+
+Für die Aussonderung gilt dasselbe, dort zusätzlich mit `hide = true`: Das
+Gerät verschwindet aus den Standardlisten, seine Historie bleibt aber
+vollständig erhalten. Löschen wäre der falsche Weg — an einem ausgesonderten
+Normal hängen Kalibrierungen, die andere Ergebnisse stützen.
+
+## Import
+
+**Administration → Statusverwaltung**, Schaltfläche **Paket** (Berechtigung
+`status_import`). Wiedererkannt wird ein Status über Bereich und Titel.
+
+## Anpassen
+
+```bash
+python3 scripts/build_config_manifest.py --write STATUS-INVENTORY-DAKKS
+python3 scripts/build_config_manifest.py --check
+```
+
+## Grenzen
+
+- **Die Umlaufregel ist eine Setzung.** Wer Geräte auch während der
+  Kalibrierung verleihen will (etwa bei interner Kalibrierung im Haus), setzt
+  `active` für „In Kalibrierung" auf `true`.
+- **Kein automatischer Statuswechsel.** Dass ein Gerät bei nicht bestandener
+  Kalibrierung auf „Gesperrt" geht, ist eine Folgeaktion in den Statusregeln
+  und nicht Teil dieser Vorlage — sie hängt an den Statusnamen der jeweiligen
+  Installation.
+- **Einsprachig (deutsch).**

--- a/STATUS-INVENTORY-DAKKS/manifest.json
+++ b/STATUS-INVENTORY-DAKKS/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/status-package.schema.json",
+  "format": "calserver.status-package",
+  "format_version": 1,
+  "name": "Status: Geräte-Lebenszyklus für Kalibrierlabore",
+  "document": {
+    "format": "calserver.statuses",
+    "version": 1
+  },
+  "content": {
+    "statuses": 6,
+    "field_rules": 0,
+    "types": [
+      "inventory"
+    ],
+    "transitions": 0,
+    "processing_times": 0
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "statuses.json",
+      "sha256": "be458e28ff40023e9b4602daaac40fb97d9d7400100dab2026583c13bd69fca6",
+      "size_bytes": 2390
+    },
+    {
+      "path": "README.md",
+      "sha256": "4f0c56915cf767025e5f782923be80c38ed81673102062ea21f8eee3d1461400",
+      "size_bytes": 3043
+    }
+  ],
+  "description": "Gerätestatus von „In Betrieb“ bis „Ausgesondert“ mit Begründungspflicht bei Sperrung und Aussonderung.",
+  "created_at": "2026-08-15T12:00:00+00:00",
+  "locale": "de"
+}

--- a/STATUS-INVENTORY-DAKKS/statuses.json
+++ b/STATUS-INVENTORY-DAKKS/statuses.json
@@ -1,0 +1,90 @@
+{
+  "format": "calserver.statuses",
+  "version": 1,
+  "generator": "calserver-reports",
+  "types": [
+    "inventory"
+  ],
+  "statuses": [
+    {
+      "key": "inventory-in-betrieb",
+      "type": "inventory",
+      "title": "In Betrieb",
+      "short_title": "BET",
+      "description": "Gerät ist einsatzbereit und kalibriert.",
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check",
+      "sort_order": 10,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "inventory-eingelagert",
+      "type": "inventory",
+      "title": "Eingelagert",
+      "short_title": "LAG",
+      "description": "Reserve; einsatzbereit, aber nicht in Verwendung.",
+      "color": "#64748B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-box",
+      "sort_order": 20,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "inventory-in-kalibrierung",
+      "type": "inventory",
+      "title": "In Kalibrierung",
+      "short_title": "KAL",
+      "description": "Gerät ist zur Kalibrierung außer Haus oder im Labor gebunden.",
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-sync",
+      "sort_order": 30,
+      "active": false,
+      "hide": false
+    },
+    {
+      "key": "inventory-in-reparatur",
+      "type": "inventory",
+      "title": "In Reparatur",
+      "short_title": "REP",
+      "description": "Gerät ist in Instandsetzung.",
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-wrench",
+      "sort_order": 40,
+      "active": false,
+      "hide": false
+    },
+    {
+      "key": "inventory-gesperrt",
+      "type": "inventory",
+      "title": "Gesperrt",
+      "short_title": "SPR",
+      "description": "Nicht verwenden: Kalibrierung nicht bestanden, Schaden oder Verdacht darauf.",
+      "color": "#991B1B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-ban",
+      "sort_order": 50,
+      "active": false,
+      "hide": false
+    },
+    {
+      "key": "inventory-ausgesondert",
+      "type": "inventory",
+      "title": "Ausgesondert",
+      "short_title": "AUS",
+      "description": "Endgültig aus dem Bestand genommen; Historie bleibt erhalten.",
+      "color": "#3F3F46",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-trash",
+      "sort_order": 60,
+      "active": false,
+      "hide": true
+    }
+  ],
+  "transitions": [],
+  "processing_times": []
+}

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -13,7 +13,7 @@
           <p class="page__eyebrow">Immer der aktuelle Build</p>
           <h1>Vorlagen für calServer</h1>
           <p class="page__subhead">
-            Fertige Vorlagenpakete für <a href="https://calserver.com">calServer</a>: Berichte, Sticker und Etiketten, Prüfpläne und Wiki-Vorlagen. Jedes Paket wird im passenden Bereich von calServer importiert und dort weiter angepasst; die Info-Seiten nennen die verfügbaren Parameter. Standard ist calServer V2. Die V1-Vorlagen mit eingebettetem SQL stehen gesammelt in der Kategorie „calServer V1 (Legacy)“.
+            Fertige Vorlagenpakete für <a href="https://calserver.com">calServer</a>: Berichte, Sticker und Etiketten, Prüfpläne, Kategoriebäume, Statusmodelle und Wiki-Vorlagen. Jedes Paket wird im passenden Bereich von calServer importiert und dort weiter angepasst; die Info-Seiten nennen die verfügbaren Parameter. Standard ist calServer V2. Die V1-Vorlagen mit eingebettetem SQL stehen gesammelt in der Kategorie „calServer V1 (Legacy)“.
           </p>
         </div>
         <div class="page__meta" id="page-meta"></div>
@@ -85,6 +85,14 @@
           note: "Prüfplan-Pakete, keine Berichte. Import unter Kalibrierungen → Prüfpläne.",
         },
         {
+          name: "Kategorien",
+          note: "Kategoriebäume samt Feldfunktionen je Kategorie. Import unter Administration → Kategorien.",
+        },
+        {
+          name: "Status",
+          note: "Statusmodelle je Modul: Statusliste, Feldfunktionen, Folgeaktionen. Import unter Administration → Statusverwaltung.",
+        },
+        {
           name: "Wiki-Vorlagen",
           note: "Wiki-Pakete, keine Berichte. Import unter Wiki → Importieren.",
         },
@@ -101,11 +109,15 @@
       const getCategory = (artifactName = "") => {
         const name = artifactName.toLowerCase();
 
-        // Prüfplan- und Wiki-Pakete sind eigene Bundle-Klassen ohne Jasper —
-        // Prüfung VOR allen Report-Regeln, damit kein späterer Teilstring-
-        // Treffer sie einsammelt.
+        // Prüfplan-, Wiki- und Konfigurationspakete sind eigene Bundle-Klassen
+        // ohne Jasper — Prüfung VOR allen Report-Regeln, damit kein späterer
+        // Teilstring-Treffer sie einsammelt. „status-" trifft sonst nichts,
+        // „category-" dagegen sehr wohl (die Sticker-Regel greift auf
+        // „cal-inv"), deshalb stehen beide hier oben.
         if (name.includes("pruefplan")) return "Prüfpläne";
         if (name.startsWith("wiki-")) return "Wiki-Vorlagen";
+        if (name.startsWith("category-")) return "Kategorien";
+        if (name.startsWith("status-")) return "Status";
 
         // Alles Übrige ist ein Report-Bundle. V2 (JSON-Datenquelle, Suffix
         // -json-sample) ist der Standard und wird thematisch einsortiert,

--- a/robots.md
+++ b/robots.md
@@ -240,6 +240,97 @@ in calhelp/calServer-yii.
 
 ---
 
+## 0.5) Konfigurationspakete (`calserver.category-package` / `calserver.status-package`) — MUST
+
+This repo also hosts **configuration packages** for calServer V2: category
+trees and status models. Like the Prüfplan and Wiki bundles they are a
+**separate bundle class**: NO JasperReports involved, none of the report rules
+(sections 0.1, 1, 2, 6) apply. An AI agent should be able to author a valid
+configuration bundle end-to-end from this section alone.
+
+**Why they live here and not in the product:** a category tree and a status
+model are editorial content of a laboratory, not product code. They change when
+a lab's scope or process changes, not when calServer ships a release. calServer
+imports; this repo maintains the content.
+
+### Naming and structure (MUST)
+
+- Folder `CATEGORY-<SLUG>/` or `STATUS-<SLUG>/` (e.g. `CATEGORY-INVENTORY-DAKKS`,
+  `STATUS-CALIBRATION-DAKKS`); ZIP name is the lowercased form. Never use the
+  `-JSON-SAMPLE` suffix — that triggers the report (APEX) packaging rules and
+  the JRXML assertion.
+- Required files at the bundle root, and **nothing else**: `manifest.json`,
+  `README.md`, plus `categories.json` (CATEGORY-*) or `statuses.json`
+  (STATUS-*). NO subfolders, NO images, NO `main_reports/`, NO `*.jrxml`.
+- The format owner is calServer V2
+  (`laravel/app/Services/Category/CategoryPackageService.php` and
+  `laravel/app/Services/Status/StatusPackageService.php` in
+  calhelp/calServer-yii); the machine-readable manifest schemas are
+  `schema/category-package.schema.json` and `schema/status-package.schema.json`
+  (published to Pages).
+
+### Content rules (MUST)
+
+- **Keys are package-internal, uIDs are never written.** A category is
+  recognised on import by (type, parent, name), a status by (type, title).
+  `parent_key`, `from_key`/`to_key` and `start_key`/`stop_key` reference the
+  `key` of another entry **in the same document**; parents MUST appear before
+  their children.
+- **Categories:** `type` is one of `inventory`, `calibration`, `repair`,
+  `booking` (never `types` — that is an assignment discriminator, not a
+  catalogue). Assignments (`category_item`) are NOT part of a package: which
+  device sits in which category is the installation's stock, not a template.
+- **Statuses:** `type` is one of `inventory`, `calibration`, `booking`,
+  `repair`, `location`, `notepad`, `support_tickets`. `active: false` or
+  `hide: true` takes a record out of circulation (the loan module reads that) —
+  use it deliberately, and say so in the README.
+- **Field rules carry the readable field name**, never a V1 metrology code:
+  `{"field": "cal_result", "edit_mandatory": true}`. The importer maps it to
+  whatever column reference the target installation uses. A field the target
+  does not have is **skipped with a warning**, so a rule on a customer-specific
+  field does not break the package — but it also does nothing. Only reference
+  factory fields (`database/data/default_field_definitions.json` in
+  calhelp/calServer-yii) unless the README explains the prerequisite.
+- Statuses that carry no field rules are allowed and useful; a package whose
+  every status is decoration should say in its README why.
+
+### Manifest (MUST)
+
+- NEVER edit `manifest.json` by hand and NEVER invent sha256 values.
+  Regenerate: `python3 scripts/build_config_manifest.py --write <BUNDLE>`,
+  then verify: `python3 scripts/build_config_manifest.py --check`.
+  CI runs `--check` on every push/PR (validate-reports.yml) and fails on any
+  drift: unlisted file, missing file, wrong checksum, disallowed entry,
+  duplicate key, unresolvable `parent_key`, transition pointing at a status the
+  package does not carry.
+- Keep `created_at`, `name`, `description` and `locale` stable across `--write`
+  runs (the script preserves them).
+
+### Packaging & downloads page (MUST)
+
+- `package-reports.yml`: add an `upload-artifact` step for the bundle folder
+  and a `create_config_zip "<BUNDLE>" "<zip-name>" "<document>"` call (NOT
+  `create_zip()` — that stages `main_reports/` and fails without a JRXML).
+- `publish-downloads.yml`: add a `get_last_modified` line plus `README_MAP`
+  and `TITLE_MAP` entries (`Kategorien: <Thema>` / `Status: <Thema>`); no
+  `SCHEMA_MAP`.
+- Category on the downloads page is automatic: a ZIP name starting with
+  `category-` lands in **"Kategorien"**, one starting with `status-` in
+  **"Status"** (`downloads/index.html`, `getCategory()`). Both rules sit above
+  the report rules on purpose — `status-…` would otherwise fall through to the
+  legacy bucket.
+- Downloads-page only: NO `/api/report/<uuid>` upload step, NO
+  `release-reports.yml` entry.
+
+### Verify locally
+
+- `python3 scripts/build_config_manifest.py --check` is green
+- `cd <BUNDLE> && zip -r /tmp/<zip-name>.zip .` produces a ZIP that calServer
+  V2 imports as-is (Administration → Kategorien bzw. Statusverwaltung →
+  Paket; permissions `category_import` / `status_import`)
+
+---
+
 ## 1) Required bundle structure (MUST)
 For every report bundle folder (e.g. DAKKS-SAMPLE, DCC, ORDER-SAMPLE, STICKERS-*):
 - `main_reports/`  → contains the entry-point JRXML(s) users execute

--- a/schema/category-package.schema.json
+++ b/schema/category-package.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calhelp.github.io/calServer-reports/schema/category-package.schema.json",
+  "title": "calServer Kategorie-Paket (calserver.category-package)",
+  "description": "Manifest eines Kategorie-Pakets: ein ZIP mit categories.json (calserver.categories) und optionalem README.md. Das Manifest listet jeden Paket-Eintrag mit SHA-256-Prüfsumme und ist damit der Manipulationsanker des Formats. Ein Paket trägt den Katalog (Baum, Darstellung, Feldfunktionen je Kategorie), nicht die Zuordnungen einzelner Datensätze. Zusätzliche, hier nicht beschriebene Felder sind erlaubt und werden von älteren Lesern ignoriert (Vorwärtskompatibilität); die verbindliche Lese-Semantik gehört calServer V2 (laravel/app/Services/Category/CategoryPackageService.php).",
+  "type": "object",
+  "required": ["format", "format_version", "name", "document", "files"],
+  "properties": {
+    "format": {
+      "const": "calserver.category-package"
+    },
+    "format_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Version des Paketformats. Leser lehnen Versionen oberhalb der eigenen ab, statt unbekannte Inhalte still zu verlieren. Aktuelle Version: 1."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Anzeigename des Pakets. Rein deklarativ: die Kategorien tragen ihre Namen in categories.json."
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Optionale Kurzbeschreibung (ein Absatz)."
+    },
+    "document": {
+      "type": "object",
+      "required": ["format", "version"],
+      "description": "Deklarative Angabe zum eingebetteten categories.json, damit Werkzeuge ohne Öffnen der Datei entscheiden können. Beim Import bleibt der Leser die letzte Instanz.",
+      "properties": {
+        "format": {
+          "const": "calserver.categories"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "description": "Abgeleitete Kennzahlen für die Anzeige (Anzahl Kategorien, enthaltene Typen). Nicht verbindlich — maßgeblich ist categories.json.",
+      "properties": {
+        "categories": { "type": "integer", "minimum": 0 },
+        "field_rules": { "type": "integer", "minimum": 0 },
+        "types": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "created_at": {
+      "type": ["string", "null"],
+      "description": "Zeitpunkt der Paketerstellung (ISO 8601). Provenienz, keine Semantik beim Import."
+    },
+    "generator": {
+      "type": ["string", "null"],
+      "description": "Erzeuger des Pakets, z. B. calserver-reports oder calserver-v2."
+    },
+    "locale": {
+      "type": ["string", "null"],
+      "description": "Sprache der Kategoriebezeichnungen im Paket (z. B. de). Kategorien sind einsprachig; wer eine andere Sprache braucht, pflegt ein eigenes Paket."
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Jeder Eintrag des Archivs mit Prüfsumme. Fehlt eine gelistete Datei, taucht eine ungelistete auf oder weicht eine Prüfsumme ab, wird das Paket abgelehnt.",
+      "items": {
+        "type": "object",
+        "required": ["path", "sha256", "size_bytes"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^(categories\\.json|README\\.md)$",
+            "description": "Pfad relativ zur Paketwurzel. Erlaubt sind nur categories.json und README.md — ein Kategoriepaket trägt keine Binärdateien."
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/status-package.schema.json
+++ b/schema/status-package.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calhelp.github.io/calServer-reports/schema/status-package.schema.json",
+  "title": "calServer Status-Paket (calserver.status-package)",
+  "description": "Manifest eines Status-Pakets: ein ZIP mit statuses.json (calserver.statuses) und optionalem README.md. Das Manifest listet jeden Paket-Eintrag mit SHA-256-Prüfsumme und ist damit der Manipulationsanker des Formats. Ein Paket trägt das Statusmodell eines Moduls (Statusliste, Feldfunktionen je Status, Folgeaktionen, Zeitvariablen), nicht den Status einzelner Datensätze. Zusätzliche, hier nicht beschriebene Felder sind erlaubt und werden von älteren Lesern ignoriert (Vorwärtskompatibilität); die verbindliche Lese-Semantik gehört calServer V2 (laravel/app/Services/Status/StatusPackageService.php).",
+  "type": "object",
+  "required": [
+    "format",
+    "format_version",
+    "name",
+    "document",
+    "files"
+  ],
+  "properties": {
+    "format": {
+      "const": "calserver.status-package"
+    },
+    "format_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Version des Paketformats. Leser lehnen Versionen oberhalb der eigenen ab, statt unbekannte Inhalte still zu verlieren. Aktuelle Version: 1."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Anzeigename des Pakets. Rein deklarativ: die Status tragen ihre Titel in statuses.json."
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optionale Kurzbeschreibung (ein Absatz)."
+    },
+    "document": {
+      "type": "object",
+      "required": [
+        "format",
+        "version"
+      ],
+      "description": "Deklarative Angabe zum eingebetteten statuses.json, damit Werkzeuge ohne Öffnen der Datei entscheiden können. Beim Import bleibt der Leser die letzte Instanz.",
+      "properties": {
+        "format": {
+          "const": "calserver.statuses"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "description": "Abgeleitete Kennzahlen für die Anzeige (Anzahl Status, Feldfunktionen, Folgeaktionen, enthaltene Typen). Nicht verbindlich — maßgeblich ist statuses.json.",
+      "properties": {
+        "statuses": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "field_rules": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "transitions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "processing_times": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "created_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Zeitpunkt der Paketerstellung (ISO 8601). Provenienz, keine Semantik beim Import."
+    },
+    "generator": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Erzeuger des Pakets, z. B. calserver-reports oder calserver-v2."
+    },
+    "locale": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Sprache der Statusbezeichnungen im Paket (z. B. de). Status sind einsprachig; wer eine andere Sprache braucht, pflegt ein eigenes Paket."
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Jeder Eintrag des Archivs mit Prüfsumme. Fehlt eine gelistete Datei, taucht eine ungelistete auf oder weicht eine Prüfsumme ab, wird das Paket abgelehnt.",
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "sha256",
+          "size_bytes"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^(statuses\\.json|README\\.md)$",
+            "description": "Pfad relativ zur Paketwurzel. Erlaubt sind nur statuses.json und README.md — ein Statuspaket trägt keine Binärdateien."
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build_config_manifest.py
+++ b/scripts/build_config_manifest.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Manifest-Werkzeug für Konfigurationspakete.
+
+Deckt beide Klassen ab, weil sie dieselbe Bauart haben — ein JSON-Dokument,
+ein optionales README, kein Binärinhalt:
+
+  calserver.category-package   CATEGORY-*/categories.json
+  calserver.status-package     STATUS-*/statuses.json
+
+Zwei Modi:
+
+  --write BUNDLE_DIR [...]
+      Berechnet die files[]-Liste (sha256 + size_bytes) neu und schreibt das
+      Manifest. `content` wird aus dem Dokument abgeleitet; bestehende Felder
+      (name, description, created_at, generator, locale) bleiben erhalten.
+      sha256-Werte werden NIE von Hand gepflegt — immer über diesen Modus.
+
+  --check [BUNDLE_DIR ...]   (Default; ohne Argumente: alle CATEGORY-*/STATUS-*)
+      Validiert jedes Manifest gegen das zugehörige Schema (Paket `jsonschema`,
+      falls installiert; sonst strukturelle Minimalprüfung), rechnet alle
+      sha256 nach, prüft Vollständigkeit in beide Richtungen (jede Datei
+      gelistet, jeder Listeneintrag vorhanden), die Eintrags-Allowlist und den
+      Kopf des Dokuments. Zusätzlich inhaltlich:
+
+        Kategorien — Schlüssel eindeutig, parent_key existiert und zeigt nicht
+        auf sich selbst, Eltern stehen vor ihren Kindern, Typ bekannt,
+        Feldfunktion nennt ein Feld.
+
+        Status — Schlüssel eindeutig, (Typ, Titel) eindeutig, Typ bekannt,
+        Folgeaktionen und Zeitvariablen verweisen auf Status des Pakets,
+        Feldfunktion nennt ein Feld.
+
+      Exit 1 bei Abweichung.
+
+Die verbindliche Lese-Semantik gehört calServer V2
+(laravel/app/Services/Category/CategoryPackageService.php bzw.
+laravel/app/Services/Status/StatusPackageService.php in calhelp/calServer-yii);
+dieses Skript hält die Bundles dazu kompatibel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SCHEMA_BASE_URL = "https://calhelp.github.io/calServer-reports/schema"
+
+# Bundle-Klassen. `prefix` ist zugleich das Namensmuster der Ordner.
+KINDS = {
+    "category": {
+        "prefix": "CATEGORY-",
+        "package_format": "calserver.category-package",
+        "document_format": "calserver.categories",
+        "document_name": "categories.json",
+        "schema": "category-package.schema.json",
+        "collection": "categories",
+        "types": ("inventory", "calibration", "repair", "booking"),
+    },
+    "status": {
+        "prefix": "STATUS-",
+        "package_format": "calserver.status-package",
+        "document_format": "calserver.statuses",
+        "document_name": "statuses.json",
+        "schema": "status-package.schema.json",
+        "collection": "statuses",
+        "types": (
+            "inventory",
+            "calibration",
+            "booking",
+            "repair",
+            "location",
+            "notepad",
+            "support_tickets",
+        ),
+    },
+}
+
+PACKAGE_VERSION = 1
+MAX_DOCUMENT_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+README_NAME = "README.md"
+
+
+def kind_of(bundle: Path) -> str:
+    """Bundle-Klasse aus dem Ordnernamen. Der Präfix ist die Regel (robots.md)."""
+    name = bundle.name.upper()
+    for kind, spec in KINDS.items():
+        if name.startswith(spec["prefix"]):
+            return kind
+
+    raise SystemExit(
+        f"{bundle.name}: unbekannte Bundle-Klasse. Ordner muss mit "
+        + " oder ".join(spec["prefix"] for spec in KINDS.values())
+        + " beginnen."
+    )
+
+
+def sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"{path}: kein gültiges JSON ({error})")
+
+    if not isinstance(data, dict):
+        raise SystemExit(f"{path}: JSON-Objekt erwartet")
+
+    return data
+
+
+def file_entries(bundle: Path, spec: dict) -> list[dict]:
+    """Die erlaubten Dateien des Bundles mit Prüfsumme, in fester Reihenfolge."""
+    entries = []
+    for name in (spec["document_name"], README_NAME):
+        path = bundle / name
+        if path.is_file():
+            entries.append(
+                {
+                    "path": name,
+                    "sha256": sha256_of(path),
+                    "size_bytes": path.stat().st_size,
+                }
+            )
+
+    return entries
+
+
+def content_summary(document: dict, spec: dict, kind: str) -> dict:
+    items = document.get(spec["collection"], [])
+    items = items if isinstance(items, list) else []
+
+    types: list[str] = []
+    field_rules = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if isinstance(item_type, str) and item_type not in types:
+            types.append(item_type)
+        rules = item.get("field_rules")
+        if isinstance(rules, list):
+            field_rules += len(rules)
+
+    summary: dict = {
+        spec["collection"]: len(items),
+        "field_rules": field_rules,
+        "types": types,
+    }
+
+    if kind == "status":
+        for key in ("transitions", "processing_times"):
+            value = document.get(key)
+            summary[key] = len(value) if isinstance(value, list) else 0
+
+    return summary
+
+
+def write_manifest(bundle: Path) -> None:
+    kind = kind_of(bundle)
+    spec = KINDS[kind]
+
+    document_path = bundle / spec["document_name"]
+    if not document_path.is_file():
+        raise SystemExit(f"{bundle.name}: {spec['document_name']} fehlt")
+
+    document = read_json(document_path)
+    manifest_path = bundle / MANIFEST_NAME
+    existing = read_json(manifest_path) if manifest_path.is_file() else {}
+
+    manifest = {
+        "$schema": f"{SCHEMA_BASE_URL}/{spec['schema']}",
+        "format": spec["package_format"],
+        "format_version": PACKAGE_VERSION,
+        "name": existing.get("name") or bundle.name,
+        "document": {
+            "format": spec["document_format"],
+            "version": document.get("version", 1),
+        },
+        "content": content_summary(document, spec, kind),
+        "generator": existing.get("generator") or "calserver-reports",
+        "files": file_entries(bundle, spec),
+    }
+
+    # Bestehende Provenienz nicht überschreiben: created_at markiert die
+    # Entstehung des Pakets, nicht den letzten Manifestlauf.
+    for key in ("description", "created_at", "locale"):
+        if existing.get(key) is not None:
+            manifest[key] = existing[key]
+
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"{bundle.name}: Manifest geschrieben ({len(manifest['files'])} Dateien)")
+
+
+def validate_schema(manifest: dict, spec: dict, bundle: Path, problems: list[str]) -> None:
+    schema_path = REPO_ROOT / "schema" / spec["schema"]
+    if not schema_path.is_file():
+        problems.append(f"{bundle.name}: Schema fehlt ({schema_path})")
+        return
+
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        # Ohne die Bibliothek bleibt die strukturelle Prüfung unten; die CI
+        # installiert sie (validate-reports.yml).
+        return
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    for error in sorted(validator.iter_errors(manifest), key=lambda e: list(e.path)):
+        location = "/".join(str(part) for part in error.path) or "(Wurzel)"
+        problems.append(f"{bundle.name}: Schemaverstoß bei {location}: {error.message}")
+
+
+def check_categories(document: dict, spec: dict, bundle: Path, problems: list[str]) -> None:
+    categories = document.get("categories")
+    if not isinstance(categories, list) or categories == []:
+        problems.append(f"{bundle.name}: categories fehlt oder ist leer")
+        return
+
+    seen: set[str] = set()
+    for index, category in enumerate(categories, start=1):
+        if not isinstance(category, dict):
+            problems.append(f"{bundle.name}: Eintrag {index} in categories ist kein Objekt")
+            continue
+
+        key = category.get("key")
+        name = category.get("name")
+        if not isinstance(key, str) or key == "":
+            problems.append(f"{bundle.name}: Eintrag {index} hat keinen key")
+            continue
+        if not isinstance(name, str) or name.strip() == "":
+            problems.append(f"{bundle.name}: {key} hat keinen name")
+        if key in seen:
+            problems.append(f"{bundle.name}: key doppelt vergeben: {key}")
+        seen.add(key)
+
+        category_type = category.get("type")
+        if category_type not in spec["types"]:
+            problems.append(f"{bundle.name}: {key} hat unbekannten type {category_type!r}")
+
+        parent = category.get("parent_key")
+        if parent is not None:
+            if parent == key:
+                problems.append(f"{bundle.name}: {key} ist seine eigene Elternkategorie")
+            elif parent not in seen:
+                # Eltern vor Kindern: der Leser löst in einem Durchlauf auf.
+                problems.append(
+                    f"{bundle.name}: {key} verweist auf parent_key {parent!r}, "
+                    "der davor nicht steht"
+                )
+
+        check_field_rules(category.get("field_rules"), f"{bundle.name}: {key}", problems)
+
+
+def check_statuses(document: dict, spec: dict, bundle: Path, problems: list[str]) -> None:
+    statuses = document.get("statuses")
+    if not isinstance(statuses, list) or statuses == []:
+        problems.append(f"{bundle.name}: statuses fehlt oder ist leer")
+        return
+
+    seen: set[str] = set()
+    titles: set[tuple[str, str]] = set()
+
+    for index, status in enumerate(statuses, start=1):
+        if not isinstance(status, dict):
+            problems.append(f"{bundle.name}: Eintrag {index} in statuses ist kein Objekt")
+            continue
+
+        key = status.get("key")
+        title = status.get("title")
+        status_type = status.get("type")
+
+        if not isinstance(key, str) or key == "":
+            problems.append(f"{bundle.name}: Eintrag {index} hat keinen key")
+            continue
+        if key in seen:
+            problems.append(f"{bundle.name}: key doppelt vergeben: {key}")
+        seen.add(key)
+
+        if not isinstance(title, str) or title.strip() == "":
+            problems.append(f"{bundle.name}: {key} hat keinen title")
+        if status_type not in spec["types"]:
+            problems.append(f"{bundle.name}: {key} hat unbekannten type {status_type!r}")
+
+        if isinstance(title, str) and isinstance(status_type, str):
+            # Der Leser erkennt Status über (Typ, Titel) wieder — zweimal
+            # derselbe Titel im selben Typ waere im Ziel eine Kollision.
+            pair = (status_type, title.strip().casefold())
+            if pair in titles:
+                problems.append(f"{bundle.name}: Titel {title!r} doppelt im Typ {status_type}")
+            titles.add(pair)
+
+        check_field_rules(status.get("field_rules"), f"{bundle.name}: {key}", problems)
+
+    for transition in document.get("transitions", []) or []:
+        if not isinstance(transition, dict):
+            problems.append(f"{bundle.name}: Eintrag in transitions ist kein Objekt")
+            continue
+        for side in ("from_key", "to_key"):
+            reference = transition.get(side)
+            if reference not in seen:
+                problems.append(
+                    f"{bundle.name}: Folgeaktion verweist auf unbekannten {side} {reference!r}"
+                )
+        if not isinstance(transition.get("type"), str) or transition.get("type") == "":
+            problems.append(f"{bundle.name}: Folgeaktion ohne type")
+
+    for entry in document.get("processing_times", []) or []:
+        if not isinstance(entry, dict):
+            problems.append(f"{bundle.name}: Eintrag in processing_times ist kein Objekt")
+            continue
+        if not isinstance(entry.get("variable_name"), str) or entry.get("variable_name") == "":
+            problems.append(f"{bundle.name}: Zeitvariable ohne variable_name")
+        references = [entry.get("start_key"), entry.get("stop_key")]
+        if not any(reference in seen for reference in references):
+            problems.append(
+                f"{bundle.name}: Zeitvariable {entry.get('variable_name')!r} verweist auf "
+                "keinen Status des Pakets"
+            )
+
+
+def check_field_rules(rules: object, label: str, problems: list[str]) -> None:
+    if rules is None:
+        return
+
+    if not isinstance(rules, list):
+        problems.append(f"{label}: field_rules ist keine Liste")
+        return
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            problems.append(f"{label}: Feldfunktion ist kein Objekt")
+            continue
+        field = rule.get("field")
+        if not isinstance(field, str) or field.strip() == "":
+            problems.append(f"{label}: Feldfunktion ohne field")
+
+
+def check_bundle(bundle: Path) -> list[str]:
+    problems: list[str] = []
+    kind = kind_of(bundle)
+    spec = KINDS[kind]
+
+    manifest_path = bundle / MANIFEST_NAME
+    document_path = bundle / spec["document_name"]
+
+    if not manifest_path.is_file():
+        return [f"{bundle.name}: {MANIFEST_NAME} fehlt"]
+    if not document_path.is_file():
+        return [f"{bundle.name}: {spec['document_name']} fehlt"]
+
+    manifest = read_json(manifest_path)
+    document = read_json(document_path)
+
+    validate_schema(manifest, spec, bundle, problems)
+
+    if manifest.get("format") != spec["package_format"]:
+        problems.append(
+            f"{bundle.name}: format ist {manifest.get('format')!r}, "
+            f"erwartet {spec['package_format']!r}"
+        )
+
+    version = manifest.get("format_version")
+    if version != PACKAGE_VERSION:
+        problems.append(f"{bundle.name}: format_version ist {version!r}, erwartet {PACKAGE_VERSION}")
+
+    if document.get("format") != spec["document_format"]:
+        problems.append(
+            f"{bundle.name}: {spec['document_name']} hat format {document.get('format')!r}, "
+            f"erwartet {spec['document_format']!r}"
+        )
+
+    document_version = document.get("version")
+    if not isinstance(document_version, int) or document_version > MAX_DOCUMENT_VERSION:
+        problems.append(
+            f"{bundle.name}: Dokumentversion {document_version!r} ist unlesbar "
+            f"(hoechstens {MAX_DOCUMENT_VERSION})"
+        )
+
+    # Dateien: Manifest gegen Platte, in beide Richtungen.
+    listed = {}
+    for entry in manifest.get("files", []):
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            problems.append(f"{bundle.name}: unvollständiger Dateieintrag im Manifest")
+            continue
+        listed[entry["path"]] = entry
+
+    allowed = {spec["document_name"], README_NAME}
+    on_disk = {
+        item.name
+        for item in bundle.iterdir()
+        if item.is_file() and item.name != MANIFEST_NAME
+    }
+
+    for name in sorted(on_disk - allowed):
+        problems.append(
+            f"{bundle.name}: {name} gehört nicht in ein {spec['package_format']} "
+            "(erlaubt sind nur Dokument und README.md)"
+        )
+
+    for name in sorted(item.name for item in bundle.iterdir() if item.is_dir()):
+        problems.append(f"{bundle.name}: Unterordner {name}/ ist in diesem Format nicht erlaubt")
+
+    for name in sorted(on_disk & allowed):
+        if name not in listed:
+            problems.append(f"{bundle.name}: {name} fehlt im Manifest")
+
+    for name, entry in sorted(listed.items()):
+        path = bundle / name
+        if not path.is_file():
+            problems.append(f"{bundle.name}: Manifest listet {name}, die Datei fehlt")
+            continue
+
+        actual = sha256_of(path)
+        if entry.get("sha256") != actual:
+            problems.append(f"{bundle.name}: sha256 weicht ab bei {name}")
+
+        size = path.stat().st_size
+        if entry.get("size_bytes") != size:
+            problems.append(f"{bundle.name}: size_bytes weicht ab bei {name}")
+
+    if kind == "category":
+        check_categories(document, spec, bundle, problems)
+    else:
+        check_statuses(document, spec, bundle, problems)
+
+    return problems
+
+
+def discover_bundles() -> list[Path]:
+    bundles = []
+    for spec in KINDS.values():
+        bundles.extend(sorted(REPO_ROOT.glob(f"{spec['prefix']}*")))
+
+    return [bundle for bundle in bundles if bundle.is_dir()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--write", action="store_true", help="Manifest(e) neu schreiben")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Manifest(e) prüfen (Vorgabe; das Flag gibt es der Deutlichkeit halber)",
+    )
+    parser.add_argument("bundles", nargs="*", help="Bundle-Verzeichnisse (Default: alle)")
+    args = parser.parse_args()
+
+    if args.bundles:
+        bundles = [Path(bundle) if Path(bundle).is_absolute() else REPO_ROOT / bundle for bundle in args.bundles]
+    else:
+        bundles = discover_bundles()
+
+    if not bundles:
+        print("Keine Konfigurationspakete gefunden.")
+        return 0
+
+    if args.write:
+        for bundle in bundles:
+            write_manifest(bundle)
+        return 0
+
+    problems: list[str] = []
+    for bundle in bundles:
+        problems.extend(check_bundle(bundle))
+
+    if problems:
+        print("Manifest-Prüfung fehlgeschlagen:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"{len(bundles)} Konfigurationspaket(e) geprüft: alles konsistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Worum es geht

Zwei weitere Vorlagenkategorien auf der Downloads-Seite: **Kategorien** und **Status**. Beide transportieren, was ein Labor beim Aufsetzen sonst von Hand nachbaut — und was bei einem DAkkS-Labor kein Beiwerk ist, weil im Statusmodell die Regel hängt, dass eine Kalibrierung ohne Prüfentscheid gar nicht erst abgeschlossen werden kann.

Gegenstück im Produkt: [calServer-yii#…](https://github.com/calhelp/calServer-yii/pulls) (Import/Export für beide Module, Formate `calserver.category-package` und `calserver.status-package`). Diese PR kann unabhängig mergen — die Pakete stehen dann auf der Seite, importierbar sind sie ab dem Release, das die Produkt-PR enthält.

## Neue Bundle-Klassen

Gebaut wie Prüfplan- und Wiki-Paket: `manifest.json` mit sha256 je Datei, das Dokument, `README.md`, keine Unterordner.

| Bundle | Inhalt |
|--------|--------|
| `CATEGORY-INVENTORY-DAKKS` | 36 Inventarkategorien: acht Messgrößen mit je Bezugsnormale / Gebrauchsnormale / Prüfmittel, dazu Hilfs- und Betriebsmittel |
| `STATUS-CALIBRATION-DAKKS` | 6 Kalibrierstatus, Prüfentscheid + Kalibrierdatum + Scheinnummer als Pflichtfelder im Status „Abgeschlossen", dazu eine Durchlaufzeit-Variable |
| `STATUS-INVENTORY-DAKKS` | 6 Gerätestatus mit Umlaufregel (Kalibrierung, Reparatur, Sperrung, Aussonderung sind aus dem Umlauf) |

**Warum Messgröße oben und Normalstufe darunter:** Der Akkreditierungsumfang ist genauso gegliedert, damit lassen sich Bestand und Umfang nebeneinanderlegen. Die Pflichtfelder sitzen auf der Normalstufe, nicht global: Ein Bezugsnormal ohne Seriennummer ist nicht rückführbar, ein Hilfsmittel braucht die Angabe nicht.

**Warum der Prüfentscheid erst am Ende Pflicht ist:** Vorher gibt es die Angabe nicht. Eine globale Pflicht hieße, beim Anlegen etwas einzutragen, das erst die Messung ergibt. „Nicht bestanden" ist entsprechend kein eigener Status, sondern der Wert im Prüfentscheid — sonst wäre ein fertig bearbeiteter Auftrag je nach Ergebnis in einem anderen Zustand.

## Infrastruktur

- `schema/category-package.schema.json`, `schema/status-package.schema.json` (werden nach Pages veröffentlicht, die `$schema`-URLs der Manifeste lösen damit auf)
- `scripts/build_config_manifest.py --write/--check` für beide Klassen: sha256-Parität in beide Richtungen, Eintrags-Allowlist plus inhaltliche Prüfung (Schlüssel eindeutig, `parent_key` auflösbar und vor dem Kind, Folgeaktionen und Zeitvariablen zeigen auf Status des Pakets)
- `package-reports.yml` (`create_config_zip`), `publish-downloads.yml` (`get_last_modified`, `README_MAP`, `TITLE_MAP`), `validate-reports.yml` (`--check` bei jedem Push/PR)
- `robots.md` §0.5 als verbindliche Regel für neue Bundles dieser Klasse

## Downloads-Seite

Zwei neue Kategorien mit Einordnungszeile und Importziel. Beide Regeln stehen **über** den Report-Regeln in `getCategory()`: `status-…` fiele sonst durch die `-json-sample`-Prüfung in den Legacy-Block, und `category-inventory-dakks` würde von der Sticker-Regel eingesammelt.

## Validierung

- `build_config_manifest.py --check` grün für alle drei Bundles
- Kategorienzuordnung gegen alle 34 ZIP-Namen des Repos geprüft (Node-Skript gegen die echte `getCategory()` aus der Seite)
- **Alle drei Vorlagen durch den echten Importer von calServer V2 gespielt**: 36 Kategorien, 2×6 Status, 55 Feldfunktionen, **keine Warnung** — und gegengeprüft, dass die importierte Regel den Übergang nach „Abgeschlossen" ohne Prüfentscheid tatsächlich blockiert. Der Lauf hat zwei falsche Feldnamen in meinem ersten Entwurf gefunden (`cal_interval` statt `calibration_interval`; ein Bemerkungsfeld, das der Inventarbereich ab Werk nicht führt).
- Workflows: YAML valide, `yamllint` ohne neue Befunde

## Offen gelassen

Statuspakete für Reparatur und Buchung fehlen noch — dieselbe Bauart, nur anderer Inhalt. Sinnvoll, wenn absehbar ist, welche Zustände dort wirklich gebraucht werden, statt sie zu erfinden.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5uBTWu81WJba6kBy9hS3x)_