### PR TITLE
feat(leihschein): Fensterbrief nach DIN 5008 mit Abhakliste statt Quittung

### DIFF
--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -1,14 +1,14 @@
-# LOCATION-JSON-SAMPLE — Standort-/Leihbericht (V2 / APEX)
+# LOCATION-JSON-SAMPLE — Leihschein / Versandschein (V2 / APEX)
 
 Standort-/Leihbericht als **V2-Bundle** im Sinne von
 [ADR-009](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/entwicklung/adr/009-report-data-contract-statt-sql-templates.md):
 gefüllt aus dem Report-Data-Contract `location-report` (JSON) mit lesbaren
 API-Feldnamen statt aus eingebettetem SQL gegen V1-Codespalten.
 
-Sechste Bundle-Familie; das Layout folgt dem V1-Leihschein
-(`httpdocs/reports/locations/Location/main_reports/Location.jrxml`): Kunden- und
-Lieferadresse mit Kontakten, Leihdaten (Leihdatum/-zeit, Rückgabedatum, Status),
-Prüfmittel-Grid und Standortblock (`location_1..5`) mit Signaturzeilen.
+Seit Contract **v1.2** ist der Bericht als **Versanddokument** gesetzt: ein
+Fensterbrief nach DIN 5008 Form B mit der Lieferadresse im Anschriftfeld und
+einer Prüfmittelliste zum Abhaken. Begründung:
+[ADR 2026-08-16](https://github.com/calhelp/calServer-yii/blob/develop/laravel/docs/adr/2026-08-16-der-leihschein-ist-ein-versanddokument.md).
 
 ## Referenz-Bundle für den Systembericht „Leihschein"
 
@@ -27,14 +27,85 @@ Details: [Systemberichte](https://github.com/calhelp/calServer-yii/blob/develop/
 Als Referenz gedacht, nicht als Vorschrift: Ein eigenes Layout wird auf
 derselben Zeile genauso hochgeladen.
 
+## Fensterbrief: die Geometrie
+
+| Element | Lage (ab Blattkante) | Im Titelband (pt) |
+|---------|----------------------|-------------------|
+| Anschriftfeld (Frame) | 20 mm links, 45 mm oben, 85 × 45 mm | `x=40 y=116 w=241 h=128` |
+| Rücksendeangabe | Zusatz-/Vermerkzone, 12 mm ab Feldoberkante | Frame-intern `y=34` |
+| Lieferanschrift | Anschriftzone, 17,7 mm ab Feldoberkante | Frame-intern `y=50` |
+| Betreffzeile | 98,4 mm oben | `y=267` |
+| Falz-/Lochmarken | linker Rand bei 105 / 148,5 / 210 mm | Hintergrundband |
+
+Das passt in einen DIN-lang-Fensterumschlag nach DIN 680 (Fenster 20 mm von
+links, 15 mm von unten) bei Falzung auf 105 mm und 210 mm.
+
+**Form A statt Form B?** Wer einen kurzen Briefkopf hat und das Anschriftfeld
+schon ab 27 mm setzen will, ändert **eine** Zahl: `y="116"` am Frame
+`Anschriftfeld` wird zu `y="64"`. Deshalb steckt der ganze Block in einem Frame.
+
+**Der linke 12-pt-Streifen ist frei.** Dort liegen die Falz- und Lochmarken; der
+Textkörper beginnt bei `x=12` (rund 10 mm ab Blattkante). Wer Elemente ergänzt,
+setzt sie nicht auf `x=0`, sonst läuft die Lochmarke bei 148,5 mm hindurch.
+
 ## Aufbau
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/location-json-sample.jrxml` | Hauptbericht: Kopf mit Kunde-/Lieferadresse + Kontakten, Leihdaten-Block, Prüfmittel-Grid, Standortblock (`location_1..5`), Signaturzeilen (Entleiher/Ausgabe), Seiten-Footer |
-| `subreports/devices.jrxml` | Prüfmittel-Zeilen, gefüllt aus `devices[]` — eine Zeile je Gerät der Leihe |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `location-report` **v1.1**) |
+| `main_reports/location-json-sample.jrxml` | Hauptbericht: Anschriftfeld mit Rücksendeangabe, Informationsblock rechts (Kunden-Nr., Ansprechpartner, Telefon, Versanddatum, Rückgabe, Status, Sendungsnummer), Betreffzeile, Entleiher-Block, Versandhinweis, Prüfvermerk, Standortblock (`location_1..5`), Falzmarken, Seiten-Footer |
+| `subreports/devices.jrxml` | Sendungsinhalt als Abhakliste — je Gerät eine Zeile mit Ankreuzfeld, Positionsnummer und nächster Kalibrierung; Spaltenköpfe wiederholen sich auf Folgeseiten |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `location-report` **v1.2**) |
 | `main_reports/location-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
+
+## Was das Blatt kann
+
+- **Fensterbrief.** Die Lieferadresse steht im Fenster, darüber die
+  Rücksendeangabe. Kein Adressetikett mehr, kein Abtippen.
+- **Abhakliste.** Jede Position trägt ein Ankreuzfeld und eine Nummer, über der
+  Tabelle steht die Positionszahl aus dem Datensatz (nicht die gedruckte
+  Zeilenzahl — weicht beides ab, ist genau das der Befund). Am Ende ein
+  Prüfvermerk „Sendung vollständig und unbeschädigt erhalten" mit Datumslinie.
+- **Keine Unterschriftszeilen.** Das Blatt reist mit der Sendung; niemand
+  quittiert es am Tresen. Wer im eigenen Layout gegenzeichnen lässt, baut sie
+  wieder ein.
+- **Sendungsdaten.** Sendungsverfolgungsnummer im Informationsblock,
+  Versandhinweis (Bemerkung der Buchung) über der Tabelle. Beide fehlen
+  spurlos, wenn sie leer sind.
+
+## Datenanbindung
+
+- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
+- Der Runner füllt den Hauptbericht mit einer `JsonDataSource`
+  (`dataSourceType=json`, `dataJson`); der Bericht ist genau ein Datensatz
+  (Wurzelobjekt).
+- Das **Rückgabedatum** ist seit v1.2 ein eigenes Feld: `location.rental_end`.
+  Bis v1.1 stand es unter `location.custom_fields.rental_end` — dort ist es
+  seit ADR-013 leer, weil die Leihende eine physische Spalte wurde und
+  `custom_fields` nur JSON-Felder trägt. Das Backend spiegelt den Wert
+  zusätzlich unter dem alten Schlüssel, damit v1.1-Vorlagen weiterlaufen.
+- Das **Prüfmittel-Grid** läuft über `subDataSource("devices")` in
+  `subreports/devices.jrxml`. Ein Set (Koffer) wird als **ein** Objekt
+  verliehen und auf **einem** Schein quittiert, also stehen seine Teile mit
+  darauf. `device` bleibt daneben bestehen, damit eine gegen v1.0 geschriebene
+  Vorlage weiterläuft.
+- **Sendungsnummer und Bemerkung** liest das Backend, nicht das Template: Der
+  Block `shipping` kommt gefüllt an, unabhängig davon, unter welchem `api_name`
+  die Installation die beiden Felder führt (Details unten).
+- `location_1..5` und `status` liefern **lesbaren Text**, keine uIDs: Ist ein
+  Standortfeld als `[CURRENT_USER]` konfiguriert, hält die Spalte eine
+  Benutzer-uID — der Bericht bekommt den Namen. Genauso wird der Status-uID zum
+  Status-Titel.
+- Die Lieferadresse (`delivery_customer`) fällt **serverseitig** auf den
+  Kunden zurück, wenn kein eigener Lieferkunde hinterlegt ist — das Template
+  braucht keine Fallback-Logik.
+- Den Datensatz erzeugt das calServer-V2-Backend (`LocationReportDataBuilder`).
+
+Aktivierung in calServer: Bundle auf ein Report-Setting mit grid_name
+`location` und Ordner `locations` hochladen — für den Leihschein ist das der
+Systembericht-Platzhalter (siehe oben). Der Contract wird am Bundle erkannt
+(kein `<queryString>` → `location-report`); eine Report-Variable
+`data_contract` ist nur nötig, wenn davon abgewichen werden soll (Details siehe
+V2-Doku „V2-Berichte mit JSON-Datenquelle").
 
 ## ⚠️ Warum ein leeres/weißes Blatt erscheinen kann
 
@@ -58,49 +129,21 @@ sondern die fehlende Datenanbindung. Abhilfe:
   Variable läuft der klassische JDBC-Pfad, der hier mangels `<queryString>`
   keine Daten hat.
 
-## Datenanbindung
-
-- **Kein** `<queryString>`, **keine** `REPORT_CONNECTION`.
-- Der Runner füllt den Hauptbericht mit einer `JsonDataSource`
-  (`dataSourceType=json`, `dataJson`); der Bericht ist genau ein Datensatz
-  (Wurzelobjekt).
-- Das Rückgabedatum ist ein konfiguriertes Custom Field und wird unter seinem
-  `api_name` gebunden: `location.custom_fields.rental_end`.
-- Das **Prüfmittel-Grid** läuft über `subDataSource("devices")` in
-  `subreports/devices.jrxml`. Ein Set (Koffer) wird als **ein** Objekt
-  verliehen und auf **einem** Schein quittiert, also stehen seine Teile mit
-  darauf. Bis v1.0 band der Hauptbericht eine feste Zeile an `device.*` — der
-  Entleiher unterschrieb für einen Koffer, dessen Inhalt das Papier nicht
-  nannte. `device` bleibt daneben bestehen, damit eine gegen v1.0 geschriebene
-  Vorlage weiterläuft.
-- `location_1..5` und `status` liefern **lesbaren Text**, keine uIDs: Ist ein
-  Standortfeld als `[CURRENT_USER]` konfiguriert, hält die Spalte eine
-  Benutzer-uID — der Bericht bekommt den Namen. Genauso wird der Status-uID zum
-  Status-Titel.
-- Die Lieferadresse (`delivery_customer`) fällt **serverseitig** auf den
-  Kunden zurück, wenn kein eigener Lieferkunde hinterlegt ist — das Template
-  braucht keine Fallback-Logik.
-- Den Datensatz erzeugt das calServer-V2-Backend (`LocationReportDataBuilder`).
-
-Aktivierung in calServer: Bundle auf ein Report-Setting mit grid_name
-`location` und Ordner `locations` hochladen — für den Leihschein ist das der
-Systembericht-Platzhalter (siehe oben). Der Contract wird am Bundle erkannt
-(kein `<queryString>` → `location-report`); eine Report-Variable
-`data_contract` ist nur nötig, wenn davon abgewichen werden soll (Details siehe
-V2-Doku „V2-Berichte mit JSON-Datenquelle").
-
-## Contract `location-report` (v1.1)
+## Contract `location-report` (v1.2)
 
 | Block | Felder |
 |-------|--------|
-| `meta` | `contract`, `schema_version`, `generated_at`, `locale` |
-| `location` | `location_1..5`, `location_date`, `location_time`, `is_active`, `status`, `custom_fields{}` (inkl. `rental_end`, wenn konfiguriert) |
+| `meta` | `contract`, `schema_version`, `generated_at`, `generated_date`, `locale` |
+| `location` | `location_1..5`, `location_date`, `location_time`, **`rental_end`** (v1.2), `is_active`, `status`, `custom_fields{}` |
+| `shipping` | **v1.2** — `tracking_number`, `note`, `item_count` |
 | `device` | `asset_number`, `serial_number`, `description`, `manufacturer`, `model`, `type_code`, `next_calibration_date`, `custom_fields{}` (`{}` wenn kein Gerät verknüpft) |
 | `devices[]` | **v1.1** — alle Geräte der Leihe, Wurzelgerät zuerst; Felder wie `device`. Bei einer Einzelbuchung genau ein Eintrag. |
 | `customer` | `name`, `customer_number`, `street`, `zip`, `city`, `country`, `custom_fields{}` |
 | `customer_contact` | `name`, `street`, `zip`, `city`, `email`, `phone` (`{}` wenn kein Kontakt verknüpft) |
 | `delivery_customer` | wie `customer`; serverseitiger Fallback auf `customer` |
 | `delivery_contact` | wie `customer_contact` |
+
+v1.2 ist **additiv**: Jedes Feld aus v1.0/v1.1 behält Namen und Bedeutung.
 
 > **Status:** Referenz-/Beispielvorlage. JasperReports **6.20.6** bleibt
 > verbindlich (siehe `robots.md`).
@@ -114,8 +157,21 @@ von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
 
 | Parameter | Rolle | Wirkung |
 |-----------|-------|---------|
-| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Standort-/Leihbericht). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+| `Company_sender_line` | variable (global) | Die Rücksendeangabe über der Anschrift. Leer → aus den vier folgenden zusammengesetzt |
+| `Company_name`, `Company_street`, `Company_zip`, `Company_city` | variable (global) | Absenderanschrift. Dieselben `company_*`-Variablen nutzt der Auftragsbeleg |
+| `Company_country` | variable (global) | Absenderland. Steuert zugleich die Landzeile des Empfängers — gedruckt nur bei abweichendem Land |
+| `Show_fold_marks` | variable (type) | `0` schaltet Falz- und Lochmarken ab (vorgedrucktes Briefpapier) |
+| `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite. Leerer Default → keine Änderung am Layout |
 
-Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
-und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)
-bleibt wie gehabt maßgeblich.
+Sind die `company_*`-Variablen nicht gepflegt, bleibt die Rücksendeangabe leer —
+kein Fehler, der Umschlag trägt sie dann selbst.
+
+### Sendungsnummer und Bemerkung aus anderen Feldern
+
+Beide Angaben sind mandantenkonfigurierte Standortfelder. Das Backend adressiert
+sie über ihren **physischen Spaltenschlüssel**, nicht über den `api_name` — so
+bleibt die Vorlage gültig, auch wenn die Installation das Feld umbenannt hat.
+Werksvorgabe sind `L2837` (Sendungsverfolgungsnummer) und `L2826` (Bemerkung).
+Liegen die Daten woanders, zeigen die Berichtsvariablen
+`shipping_tracking_field` bzw. `shipping_note_field` (`report_type = location`)
+auf den anderen Schlüssel. Am Template ändert das nichts.

--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -166,12 +166,20 @@ von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
 Sind die `company_*`-Variablen nicht gepflegt, bleibt die Rücksendeangabe leer —
 kein Fehler, der Umschlag trägt sie dann selbst.
 
-### Sendungsnummer und Bemerkung aus anderen Feldern
+### Sendungsnummer und Bemerkung
 
-Beide Angaben sind mandantenkonfigurierte Standortfelder. Das Backend adressiert
-sie über ihren **physischen Spaltenschlüssel**, nicht über den `api_name` — so
-bleibt die Vorlage gültig, auch wenn die Installation das Feld umbenannt hat.
-Werksvorgabe sind `L2837` (Sendungsverfolgungsnummer) und `L2826` (Bemerkung).
-Liegen die Daten woanders, zeigen die Berichtsvariablen
-`shipping_tracking_field` bzw. `shipping_note_field` (`report_type = location`)
-auf den anderen Schlüssel. Am Template ändert das nichts.
+Beide Angaben sind mandantenkonfigurierte Standortfelder — wie sie heißen,
+entscheidet die Installation. Deshalb rät das Backend nicht, sondern lässt sich
+das Feld nennen:
+
+| Berichtsvariable (`report_type = location`) | Zeigt auf das Feld mit |
+|---------------------------------------------|------------------------|
+| `shipping_tracking_field` | der Sendungsverfolgungsnummer |
+| `shipping_note_field` | der Bemerkung zur Sendung |
+
+Inhalt ist der `api_name` des Feldes aus der Feldverwaltung; der physische
+Spaltenschlüssel geht genauso, die Registry übersetzt ihn. Heißt das Feld
+bereits `tracking_number` bzw. `shipping_note`, findet der Bericht es ohne
+Variable. Ist nichts konfiguriert, bleiben `shipping.tracking_number` und
+`shipping.note` leer, und Sendungsnummer wie Hinweis verschwinden spurlos vom
+Blatt. Am Template ändert das nichts — es sieht nur `shipping.*`.

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
@@ -1,14 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 location/loan report (ADR-009, contract "location-report" v1.0). Filled from
-  a JSON data source — NO SQL. Layout follows the V1 Location.jrxml loan sheet:
-  customer / delivery-customer address blocks with contacts, loan-data block
-  (Leihdatum/-zeit, Rückgabedatum aus location.custom_fields.rental_end, Status),
-  device grid and a location block (location_1..5). The delivery block always
-  carries printable values — the server falls back to the owning customer, so no
-  branching is needed here. All labels are staticText (no report-level $V{} → no
-  null-in-title risk). See main_reports/sample-data.json.
+  V2 location/loan report (ADR-009, contract "location-report" v1.2). Filled from
+  a JSON data source — NO SQL.
+
+  Seit v1.2 ist der Leihschein zugleich das VERSANDDOKUMENT der Sendung: Er ist
+  als Fensterbrief nach DIN 5008 Form B gesetzt, die Lieferadresse steht im
+  Fenster, und die Prüfmittelliste trägt je Zeile ein Ankreuzfeld, damit
+  Packerei und Empfänger die Sendung abhaken können. Unterschriftszeilen gibt es
+  nicht mehr — das Blatt reist mit der Sendung, es wird nicht am Tresen
+  quittiert.
+
+  Geometrie des Anschriftfelds (DIN 676 Form B, DIN-lang-Fensterumschlag nach
+  DIN 680: Fenster 20 mm von links, 15 mm von unten):
+
+    Anschriftfeld   20 mm von links, 45 mm von oben, 85 × 45 mm
+    Zusatz-/Vermerkzone  obere 17,7 mm  (hier: die Rücksendeangabe)
+    Anschriftzone        untere 27,3 mm (hier: die Lieferanschrift)
+    Betreffzeile    98,4 mm von oben
+
+  Umgerechnet (1 mm = 2,8346 pt, Seitenränder links 17 pt / oben 12 pt) liegt das
+  Feld im Titelband bei x=40, y=116, 241 × 128 pt. Es steckt in EINEM Frame:
+  Wer auf Form A umstellen muss (Anschriftfeld ab 27 mm, kurzer Briefkopf),
+  ändert genau eine Zahl — y=116 wird zu y=64.
+
+  Der Absender kommt NICHT aus dem Datensatz, sondern aus den
+  company_*-Berichtsvariablen (dieselben, die der Auftragsbeleg nutzt); ohne
+  gepflegte Variablen bleibt die Rücksendeangabe leer und der Umschlag trägt sie
+  selbst. Alle Beschriftungen sind staticText (kein report-level $V{} → kein
+  null-im-Titel-Risiko). Siehe main_reports/sample-data.json.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="location-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="e8eef700-0500-4e80-af70-000000000500">
 	<property name="com.jaspersoft.studio.data.defadapter" value="location-json-sample_adapter.xml"/>
@@ -17,12 +37,42 @@
 	<style name="Value" fontSize="9"/>
 	<style name="SectionTitle" fontSize="10" isBold="true"/>
 	<style name="Small" fontSize="8"/>
+	<style name="Address" fontSize="10"/>
+	<style name="SenderLine" fontSize="6"/>
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
 	<parameter name="Company_footer" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_sender_line" class="java.lang.String">
+		<parameterDescription><![CDATA[Rücksendeangabe über der Anschrift (die kleine einzeilige Absenderzeile im Fenster). Leer = aus Name/Straße/PLZ/Ort zusammengesetzt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_name" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Firmenname. Fällt in die Rücksendeangabe ein, wenn Company_sender_line leer ist.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_street" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Straße und Hausnummer.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_zip" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Postleitzahl.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_city" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Ort.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_country" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Land. Steuert zugleich, ob die Empfängeranschrift eine Landzeile bekommt — gedruckt wird sie nur bei abweichendem Land.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Show_fold_marks" class="java.lang.String">
+		<parameterDescription><![CDATA[Falz- und Lochmarken am linken Rand drucken (105 mm, 148,5 mm, 210 mm). "0" = aus, z. B. bei vorgedrucktem Briefpapier, das sie schon trägt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<field name="location_1" class="java.lang.String"><fieldDescription><![CDATA[location.location_1]]></fieldDescription></field>
 	<field name="location_2" class="java.lang.String"><fieldDescription><![CDATA[location.location_2]]></fieldDescription></field>
@@ -32,13 +82,15 @@
 	<field name="location_date" class="java.lang.String"><fieldDescription><![CDATA[location.location_date]]></fieldDescription></field>
 	<field name="location_time" class="java.lang.String"><fieldDescription><![CDATA[location.location_time]]></fieldDescription></field>
 	<field name="location_status" class="java.lang.String"><fieldDescription><![CDATA[location.status]]></fieldDescription></field>
-	<field name="rental_end" class="java.lang.String"><fieldDescription><![CDATA[location.custom_fields.rental_end]]></fieldDescription></field>
-	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
-	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[device.serial_number]]></fieldDescription></field>
-	<field name="device_description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
-	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[device.manufacturer]]></fieldDescription></field>
-	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[device.model]]></fieldDescription></field>
-	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription></field>
+	<!--
+	  Rückgabedatum: seit Contract v1.2 ein eigenes Feld. Bis v1.1 stand es unter
+	  location.custom_fields.rental_end — dort ist es seit ADR-013 leer, weil die
+	  Leihende eine echte Spalte wurde und custom_fields nur JSON-Felder trägt.
+	-->
+	<field name="rental_end" class="java.lang.String"><fieldDescription><![CDATA[location.rental_end]]></fieldDescription></field>
+	<field name="tracking_number" class="java.lang.String"><fieldDescription><![CDATA[shipping.tracking_number]]></fieldDescription></field>
+	<field name="shipping_note" class="java.lang.String"><fieldDescription><![CDATA[shipping.note]]></fieldDescription></field>
+	<field name="item_count" class="java.lang.Integer"><fieldDescription><![CDATA[shipping.item_count]]></fieldDescription></field>
 	<field name="customer_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
 	<field name="customer_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
 	<field name="customer_street" class="java.lang.String"><fieldDescription><![CDATA[customer.street]]></fieldDescription></field>
@@ -51,108 +103,231 @@
 	<field name="delivery_street" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.street]]></fieldDescription></field>
 	<field name="delivery_zip" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.zip]]></fieldDescription></field>
 	<field name="delivery_city" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.city]]></fieldDescription></field>
+	<field name="delivery_country" class="java.lang.String"><fieldDescription><![CDATA[delivery_customer.country]]></fieldDescription></field>
 	<field name="delivery_contact_name" class="java.lang.String"><fieldDescription><![CDATA[delivery_contact.name]]></fieldDescription></field>
 	<field name="delivery_contact_email" class="java.lang.String"><fieldDescription><![CDATA[delivery_contact.email]]></fieldDescription></field>
 	<field name="delivery_contact_phone" class="java.lang.String"><fieldDescription><![CDATA[delivery_contact.phone]]></fieldDescription></field>
+	<!--
+	  Falz- und Lochmarken. Sie gehören auf JEDE Seite (gefalzt wird der ganze
+	  Stapel), deshalb ins Hintergrundband. Die Marken sitzen am linken Rand bei
+	  105 mm / 148,5 mm / 210 mm ab Seitenoberkante; die Lochmarke ist länger.
+	-->
+	<background>
+		<band height="818">
+			<line>
+				<reportElement x="0" y="286" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="409" width="14" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="583" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+		</band>
+	</background>
 	<title>
-		<band height="240">
+		<band height="364">
+			<!--
+			  Anschriftfeld (DIN 676 Form B). Der Frame IST das Feld: 85 × 45 mm
+			  an 20/45 mm. Innen liegt die Rücksendeangabe in der Zusatz- und
+			  Vermerkzone (12 mm ab Feldoberkante) und die Anschrift am Beginn
+			  der Anschriftzone (17,7 mm = 50 pt ab Feldoberkante).
+			-->
+			<frame>
+				<reportElement x="40" y="116" width="241" height="128"/>
+				<textField isBlankWhenNull="true">
+					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
+					<textFieldExpression><![CDATA[($P{Company_sender_line} != null && !$P{Company_sender_line}.trim().isEmpty())
+	? $P{Company_sender_line}
+	: (
+		($P{Company_name} == null ? "" : $P{Company_name})
+		+ (($P{Company_street} == null || $P{Company_street}.trim().isEmpty()) ? "" : " · " + $P{Company_street})
+		+ ((($P{Company_zip} == null || $P{Company_zip}.trim().isEmpty()) && ($P{Company_city} == null || $P{Company_city}.trim().isEmpty()))
+			? ""
+			: " · " + ($P{Company_zip} == null ? "" : $P{Company_zip}) + " " + ($P{Company_city} == null ? "" : $P{Company_city}))
+	).trim()]]></textFieldExpression>
+				</textField>
+				<!--
+				  Die Anschrift ist EIN Textfeld mit \n-Zeilen, kein Stapel
+				  Einzelfelder: Fehlt der Ansprechpartner, rückt die Straße auf,
+				  statt eine Lücke im Fenster zu lassen. Keine Leerzeile vor dem
+				  Ort — die kannte DIN 5008 bis 1996, seit der Fassung 2020 ist
+				  die Anschrift durchgehend. Die Landzeile druckt nur bei
+				  abweichendem Land (Company_country); "DE" unter einer deutschen
+				  Inlandsanschrift wäre schlicht falsch.
+				-->
+				<textField isBlankWhenNull="true">
+					<reportElement style="Address" x="0" y="50" width="241" height="78"/>
+					<textElement><paragraph lineSpacing="Fixed" lineSpacingSize="12.5"/></textElement>
+					<textFieldExpression><![CDATA[(($F{delivery_name} == null || $F{delivery_name}.trim().isEmpty()) ? "" : $F{delivery_name} + "\n")
++ (($F{delivery_contact_name} == null || $F{delivery_contact_name}.trim().isEmpty()) ? "" : $F{delivery_contact_name} + "\n")
++ (($F{delivery_street} == null || $F{delivery_street}.trim().isEmpty()) ? "" : $F{delivery_street} + "\n")
++ (($F{delivery_zip} == null ? "" : $F{delivery_zip}) + " " + ($F{delivery_city} == null ? "" : $F{delivery_city})).trim()
++ (($F{delivery_country} == null || $F{delivery_country}.trim().isEmpty()
+		|| ($P{Company_country} != null && $F{delivery_country}.trim().equalsIgnoreCase($P{Company_country}.trim())))
+	? ""
+	: "\n" + $F{delivery_country})]]></textFieldExpression>
+				</textField>
+			</frame>
+			<!--
+			  Informationsblock rechts (DIN 5008: ab 125 mm, also außerhalb des
+			  Fensters, das bei 105 mm endet). Er trägt, was der Empfänger beim
+			  Auspacken braucht: wen er anruft, bis wann er zurückschicken muss
+			  und unter welcher Nummer die Sendung läuft.
+			-->
+			<frame>
+				<reportElement x="337" y="116" width="224" height="91"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{customer_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Ansprechpartner]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{delivery_contact_name} != null && !$F{delivery_contact_name}.trim().isEmpty()) ? $F{delivery_contact_name} : $F{contact_name}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12"/><text><![CDATA[Telefon]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="26" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{delivery_contact_phone} != null && !$F{delivery_contact_phone}.trim().isEmpty()) ? $F{delivery_contact_phone} : $F{contact_phone}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="39" width="104" height="12"/><text><![CDATA[Versanddatum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="39" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{location_date} == null ? "" : $F{location_date}) + (($F{location_time} == null || $F{location_time}.isEmpty()) ? "" : " " + $F{location_time})]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="52" width="104" height="12"/><text><![CDATA[Rückgabe bis]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="52" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rental_end}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="65" width="104" height="12"/><text><![CDATA[Verleih-Status]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="65" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{location_status}]]></textFieldExpression></textField>
+				<staticText>
+					<reportElement style="Label" x="0" y="78" width="104" height="12">
+						<printWhenExpression><![CDATA[$F{tracking_number} != null && !$F{tracking_number}.trim().isEmpty()]]></printWhenExpression>
+					</reportElement>
+					<text><![CDATA[Sendungsnummer]]></text>
+				</staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="78" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tracking_number}]]></textFieldExpression></textField>
+			</frame>
+			<!-- Betreffzeile (DIN 5008: 98,4 mm ab Seitenoberkante) -->
+			<staticText>
+				<reportElement x="12" y="267" width="549" height="18"/>
+				<textElement><font size="13" isBold="true"/></textElement>
+				<text><![CDATA[Leihschein / Versandschein]]></text>
+			</staticText>
+			<staticText><reportElement style="SectionTitle" x="12" y="296" width="270" height="14"/><text><![CDATA[Entleiher]]></text></staticText>
 			<textField>
-				<reportElement x="0" y="0" width="561" height="22"/>
-				<textElement textAlignment="Center"><font size="15" isBold="true"/></textElement>
-				<textFieldExpression><![CDATA["Standort- / Leihbericht"]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="0" y="24" width="561" height="14"/>
-				<textElement textAlignment="Center"><font size="10"/></textElement>
-				<textFieldExpression><![CDATA[($F{asset_number} == null ? "" : $F{asset_number}) + "  ·  " + ($F{device_description} == null ? "" : $F{device_description})]]></textFieldExpression>
-			</textField>
-			<line><reportElement x="0" y="44" width="561" height="1"/></line>
-			<staticText><reportElement style="SectionTitle" x="0" y="52" width="270" height="14"/><text><![CDATA[Kunde]]></text></staticText>
-			<textField>
-				<reportElement style="Value" x="0" y="70" width="270" height="13"/>
+				<reportElement style="Value" x="12" y="312" width="270" height="13"/>
 				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{customer_number} == null || $F{customer_number}.isEmpty()) ? "" : ("  (" + $F{customer_number} + ")"))]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="0" y="84" width="270" height="13"/><textFieldExpression><![CDATA[$F{customer_street}]]></textFieldExpression></textField>
-			<textField>
-				<reportElement style="Value" x="0" y="98" width="270" height="13"/>
-				<textFieldExpression><![CDATA[($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})]]></textFieldExpression>
+			<textField isBlankWhenNull="true">
+				<reportElement style="Small" x="12" y="325" width="270" height="12"/>
+				<textFieldExpression><![CDATA[(($F{customer_street} == null ? "" : $F{customer_street} + ", ")
+	+ ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})).trim()]]></textFieldExpression>
 			</textField>
-			<staticText><reportElement style="Label" x="0" y="116" width="60" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="60" y="116" width="210" height="12"/><textFieldExpression><![CDATA[$F{contact_name}]]></textFieldExpression></textField>
-			<textField>
-				<reportElement style="Small" x="60" y="129" width="210" height="12"/>
-				<textFieldExpression><![CDATA[($F{contact_email} == null ? "" : $F{contact_email}) + (($F{contact_phone} == null || $F{contact_phone}.isEmpty()) ? "" : ("  ·  " + $F{contact_phone}))]]></textFieldExpression>
+			<textField isBlankWhenNull="true">
+				<reportElement style="Small" x="12" y="337" width="270" height="12"/>
+				<textFieldExpression><![CDATA[(($F{contact_name} == null ? "" : $F{contact_name})
+	+ (($F{contact_email} == null || $F{contact_email}.isEmpty()) ? "" : "  ·  " + $F{contact_email})
+	+ (($F{contact_phone} == null || $F{contact_phone}.isEmpty()) ? "" : "  ·  " + $F{contact_phone})).trim()]]></textFieldExpression>
 			</textField>
-			<staticText><reportElement style="SectionTitle" x="291" y="52" width="270" height="14"/><text><![CDATA[Lieferadresse]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="291" y="70" width="270" height="13"/><textFieldExpression><![CDATA[$F{delivery_name}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="291" y="84" width="270" height="13"/><textFieldExpression><![CDATA[$F{delivery_street}]]></textFieldExpression></textField>
-			<textField>
-				<reportElement style="Value" x="291" y="98" width="270" height="13"/>
-				<textFieldExpression><![CDATA[($F{delivery_zip} == null ? "" : $F{delivery_zip}) + " " + ($F{delivery_city} == null ? "" : $F{delivery_city})]]></textFieldExpression>
+			<!--
+			  Die Lieferadresse steht schon im Fenster — hier wiederholt sie
+			  niemand. Was das Anschriftfeld nicht trägt, weil dort nur die
+			  Postanschrift hingehört, steht daneben: die E-Mail des
+			  Lieferkontakts, damit die Rückfrage zur Sendung nicht am Papier
+			  scheitert (Telefon und Name führt der Informationsblock oben).
+			-->
+			<staticText>
+				<reportElement style="SectionTitle" x="291" y="296" width="270" height="14">
+					<printWhenExpression><![CDATA[$F{delivery_contact_email} != null && !$F{delivery_contact_email}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Rückfragen zur Sendung]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement style="Value" x="291" y="312" width="270" height="13"/>
+				<textFieldExpression><![CDATA[$F{delivery_contact_email}]]></textFieldExpression>
 			</textField>
-			<staticText><reportElement style="Label" x="291" y="116" width="60" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="351" y="116" width="210" height="12"/><textFieldExpression><![CDATA[$F{delivery_contact_name}]]></textFieldExpression></textField>
-			<textField>
-				<reportElement style="Small" x="351" y="129" width="210" height="12"/>
-				<textFieldExpression><![CDATA[($F{delivery_contact_email} == null ? "" : $F{delivery_contact_email}) + (($F{delivery_contact_phone} == null || $F{delivery_contact_phone}.isEmpty()) ? "" : ("  ·  " + $F{delivery_contact_phone}))]]></textFieldExpression>
-			</textField>
-			<line><reportElement x="0" y="150" width="561" height="1"/></line>
-			<staticText><reportElement style="SectionTitle" x="0" y="158" width="561" height="14"/><text><![CDATA[Leihdaten]]></text></staticText>
-			<staticText><reportElement style="Label" x="0" y="176" width="130" height="13"/><text><![CDATA[Leihdatum / -zeit]]></text></staticText>
-			<textField>
-				<reportElement style="Value" x="130" y="176" width="150" height="13"/>
-				<textFieldExpression><![CDATA[($F{location_date} == null ? "" : $F{location_date}) + (($F{location_time} == null || $F{location_time}.isEmpty()) ? "" : (" " + $F{location_time}))]]></textFieldExpression>
-			</textField>
-			<staticText><reportElement style="Label" x="290" y="176" width="120" height="13"/><text><![CDATA[Rückgabedatum]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="176" width="151" height="13"/><textFieldExpression><![CDATA[$F{rental_end}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="0" y="192" width="130" height="13"/><text><![CDATA[Verleih-Status]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="192" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_status}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="290" y="192" width="120" height="13"/><text><![CDATA[Nächste Kalibrierung]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="192" width="151" height="13"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
 		</band>
 	</title>
 	<detail>
-		<band height="230">
-			<staticText><reportElement style="SectionTitle" x="0" y="0" width="561" height="14"/><text><![CDATA[Prüfmittel]]></text></staticText>
-			<staticText><reportElement style="Label" x="0" y="18" width="100" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
-			<staticText><reportElement style="Label" x="100" y="18" width="110" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
-			<staticText><reportElement style="Label" x="210" y="18" width="150" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
-			<staticText><reportElement style="Label" x="360" y="18" width="201" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
-			<line><reportElement x="0" y="32" width="561" height="1"/></line>
-			<!-- Eine Zeile je Gerät der Leihe (Contract v1.1, devices[]): ein
-			     Set wird als ein Objekt verliehen und auf einem Schein
-			     quittiert, also gehören seine Teile auf das Papier. Das
-			     Wurzelgerät steht zuerst; bei einer Einzelbuchung bleibt es
-			     bei dieser einen Zeile. -->
+		<band height="210">
+			<!--
+			  Versandhinweis (Bemerkung der Buchung). Kollabiert vollständig, wenn
+			  keiner gepflegt ist — alles darunter schwimmt (positionType Float).
+			-->
+			<frame>
+				<reportElement x="12" y="0" width="549" height="30" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{shipping_note} != null && !$F{shipping_note}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<staticText><reportElement style="Label" x="0" y="0" width="549" height="12"/><text><![CDATA[Hinweis zur Sendung]]></text></staticText>
+				<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="13" width="549" height="13"/><textFieldExpression><![CDATA[$F{shipping_note}]]></textFieldExpression></textField>
+			</frame>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="12" y="36" width="300" height="14"/><text><![CDATA[Sendungsinhalt]]></text></staticText>
+			<textField>
+				<reportElement style="Small" positionType="Float" x="300" y="37" width="261" height="13"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[($F{item_count} == null ? "" : ($F{item_count} + ($F{item_count}.intValue() == 1 ? " Position" : " Positionen")))]]></textFieldExpression>
+			</textField>
+			<!--
+			  Eine Zeile je Gerät der Leihe (Contract v1.1, devices[]): ein Set
+			  wird als ein Objekt verliehen und auf einem Schein quittiert, also
+			  gehören seine Teile auf das Papier. Das Wurzelgerät steht zuerst;
+			  bei einer Einzelbuchung bleibt es bei dieser einen Zeile.
+
+			  Die Spaltenköpfe liegen im Subreport (columnHeader), nicht hier: Ein
+			  Koffer mit 17 Teilen läuft über den Seitenumbruch, und eine
+			  Ankreuzliste ohne Kopf auf Seite 2 ist nicht abhakbar.
+			-->
 			<subreport>
-				<reportElement positionType="Float" x="0" y="36" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="12" y="54" width="549" height="14" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("devices")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/devices.jasper"]]></subreportExpression>
 			</subreport>
-			<staticText><reportElement style="SectionTitle" positionType="Float" x="0" y="62" width="561" height="14"/><text><![CDATA[Standort]]></text></staticText>
-			<staticText><reportElement style="Label" positionType="Float" x="0" y="80" width="130" height="13"/><text><![CDATA[Standort 1]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="80" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_1}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" positionType="Float" x="290" y="80" width="120" height="13"/><text><![CDATA[Standort 4]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="410" y="80" width="151" height="13"/><textFieldExpression><![CDATA[$F{location_4}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" positionType="Float" x="0" y="96" width="130" height="13"/><text><![CDATA[Standort 2]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="96" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_2}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" positionType="Float" x="290" y="96" width="120" height="13"/><text><![CDATA[Standort 5]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="410" y="96" width="151" height="13"/><textFieldExpression><![CDATA[$F{location_5}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" positionType="Float" x="0" y="112" width="130" height="13"/><text><![CDATA[Standort 3]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="130" y="112" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_3}]]></textFieldExpression></textField>
-			<line><reportElement positionType="Float" x="0" y="180" width="220" height="1"/></line>
-			<staticText><reportElement positionType="Float" x="0" y="182" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift Entleiher]]></text></staticText>
-			<line><reportElement positionType="Float" x="341" y="180" width="220" height="1"/></line>
-			<staticText><reportElement positionType="Float" x="341" y="182" width="220" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift Ausgabe]]></text></staticText>
+			<!--
+			  Prüfvermerk statt Unterschrift: Das Blatt reist mit der Sendung und
+			  wird nicht am Tresen quittiert — abgehakt wird es trotzdem, beim
+			  Packen wie beim Auspacken.
+			-->
+			<line><reportElement positionType="Float" x="12" y="80" width="549" height="1"/></line>
+			<rectangle>
+				<reportElement positionType="Float" x="12" y="88" width="9" height="9"/>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</rectangle>
+			<staticText><reportElement style="Small" positionType="Float" x="26" y="87" width="280" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="341" y="87" width="40" height="12"/><text><![CDATA[Datum]]></text></staticText>
+			<line><reportElement positionType="Float" x="381" y="98" width="180" height="1"/></line>
+			<!--
+			  Standortangaben der Leihe. Rein interne Felder — der Block
+			  verschwindet, wenn keines gepflegt ist, statt einen Kasten aus
+			  Beschriftungen ohne Werte auf ein Kundendokument zu setzen.
+			-->
+			<frame>
+				<reportElement positionType="Float" x="12" y="112" width="549" height="66" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[($F{location_1} != null && !$F{location_1}.trim().isEmpty())
+	|| ($F{location_2} != null && !$F{location_2}.trim().isEmpty())
+	|| ($F{location_3} != null && !$F{location_3}.trim().isEmpty())
+	|| ($F{location_4} != null && !$F{location_4}.trim().isEmpty())
+	|| ($F{location_5} != null && !$F{location_5}.trim().isEmpty())]]></printWhenExpression>
+				</reportElement>
+				<staticText><reportElement style="SectionTitle" x="0" y="0" width="549" height="14"/><text><![CDATA[Standort]]></text></staticText>
+				<staticText><reportElement style="Label" x="0" y="18" width="130" height="13"/><text><![CDATA[Standort 1]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="18" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_1}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="290" y="18" width="120" height="13"/><text><![CDATA[Standort 4]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="18" width="139" height="13"/><textFieldExpression><![CDATA[$F{location_4}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="34" width="130" height="13"/><text><![CDATA[Standort 2]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="34" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_2}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="290" y="34" width="120" height="13"/><text><![CDATA[Standort 5]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="34" width="139" height="13"/><textFieldExpression><![CDATA[$F{location_5}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="50" width="130" height="13"/><text><![CDATA[Standort 3]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="50" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_3}]]></textFieldExpression></textField>
+			</frame>
 		</band>
 	</detail>
 	<pageFooter>
 		<band height="36">
-			<line><reportElement x="0" y="0" width="561" height="1"/></line>
-			<staticText><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Standort- / Leihbericht · calServer V2]]></text></staticText>
+			<line><reportElement x="12" y="0" width="549" height="1"/></line>
+			<staticText><reportElement x="12" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Leihschein / Versandschein · calServer V2]]></text></staticText>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
-			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="0" y="18" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="12" y="18" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/LOCATION-JSON-SAMPLE/main_reports/sample-data.json
+++ b/LOCATION-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,8 +1,9 @@
 {
   "meta": {
     "contract": "location-report",
-    "schema_version": "1.1",
+    "schema_version": "1.2",
     "generated_at": "2026-07-16T10:00:00+00:00",
+    "generated_date": "2026-07-16",
     "locale": "de-DE"
   },
   "location": {
@@ -13,11 +14,17 @@
     "location_5": "L-42",
     "location_date": "2026-07-01",
     "location_time": "08:00:00",
+    "rental_end": "2026-09-30",
     "is_active": 1,
     "status": "verliehen",
     "custom_fields": {
       "rental_end": "2026-09-30"
     }
+  },
+  "shipping": {
+    "tracking_number": "00340434161094022838",
+    "note": "Bitte den Koffer vollständig und im Originaltransportbehälter zurücksenden.",
+    "item_count": 4
   },
   "device": {
     "asset_number": "INV-9001",

--- a/LOCATION-JSON-SAMPLE/parameters.json
+++ b/LOCATION-JSON-SAMPLE/parameters.json
@@ -3,20 +3,148 @@
   "version": 1,
   "parameters": [
     {
+      "name": "Company_sender_line",
+      "label": {
+        "de": "Rücksendeangabe",
+        "en": "Return address line"
+      },
+      "description": {
+        "de": "Die kleine einzeilige Absenderangabe über der Empfängeranschrift im Briefumschlagfenster. Leer lassen, um sie aus Firmenname, Straße, PLZ und Ort zusammensetzen zu lassen.",
+        "en": "The small one-line sender note printed above the recipient address in the envelope window. Leave empty to have it composed from company name, street, postcode and city."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 1,
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt"
+    },
+    {
+      "name": "Company_name",
+      "label": {
+        "de": "Absender: Firmenname",
+        "en": "Sender: company name"
+      },
+      "description": {
+        "de": "Firmenname des Absenders. Wird für die Rücksendeangabe verwendet, wenn keine eigene Rücksendeangabe gepflegt ist. Dieselbe Variable nutzt auch der Auftragsbeleg.",
+        "en": "Sender company name. Used for the return address line when no explicit one is configured. The order document uses the same variable."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 2,
+      "example": "Musterfirma GmbH"
+    },
+    {
+      "name": "Company_street",
+      "label": {
+        "de": "Absender: Straße",
+        "en": "Sender: street"
+      },
+      "description": {
+        "de": "Straße und Hausnummer des Absenders, für die Rücksendeangabe.",
+        "en": "Sender street and number, used for the return address line."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 3,
+      "example": "Musterstraße 1"
+    },
+    {
+      "name": "Company_zip",
+      "label": {
+        "de": "Absender: PLZ",
+        "en": "Sender: postcode"
+      },
+      "description": {
+        "de": "Postleitzahl des Absenders, für die Rücksendeangabe.",
+        "en": "Sender postcode, used for the return address line."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 4,
+      "example": "12345"
+    },
+    {
+      "name": "Company_city",
+      "label": {
+        "de": "Absender: Ort",
+        "en": "Sender: city"
+      },
+      "description": {
+        "de": "Ort des Absenders, für die Rücksendeangabe.",
+        "en": "Sender city, used for the return address line."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 5,
+      "example": "Musterstadt"
+    },
+    {
+      "name": "Company_country",
+      "label": {
+        "de": "Absender: Land",
+        "en": "Sender: country"
+      },
+      "description": {
+        "de": "Land des Absenders. Steuert zugleich die Landzeile der Empfängeranschrift: Sie wird nur gedruckt, wenn das Land der Lieferadresse davon abweicht — eine Inlandsanschrift bekommt also keine überflüssige Landzeile ins Fenster.",
+        "en": "Sender country. It also controls the recipient's country line: that line is printed only when the delivery country differs, so a domestic address gets no redundant country line in the window."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 6,
+      "example": "DE"
+    },
+    {
+      "name": "Show_fold_marks",
+      "label": {
+        "de": "Falz- und Lochmarken",
+        "en": "Fold and punch marks"
+      },
+      "description": {
+        "de": "Druckt die Falzmarken bei 105 mm und 210 mm sowie die Lochmarke bei 148,5 mm an den linken Blattrand. Auf \"0\" setzen, wenn auf vorgedrucktem Briefpapier gedruckt wird, das die Marken bereits trägt.",
+        "en": "Prints the fold marks at 105 mm and 210 mm plus the punch mark at 148.5 mm on the left edge of the sheet. Set to \"0\" when printing on pre-printed stationery that already carries them."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Layout",
+      "order": 7,
+      "default": "1",
+      "example": "1"
+    },
+    {
       "name": "Company_footer",
       "label": {
         "de": "Fußzeile",
         "en": "Footer line"
       },
       "description": {
-        "de": "Optionale Fußzeile am unteren Rand jeder Seite des Standort-/Leihberichts, unterhalb von Berichtsname und Seitenzählung — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
-        "en": "Optional footer at the bottom of every page of the location/loan report, below the report name and page count — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite des Leihscheins, unterhalb von Berichtsname und Seitenzählung — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page of the loan receipt, below the report name and page count — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
       },
       "role": "variable",
       "scope": "type",
       "input": "textarea",
       "required": false,
       "group": "Layout",
+      "order": 8,
       "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
     },
     {

--- a/LOCATION-JSON-SAMPLE/subreports/devices.jrxml
+++ b/LOCATION-JSON-SAMPLE/subreports/devices.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 Prüfmittel-Subreport (Contract location-report v1.1): bekommt das
+  V2 Prüfmittel-Subreport (Contract location-report v1.2): bekommt das
   "devices"-Array über subDataSource("devices").
 
   Eine Leihe kann mehr als ein Gerät umfassen: Ein Set (Koffer) wird als ein
@@ -9,23 +9,59 @@
   eine feste Zeile an device.*, der Entleiher unterschrieb also für einen
   Koffer, dessen Inhalt auf dem Papier nicht stand.
 
+  Seit v1.2 ist die Liste eine ABHAKLISTE: jede Zeile beginnt mit einem
+  Ankreuzfeld und trägt eine Positionsnummer, damit Packerei und Empfänger die
+  Sendung Stück für Stück gegen das Papier prüfen können. Die Spaltenköpfe
+  liegen deshalb hier im columnHeader und nicht im Hauptbericht — ein Koffer mit
+  17 Teilen läuft über den Seitenumbruch, und auf Seite 2 stünde sonst eine
+  Ankreuzliste ohne Kopf.
+
   Das Wurzelgerät steht immer an erster Stelle; bei einer Einzelbuchung enthält
-  die Liste nur dieses eine. Keine $V{}-Variablen.
+  die Liste nur dieses eine.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Small" fontSize="8"/>
 	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[asset_number]]></fieldDescription></field>
 	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[serial_number]]></fieldDescription></field>
 	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[manufacturer]]></fieldDescription></field>
 	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[model]]></fieldDescription></field>
 	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[description]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
+	<columnHeader>
+		<band height="16">
+			<staticText><reportElement style="Label" x="12" y="0" width="22" height="13"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" x="34" y="0" width="88" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="122" y="0" width="94" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="216" y="0" width="128" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<staticText><reportElement style="Label" x="344" y="0" width="140" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><text><![CDATA[Nächste Kal.]]></text></staticText>
+			<line><reportElement x="0" y="14" width="549" height="1"/></line>
+		</band>
+	</columnHeader>
+	<!--
+	  splitType="Prevent": Eine Zeile darf den Seitenumbruch nicht in der Mitte
+	  erwischen. Ohne das rutscht bei einer mehrzeiligen Beschreibung deren
+	  zweite Zeile allein auf die Folgeseite — dort steht sie ohne Ankreuzfeld,
+	  ohne Positionsnummer und ohne Inventarnummer, also als Position, die
+	  niemand abhaken kann.
+	-->
 	<detail>
-		<band height="15">
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="0" y="0" width="100" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="100" y="0" width="110" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
-			<textField><reportElement style="Small" x="210" y="0" width="150" height="13"/><textFieldExpression><![CDATA[($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="360" y="0" width="201" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+		<band height="16" splitType="Prevent">
+			<!-- Ankreuzfeld zum Abhaken der Position beim Packen bzw. Auspacken. -->
+			<rectangle>
+				<reportElement x="0" y="1" width="9" height="9"/>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</rectangle>
+			<textField><reportElement style="Small" x="12" y="0" width="22" height="13"/><textFieldExpression><![CDATA[String.valueOf($V{REPORT_COUNT})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="34" y="0" width="88" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="122" y="0" width="94" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="216" y="0" width="128" height="13"/><textFieldExpression><![CDATA[(($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})).trim()]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="344" y="0" width="140" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<!-- Zeilentrenner: eine Abhakliste braucht die Führung fürs Auge. -->
+			<line><reportElement positionType="Float" x="0" y="14" width="549" height="1"/><graphicElement><pen lineWidth="0.25" lineColor="#BBBBBB"/></graphicElement></line>
 		</band>
 	</detail>
 </jasperReport>


### PR DESCRIPTION
Der Leihschein war als Quittungsformular gebaut: Adressen nebeneinander im Kopf, zwei Unterschriftszeilen am Fuß. Das passt zur Übergabe am Tresen — nur passiert die meistens nicht. Das Gerät geht per Paket raus, und der Schein geht mit. `LOCATION-JSON-SAMPLE` ist deshalb jetzt ein Versanddokument.

Braucht [calhelp/calServer-yii#3750](https://github.com/calhelp/calServer-yii/pull/3750) (Contract `location-report` v1.2).

## Was sich ändert

- **Fensterbrief nach DIN 5008 Form B.** Anschriftfeld 20 mm von links, 45 mm von oben, 85 × 45 mm; Lieferadresse in der Anschriftzone, Rücksendeangabe in der Zusatz- und Vermerkzone darüber, Betreffzeile bei 98,4 mm. Ein DIN-lang-Umschlag nach DIN 680 zeigt damit genau die Anschrift. Die Adresse ist **ein** Textfeld mit `\n`-Zeilen: Fehlt der Ansprechpartner, rückt die Straße auf, statt eine Lücke ins Fenster zu setzen. Die Leerzeile vor dem Ort ist raus (DIN 5008 kennt sie seit 2020 nicht mehr), die Landzeile druckt nur bei abweichendem Land.
- **Abhakliste statt Aufzählung.** Je Zeile ein Ankreuzfeld und eine Positionsnummer, dazu die nächste Kalibrierung je Gerät und die Positionszahl aus dem Datensatz über der Tabelle. Am Ende ein Prüfvermerk „Sendung vollständig und unbeschädigt erhalten" mit Datumslinie.
- **Unterschriftszeilen raus.** Das Blatt reist mit der Sendung, niemand quittiert es am Tresen.
- **Sendungsdaten aufs Papier.** Sendungsnummer im Informationsblock rechts, Versandhinweis über der Tabelle. Beide verschwinden spurlos, wenn leer.
- **Rückgabedatum wieder sichtbar.** Der Bericht band `location.custom_fields.rental_end`; dort steht seit ADR-013 nichts mehr, die Zeile druckte leer. Jetzt `location.rental_end`.
- **Falz- und Lochmarken** bei 105 / 148,5 / 210 mm, abschaltbar über `Show_fold_marks`.

## Trade-offs

**Form B, nicht Form A.** Der Briefkopf-Overlay belegt bei den meisten Installationen die oberen 45 mm — dort darf keine Anschrift liegen. Form A bleibt erreichbar: Das Anschriftfeld steckt in **einem** Frame, die Umstellung ist eine Koordinate (`y=116` → `y=64`). Das ist der Grund für den Frame.

**Der Textkörper rückt auf x=12.** Die Marken gehören an den linken Blattrand, und dort begann bisher der Text (6 mm) — die Lochmarke lief im ersten Rendering quer durch die Beschriftung „Standort 3". Jetzt haben die Marken ihre eigene Spalte, und der linke Rand liegt mit rund 10 mm näher an dem, was DIN 5008 für einen Brief vorsieht. Wer Elemente ergänzt, setzt sie nicht auf `x=0`.

**Spaltenköpfe im `columnHeader` des Subreports.** Ein Set kann 17 Teile haben; die Liste läuft über den Umbruch, und eine Ankreuzliste ohne Kopf auf Seite 2 ist nicht abhakbar. Dazu `splitType="Prevent"` — im ersten Mehrseiten-Test rutschte die zweite Zeile einer langen Beschreibung allein auf Seite 2, ohne Ankreuzfeld und ohne Positionsnummer.

**Der Absender kommt aus den Berichtsvariablen.** `Company_sender_line` bzw. `Company_name/_street/_zip/_city` — dieselben `company_*`, die der Auftragsbeleg nutzt. Sind sie nicht gepflegt, bleibt die Rücksendeangabe leer; kein Fehler, der Umschlag trägt sie dann selbst.

**Die Lieferadresse steht nicht doppelt.** Sie ist im Fenster, also wiederholt sie der Fließtext nicht. An ihrer Stelle steht die E-Mail des Lieferkontakts, damit die Rückfrage zur Sendung nicht am Papier scheitert.

## Geprüft

Nicht nur gelesen — gebaut: Beide JRXML gegen **JasperReports 6.20.6** kompiliert, aus `sample-data.json` gefüllt und als PDF gerendert, einseitig (4 Positionen) und mehrseitig (18 Positionen).

Gemessen im Rendering liegt die Anschrift bei **20,3–88,7 mm** horizontal und **57,5–82,5 mm** vertikal, also vollständig im Sichtfenster (20–110 mm × 45–90 mm). Links davon steht auf dieser Höhe nichts, rechts beginnt der Informationsblock erst bei 124,9 mm — 15 mm Abstand zur Fensterkante.

`scripts/check_parameters_manifest.py` und `scripts/check_jasper_version.sh` sind grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QS4CJuoK9BgaFqrKTR256R)_