### PR TITLE
feat(config-pakete): Statusvorlagen für Reparatur und Aufträge

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -288,6 +288,20 @@ jobs:
           path: STATUS-INVENTORY-DAKKS
           if-no-files-found: error
 
+      - name: Upload STATUS-REPAIR-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STATUS-REPAIR-DAKKS
+          path: STATUS-REPAIR-DAKKS
+          if-no-files-found: error
+
+      - name: Upload STATUS-BOOKING-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STATUS-BOOKING-DAKKS
+          path: STATUS-BOOKING-DAKKS
+          if-no-files-found: error
+
       # Prüfplan-Pakete (calserver.procedure-package, robots.md §0.3):
       # eigene Bundle-Klasse ohne JRXML — der ganze Ordner ist das Paket.
       - name: Upload PRUEFPLAN-FLUKE-23 as artifact
@@ -544,6 +558,8 @@ jobs:
           create_config_zip "CATEGORY-INVENTORY-DAKKS" "category-inventory-dakks" "categories.json"
           create_config_zip "STATUS-CALIBRATION-DAKKS" "status-calibration-dakks" "statuses.json"
           create_config_zip "STATUS-INVENTORY-DAKKS" "status-inventory-dakks" "statuses.json"
+          create_config_zip "STATUS-REPAIR-DAKKS" "status-repair-dakks" "statuses.json"
+          create_config_zip "STATUS-BOOKING-DAKKS" "status-booking-dakks" "statuses.json"
 
           # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL)
           create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"
@@ -591,6 +607,8 @@ jobs:
           unzip -l zip_output/category-inventory-dakks.zip
           unzip -l zip_output/status-calibration-dakks.zip
           unzip -l zip_output/status-inventory-dakks.zip
+          unzip -l zip_output/status-repair-dakks.zip
+          unzip -l zip_output/status-booking-dakks.zip
 
       - name: Send DAKKS-SAMPLE ZIP to API
         env:

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -114,6 +114,8 @@ jobs:
           get_last_modified "CATEGORY-INVENTORY-DAKKS" "category-inventory-dakks"
           get_last_modified "STATUS-CALIBRATION-DAKKS" "status-calibration-dakks"
           get_last_modified "STATUS-INVENTORY-DAKKS" "status-inventory-dakks"
+          get_last_modified "STATUS-REPAIR-DAKKS" "status-repair-dakks"
+          get_last_modified "STATUS-BOOKING-DAKKS" "status-booking-dakks"
           get_last_modified "PRUEFPLAN-FLUKE-23" "pruefplan-fluke-23"
           get_last_modified "PRUEFPLAN-MESSSCHIEBER-150MM" "pruefplan-messschieber-150mm"
           get_last_modified "WIKI-ISO-17025" "wiki-iso-17025"
@@ -226,6 +228,8 @@ jobs:
               "category-inventory-dakks":           "CATEGORY-INVENTORY-DAKKS/README.md",
               "status-calibration-dakks":           "STATUS-CALIBRATION-DAKKS/README.md",
               "status-inventory-dakks":             "STATUS-INVENTORY-DAKKS/README.md",
+              "status-repair-dakks":                "STATUS-REPAIR-DAKKS/README.md",
+              "status-booking-dakks":               "STATUS-BOOKING-DAKKS/README.md",
           }
 
           SCHEMA_MAP = {
@@ -264,6 +268,8 @@ jobs:
               "category-inventory-dakks":           "Kategorien: Inventar für Kalibrierlabore (DAkkS)",
               "status-calibration-dakks":           "Status: Kalibrierung für akkreditierte Labore",
               "status-inventory-dakks":             "Status: Geräte-Lebenszyklus für Kalibrierlabore",
+              "status-repair-dakks":                "Status: Reparatur für Kalibrierlabore",
+              "status-booking-dakks":               "Status: Aufträge für Kalibrierlabore",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ CATEGORY-INVENTORY-DAKKS/
 ├── manifest.json       # sha256 je Datei
 └── README.md
 
-STATUS-CALIBRATION-DAKKS/, STATUS-INVENTORY-DAKKS/
+STATUS-CALIBRATION-DAKKS/, STATUS-INVENTORY-DAKKS/,
+STATUS-REPAIR-DAKKS/, STATUS-BOOKING-DAKKS/
 ├── statuses.json       # Statusmodell samt Feldfunktionen je Status
 ├── manifest.json
 └── README.md

--- a/STATUS-BOOKING-DAKKS/README.md
+++ b/STATUS-BOOKING-DAKKS/README.md
@@ -1,0 +1,64 @@
+# Auftragsstatus für Kalibrierlabore
+
+Startvorlage für das Statusmodell des Auftragsbereichs: vom Angebot bis zur
+Rückgabe der Geräte. Der Auftrag ist die Klammer um alles, was zu einer
+Kundensendung gehört — Kalibrierungen, Reparaturen, Lieferschein und Rechnung.
+
+## Der Ablauf
+
+| Reihenfolge | Status | Pflichtfelder in diesem Status |
+|-------------|--------|-------------------------------|
+| 10 | Angebot | — |
+| 20 | Auftrag bestätigt | Kunde |
+| 30 | In Bearbeitung | — |
+| 40 | Versandbereit | — |
+| 50 | Abgeschlossen | — |
+| 60 | Storniert | Bemerkung (Grund) |
+
+Dazu eine Zeitvariable **Durchlaufzeit Auftrag**, die von „Auftrag bestätigt"
+bis „Abgeschlossen" misst (Format `d:h:m`). Sie misst bewusst nicht ab dem
+Angebot: wie lange ein Kunde überlegt, ist keine Leistung des Labors.
+
+## Zwei Feldfunktionen, zwei verschiedene Zwecke
+
+**Kunde bei „Auftrag bestätigt".** Ein Angebot darf ohne Kunden im System
+entstehen (Anfrage per Telefon, Interessent ohne Stammdatensatz). Sobald daraus
+ein Auftrag wird, muss der Kunde stehen — sonst gibt es später nichts zu
+adressieren und nichts zu berechnen. Die Pflicht sitzt deshalb genau an diesem
+Übergang und nicht global auf dem Feld.
+
+**Bemerkung bei „Storniert".** Das Feld ist in der Werksvorgabe gar nicht in
+der Maske sichtbar. Die Feldfunktion blendet es in diesem einen Status ein und
+macht es zugleich zur Pflicht — genau dafür sind Zusatzfelder da. Ein
+stornierter Auftrag ohne Grund ist im Nachhinein nicht mehr auseinanderzuhalten:
+Kunde abgesprungen, Angebot zu teuer, Gerät doch nicht kalibrierpflichtig, oder
+Doppelerfassung.
+
+## Import
+
+**Administration → Statusverwaltung**, Schaltfläche **Paket** (Berechtigung
+`status_import`). Wiedererkannt wird ein Status über Bereich und Titel; ein
+zweiter Import legt keine Zwillinge an.
+
+## Anpassen
+
+```bash
+python3 scripts/build_config_manifest.py --write STATUS-BOOKING-DAKKS
+python3 scripts/build_config_manifest.py --check
+```
+
+## Grenzen
+
+- **Kein Rechnungsstatus.** „Abgeschlossen" heißt hier: Geräte zurück,
+  Auftrag abgerechnet. Wer den Zahlungseingang im Auftrag führen will, ergänzt
+  einen Status „Berechnet" vor „Abgeschlossen" — das hängt daran, ob die
+  Buchhaltung in calServer oder daneben läuft.
+- **Die Auftragsnummer vergibt calServer.** `number` ist ein Zählerfeld
+  (`StatusCounter`) und wird beim Statuswechsel gezogen, nicht per Feldfunktion
+  gesetzt. Welcher Status den Zähler auslöst, steht in der Statusverwaltung am
+  Status selbst.
+- **Keine automatische Verknüpfung mit Kalibrierungen.** Dass ein Auftrag erst
+  „Versandbereit" wird, wenn alle Positionen fertig sind, prüft niemand
+  automatisch. Das wäre eine Folgeaktion in den Statusregeln und hängt an den
+  Statusnamen der jeweiligen Installation.
+- **Einsprachig (deutsch).**

--- a/STATUS-BOOKING-DAKKS/manifest.json
+++ b/STATUS-BOOKING-DAKKS/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/status-package.schema.json",
+  "format": "calserver.status-package",
+  "format_version": 1,
+  "name": "Status: Aufträge für Kalibrierlabore",
+  "document": {
+    "format": "calserver.statuses",
+    "version": 1
+  },
+  "content": {
+    "statuses": 6,
+    "field_rules": 2,
+    "types": [
+      "booking"
+    ],
+    "transitions": 0,
+    "processing_times": 1
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "statuses.json",
+      "sha256": "bb75d9b8d5169ed5e8e5c908d5b79844928aa8925caf5f4089ceec0361ca8810",
+      "size_bytes": 2972
+    },
+    {
+      "path": "README.md",
+      "sha256": "c5ba2efb814a92908d0a0afe0a463e5e468e61ab6fcd3d869127a500dc8e9a58",
+      "size_bytes": 2843
+    }
+  ],
+  "description": "Statusmodell des Auftragsbereichs vom Angebot bis zum Abschluss; Kunde ab der Auftragsbestätigung und Stornogrund als Pflichtfelder.",
+  "created_at": "2026-08-15T23:30:00+00:00",
+  "locale": "de"
+}

--- a/STATUS-BOOKING-DAKKS/statuses.json
+++ b/STATUS-BOOKING-DAKKS/statuses.json
@@ -1,0 +1,116 @@
+{
+  "format": "calserver.statuses",
+  "version": 1,
+  "generator": "calserver-reports",
+  "types": [
+    "booking"
+  ],
+  "statuses": [
+    {
+      "key": "booking-angebot",
+      "type": "booking",
+      "title": "Angebot",
+      "short_title": "ANG",
+      "description": "Preis genannt, Auftrag noch nicht erteilt.",
+      "color": "#64748B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-file-edit",
+      "sort_order": 10,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "booking-bestaetigt",
+      "type": "booking",
+      "title": "Auftrag bestätigt",
+      "short_title": "BES",
+      "description": "Kunde hat beauftragt; Geräte werden erwartet oder sind da.",
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check-square",
+      "sort_order": 20,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "customer_id",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "booking-in-bearbeitung",
+      "type": "booking",
+      "title": "In Bearbeitung",
+      "short_title": "ARB",
+      "description": "Kalibrierungen und Prüfungen laufen.",
+      "color": "#7C3AED",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-cog",
+      "sort_order": 30,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "booking-versandbereit",
+      "type": "booking",
+      "title": "Versandbereit",
+      "short_title": "VER",
+      "description": "Alle Positionen fertig, Scheine erstellt; Rückversand steht an.",
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-box",
+      "sort_order": 40,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "booking-abgeschlossen",
+      "type": "booking",
+      "title": "Abgeschlossen",
+      "short_title": "ABG",
+      "description": "Geräte zurück beim Kunden, Auftrag abgerechnet.",
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check",
+      "sort_order": 50,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "booking-storniert",
+      "type": "booking",
+      "title": "Storniert",
+      "short_title": "STO",
+      "description": "Auftrag zurückgezogen oder abgelehnt.",
+      "color": "#991B1B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-times",
+      "sort_order": 60,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "comment",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    }
+  ],
+  "transitions": [],
+  "processing_times": [
+    {
+      "variable_name": "Durchlaufzeit Auftrag",
+      "table_name": "booking",
+      "start_key": "booking-bestaetigt",
+      "stop_key": "booking-abgeschlossen",
+      "format": "d:h:m"
+    }
+  ]
+}

--- a/STATUS-REPAIR-DAKKS/README.md
+++ b/STATUS-REPAIR-DAKKS/README.md
@@ -1,0 +1,79 @@
+# Reparaturstatus für Kalibrierlabore
+
+Startvorlage für das Statusmodell des Reparaturbereichs: der Weg eines Geräts
+von der Annahme bis zur Rückgabe, samt der Feldfunktionen, die dafür sorgen,
+dass am Ende dokumentiert ist, was gemacht wurde.
+
+## Der Ablauf
+
+| Reihenfolge | Status | Pflichtfelder in diesem Status |
+|-------------|--------|-------------------------------|
+| 10 | Eingegangen | Fehlerbeschreibung, Inventar |
+| 20 | In Diagnose | — |
+| 30 | Kostenvoranschlag offen | Reparaturaktion (Befund und geplanter Aufwand) |
+| 40 | In Reparatur | — |
+| 50 | Abgeschlossen | Reparaturaktion, Wartungsdatum |
+| 60 | Nicht repariert | Reparaturaktion (Begründung) |
+
+Dazu eine Zeitvariable **Durchlaufzeit Reparatur**, die von „Eingegangen" bis
+„Abgeschlossen" misst (Format `d:h:m`).
+
+## Warum an drei Stellen dasselbe Feld Pflicht ist
+
+`notes` heißt in der Werksvorgabe **Reparaturaktion** und ist das Feld, in dem
+steht, was tatsächlich getan wurde. Es taucht dreimal als Pflichtfeld auf, und
+jedes Mal aus einem anderen Grund:
+
+- **Kostenvoranschlag offen** — hier steht der Befund. Ohne ihn kann niemand
+  entscheiden, ob der Aufwand sich lohnt, und der Kunde bekommt eine Zahl ohne
+  Begründung.
+- **Abgeschlossen** — hier steht die ausgeführte Arbeit. Ein Gerät, das repariert
+  wurde und dessen Reparatur nicht dokumentiert ist, ist für die nächste
+  Kalibrierung ein unbeschriebenes Blatt.
+- **Nicht repariert** — hier steht, warum nicht: nicht reparabel, unwirtschaftlich
+  oder vom Kunden abgelehnt. Diese drei Fälle enden gleich und sind fachlich
+  verschieden; ohne Begründung sieht später jeder Abbruch gleich aus.
+
+Die **Fehlerbeschreibung** (`description`) ist bei der Annahme Pflicht: was der
+Kunde gemeldet hat, wird beim Eingang aufgeschrieben und nicht später aus der
+Erinnerung rekonstruiert.
+
+## Nach der Reparatur kommt die Kalibrierung
+
+Ein instandgesetztes Messmittel ist nicht automatisch wieder gültig kalibriert.
+Der Status „Abgeschlossen" schiebt das Gerät deshalb fachlich zurück in den
+Kalibrierablauf — **erzwungen wird das hier nicht**. Eine Folgeaktion, die beim
+Abschluss automatisch eine Kalibrierung anlegt, hängt an den Statusnamen und
+Vorlagen der jeweiligen Installation und gehört in die Statusregeln, nicht in
+eine Vorlage.
+
+Wer das automatisieren will: Administration → Statusverwaltung → Regeln, dort
+eine Aktion auf den Übergang nach „Abgeschlossen" legen.
+
+## Import
+
+**Administration → Statusverwaltung**, Schaltfläche **Paket** (Berechtigung
+`status_import`). Wiedererkannt wird ein Status über Bereich und Titel; ein
+zweiter Import legt keine Zwillinge an.
+
+**Feldnamen:** Im Paket stehen die lesbaren Namen (`description`, `notes`,
+`repair_date`, `inventory_id`). Beim Import legt calServer sie auf die Spalte,
+die die jeweilige Installation verwendet. Ein Feld, das es dort nicht gibt,
+wird übersprungen und im Bericht genannt, statt den Import abzubrechen.
+
+## Anpassen
+
+```bash
+python3 scripts/build_config_manifest.py --write STATUS-REPAIR-DAKKS
+python3 scripts/build_config_manifest.py --check
+```
+
+## Grenzen
+
+- **Keine Umlaufregel.** Anders als beim [Gerätestatus](../STATUS-INVENTORY-DAKKS/)
+  steht hier kein `active = false`: Reparaturzeilen sind Vorgänge, keine Geräte,
+  und werden vom Leihmodul nicht ausgewertet. Dass ein Gerät während der
+  Reparatur nicht verliehen wird, regelt sein **Gerätestatus**.
+- **Keine Preise.** Ob ein Kostenvoranschlag angenommen wurde, steht im Auftrag
+  ([Auftragsstatus](../STATUS-BOOKING-DAKKS/)), nicht in der Reparaturzeile.
+- **Einsprachig (deutsch).**

--- a/STATUS-REPAIR-DAKKS/manifest.json
+++ b/STATUS-REPAIR-DAKKS/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/status-package.schema.json",
+  "format": "calserver.status-package",
+  "format_version": 1,
+  "name": "Status: Reparatur für Kalibrierlabore",
+  "document": {
+    "format": "calserver.statuses",
+    "version": 1
+  },
+  "content": {
+    "statuses": 6,
+    "field_rules": 6,
+    "types": [
+      "repair"
+    ],
+    "transitions": 0,
+    "processing_times": 1
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "statuses.json",
+      "sha256": "343862f7c7b299ec822ec19e6cd308aef8e9fcbaaffe6f25642467a7fe2a314c",
+      "size_bytes": 3746
+    },
+    {
+      "path": "README.md",
+      "sha256": "34b7549911f844b71359dbedf38ff4df840ebc63a684103bb7ef39028d8b8f87",
+      "size_bytes": 3618
+    }
+  ],
+  "description": "Statusmodell des Reparaturbereichs von der Annahme bis zur Rückgabe; Fehlerbeschreibung beim Eingang und Reparaturaktion beim Abschluss sind Pflichtfelder.",
+  "created_at": "2026-08-15T23:30:00+00:00",
+  "locale": "de"
+}

--- a/STATUS-REPAIR-DAKKS/statuses.json
+++ b/STATUS-REPAIR-DAKKS/statuses.json
@@ -1,0 +1,148 @@
+{
+  "format": "calserver.statuses",
+  "version": 1,
+  "generator": "calserver-reports",
+  "types": [
+    "repair"
+  ],
+  "statuses": [
+    {
+      "key": "repair-eingegangen",
+      "type": "repair",
+      "title": "Eingegangen",
+      "short_title": "EIN",
+      "description": "Gerät ist im Haus, Fehlerbild aufgenommen.",
+      "color": "#64748B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-inbox",
+      "sort_order": 10,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "description",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "inventory_id",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "repair-in-diagnose",
+      "type": "repair",
+      "title": "In Diagnose",
+      "short_title": "DIA",
+      "description": "Fehlersuche läuft; Aufwand noch offen.",
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-search",
+      "sort_order": 20,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "repair-kostenvoranschlag",
+      "type": "repair",
+      "title": "Kostenvoranschlag offen",
+      "short_title": "KVA",
+      "description": "Aufwand ermittelt, Freigabe des Kunden steht aus.",
+      "color": "#B45309",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-clock",
+      "sort_order": 30,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "notes",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    },
+    {
+      "key": "repair-in-reparatur",
+      "type": "repair",
+      "title": "In Reparatur",
+      "short_title": "REP",
+      "description": "Instandsetzung läuft.",
+      "color": "#7C3AED",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-wrench",
+      "sort_order": 40,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "repair-abgeschlossen",
+      "type": "repair",
+      "title": "Abgeschlossen",
+      "short_title": "ABG",
+      "description": "Instandsetzung fertig; Gerät geht zurück in die Kalibrierung.",
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check",
+      "sort_order": 50,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "notes",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        },
+        {
+          "field": "repair_date",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 20
+        }
+      ]
+    },
+    {
+      "key": "repair-nicht-repariert",
+      "type": "repair",
+      "title": "Nicht repariert",
+      "short_title": "NRP",
+      "description": "Nicht reparabel, unwirtschaftlich oder vom Kunden abgelehnt.",
+      "color": "#991B1B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-times",
+      "sort_order": 60,
+      "active": true,
+      "hide": false,
+      "field_rules": [
+        {
+          "field": "notes",
+          "edit_visible": true,
+          "edit_mandatory": true,
+          "view_visible": true,
+          "display_order": 10
+        }
+      ]
+    }
+  ],
+  "transitions": [],
+  "processing_times": [
+    {
+      "variable_name": "Durchlaufzeit Reparatur",
+      "table_name": "repair",
+      "start_key": "repair-eingegangen",
+      "stop_key": "repair-abgeschlossen",
+      "format": "d:h:m"
+    }
+  ]
+}

--- a/robots.md
+++ b/robots.md
@@ -256,9 +256,13 @@ imports; this repo maintains the content.
 ### Naming and structure (MUST)
 
 - Folder `CATEGORY-<SLUG>/` or `STATUS-<SLUG>/` (e.g. `CATEGORY-INVENTORY-DAKKS`,
-  `STATUS-CALIBRATION-DAKKS`); ZIP name is the lowercased form. Never use the
-  `-JSON-SAMPLE` suffix — that triggers the report (APEX) packaging rules and
-  the JRXML assertion.
+  `STATUS-CALIBRATION-DAKKS`, `STATUS-REPAIR-DAKKS`); ZIP name is the lowercased
+  form. Never use the `-JSON-SAMPLE` suffix — that triggers the report (APEX)
+  packaging rules and the JRXML assertion.
+- **One package per module.** A status package carries one `type`; a lab that
+  only wants the calibration statuses must not have to take the order module
+  with it. The four shipped sets (`calibration`, `inventory`, `repair`,
+  `booking`) are the pattern for any further one.
 - Required files at the bundle root, and **nothing else**: `manifest.json`,
   `README.md`, plus `categories.json` (CATEGORY-*) or `statuses.json`
   (STATUS-*). NO subfolders, NO images, NO `main_reports/`, NO `*.jrxml`.


### PR DESCRIPTION
Zwei weitere Startvorlagen der Bundle-Klasse `calserver.status-package`: Reparatur und Aufträge. Damit deckt die Vorlagenseite alle vier Statusbereiche ab, die ein Kalibrierlabor tatsächlich führt (Kalibrierung, Gerät, Reparatur, Auftrag).

## Was drin ist

**`STATUS-REPAIR-DAKKS/`** — sechs Status vom Eingang bis zur Rückgabe:

| Reihenfolge | Status | Pflichtfelder in diesem Status |
|---|---|---|
| 10 | Eingegangen | Fehlerbeschreibung, Inventar |
| 20 | In Diagnose | — |
| 30 | Kostenvoranschlag offen | Reparaturaktion (Befund) |
| 40 | In Reparatur | — |
| 50 | Abgeschlossen | Reparaturaktion, Wartungsdatum |
| 60 | Nicht repariert | Reparaturaktion (Begründung) |

Plus Zeitvariable „Durchlaufzeit Reparatur" (Eingegangen → Abgeschlossen, `d:h:m`).

`notes` (Werksvorgabe: „Reparaturaktion") ist dreimal Pflicht, jedes Mal aus einem anderen Grund: Befund vor dem Kostenvoranschlag, ausgeführte Arbeit beim Abschluss, Begründung beim Abbruch. Ohne die Begründung sehen „nicht reparabel", „unwirtschaftlich" und „vom Kunden abgelehnt" hinterher identisch aus.

**`STATUS-BOOKING-DAKKS/`** — sechs Status vom Angebot bis zur Rückgabe:

| Reihenfolge | Status | Pflichtfelder in diesem Status |
|---|---|---|
| 10 | Angebot | — |
| 20 | Auftrag bestätigt | Kunde |
| 30 | In Bearbeitung | — |
| 40 | Versandbereit | — |
| 50 | Abgeschlossen | — |
| 60 | Storniert | Bemerkung (Grund) |

Plus Zeitvariable „Durchlaufzeit Auftrag", die bewusst erst ab „Auftrag bestätigt" misst — wie lange ein Kunde über ein Angebot nachdenkt, ist keine Leistung des Labors.

Die Feldfunktion bei „Storniert" zeigt, wofür Zusatzfelder da sind: `comment` ist in der Werksvorgabe nicht in der Maske, die Regel blendet es in genau diesem Status ein (`edit_visible = 1`) und macht es zugleich zur Pflicht.

## Warum keine Automatik

Beide READMEs benennen die Grenzen statt sie zu verschweigen: Nach der Reparatur gehört das Gerät fachlich zurück in den Kalibrierablauf, erzwungen wird das hier nicht — eine Folgeaktion hängt an den Statusnamen und Vorlagen der jeweiligen Installation und gehört in die Statusregeln, nicht in eine Vorlage. Gleiches beim Auftrag: „Versandbereit erst wenn alle Positionen fertig sind" prüft niemand automatisch. Die Auftragsnummer zieht `StatusCounter` beim Statuswechsel, nicht eine Feldfunktion.

## Änderungen an der Infrastruktur

- `package-reports.yml`: beide Bundles in `upload-artifact`, `create_config_zip` und die `unzip -l`-Kontrolle aufgenommen
- `publish-downloads.yml`: `get_last_modified`, `README_MAP` und `TITLE_MAP` ergänzt — die Pakete landen damit in der Kategorie „Status" der Vorlagenseite
- `README.md`: Struktur-Block aktualisiert
- `robots.md` §0.5: Regel „ein Paket je Modul" ergänzt, damit die Klasse nicht in Sammelpakete zerfasert

## Verifikation

- `python3 scripts/build_config_manifest.py --check` → „5 Konfigurationspaket(e) geprüft: alles konsistent."
- Beide Vorlagen durch den echten `StatusPackageService` importiert (Wegwerf-Test im calServer-yii-Checkout, danach gelöscht):
  - Reparatur: 6 Status, 6 Feldregeln, 1 Zeitvariable, **null Warnungen**; `MandatoryFieldChecker` verlangt bei „Abgeschlossen" tatsächlich `notes, repair_date`
  - Auftrag: **null Warnungen**, alle sechs Titel vorhanden, ein bereits existierender Status korrekt übersprungen statt dupliziert; „Auftrag bestätigt" verlangt `customer_id`, „Storniert" verlangt `comment`
  - alle vier Statuspakete zusammen importiert: keine Warnungen, zweiter Lauf legt nichts Neues an (Idempotenz über Bereich + Titel)
- Kategorisierungstest der Downloads-Seite erweitert: „Status (4)" listet Kalibrierung, Gerät, Reparatur, Auftrag — „OK: alle Artefakte korrekt einsortiert"

Feldnamen stehen als lesbare Namen im Paket (`description`, `notes`, `repair_date`, `inventory_id`, `customer_id`, `comment`); der Import legt sie auf die Spalte der jeweiligen Installation. Fehlt ein Feld dort, wird es übersprungen und im Bericht genannt, statt den Import abzubrechen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5uBTWu81WJba6kBy9hS3x)_