### PR TITLE
Ticketmanagement-Startvorlagen: Risiken und Chancen nach ISO/IEC 17025

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -265,8 +265,9 @@ jobs:
           if-no-files-found: error
 
       # Konfigurationspakete (calserver.category-package /
-      # calserver.status-package, robots.md §0.5): eigene Bundle-Klasse ohne
-      # JRXML, der ganze Ordner ist das Paket.
+      # calserver.status-package / calserver.ticket-config-package,
+      # robots.md §0.5): eigene Bundle-Klasse ohne JRXML, der ganze Ordner ist
+      # das Paket.
       - name: Upload CATEGORY-INVENTORY-DAKKS as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -300,6 +301,27 @@ jobs:
         with:
           name: STATUS-BOOKING-DAKKS
           path: STATUS-BOOKING-DAKKS
+          if-no-files-found: error
+
+      - name: Upload STATUS-TICKETS-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STATUS-TICKETS-DAKKS
+          path: STATUS-TICKETS-DAKKS
+          if-no-files-found: error
+
+      - name: Upload TICKET-CONFIG-DAKKS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TICKET-CONFIG-DAKKS
+          path: TICKET-CONFIG-DAKKS
+          if-no-files-found: error
+
+      - name: Upload TICKET-CONFIG-DAKKS-3D as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TICKET-CONFIG-DAKKS-3D
+          path: TICKET-CONFIG-DAKKS-3D
           if-no-files-found: error
 
       # Prüfplan-Pakete (calserver.procedure-package, robots.md §0.3):
@@ -560,6 +582,9 @@ jobs:
           create_config_zip "STATUS-INVENTORY-DAKKS" "status-inventory-dakks" "statuses.json"
           create_config_zip "STATUS-REPAIR-DAKKS" "status-repair-dakks" "statuses.json"
           create_config_zip "STATUS-BOOKING-DAKKS" "status-booking-dakks" "statuses.json"
+          create_config_zip "STATUS-TICKETS-DAKKS" "status-tickets-dakks" "statuses.json"
+          create_config_zip "TICKET-CONFIG-DAKKS" "ticket-config-dakks" "ticket-config.json"
+          create_config_zip "TICKET-CONFIG-DAKKS-3D" "ticket-config-dakks-3d" "ticket-config.json"
 
           # V2 (APEX) — JSON-Datasource-Bundles (readable api_name fields, no SQL)
           create_zip "DAKKS-JSON-SAMPLE" "dakks-json-sample"

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -116,6 +116,9 @@ jobs:
           get_last_modified "STATUS-INVENTORY-DAKKS" "status-inventory-dakks"
           get_last_modified "STATUS-REPAIR-DAKKS" "status-repair-dakks"
           get_last_modified "STATUS-BOOKING-DAKKS" "status-booking-dakks"
+          get_last_modified "STATUS-TICKETS-DAKKS" "status-tickets-dakks"
+          get_last_modified "TICKET-CONFIG-DAKKS" "ticket-config-dakks"
+          get_last_modified "TICKET-CONFIG-DAKKS-3D" "ticket-config-dakks-3d"
           get_last_modified "PRUEFPLAN-FLUKE-23" "pruefplan-fluke-23"
           get_last_modified "PRUEFPLAN-MESSSCHIEBER-150MM" "pruefplan-messschieber-150mm"
           get_last_modified "WIKI-ISO-17025" "wiki-iso-17025"
@@ -230,6 +233,9 @@ jobs:
               "status-inventory-dakks":             "STATUS-INVENTORY-DAKKS/README.md",
               "status-repair-dakks":                "STATUS-REPAIR-DAKKS/README.md",
               "status-booking-dakks":               "STATUS-BOOKING-DAKKS/README.md",
+              "status-tickets-dakks":               "STATUS-TICKETS-DAKKS/README.md",
+              "ticket-config-dakks":                "TICKET-CONFIG-DAKKS/README.md",
+              "ticket-config-dakks-3d":             "TICKET-CONFIG-DAKKS-3D/README.md",
           }
 
           SCHEMA_MAP = {
@@ -270,6 +276,9 @@ jobs:
               "status-inventory-dakks":             "Status: Geräte-Lebenszyklus für Kalibrierlabore",
               "status-repair-dakks":                "Status: Reparatur für Kalibrierlabore",
               "status-booking-dakks":               "Status: Aufträge für Kalibrierlabore",
+              "status-tickets-dakks":               "Status: Risiken, Chancen und Maßnahmen im Ticketsystem",
+              "ticket-config-dakks":                "Ticketmanagement: Risiken und Chancen nach ISO/IEC 17025 (zwei Methoden)",
+              "ticket-config-dakks-3d":             "Ticketmanagement: Risiken und Chancen nach ISO/IEC 17025 (drei Methoden)",
           }
 
           INFO_TEMPLATE = """<!doctype html>

--- a/.github/workflows/validate-reports.yml
+++ b/.github/workflows/validate-reports.yml
@@ -47,12 +47,19 @@ jobs:
         run: python3 scripts/build_wiki_manifest.py --check
 
       # Konfigurationspakete (calserver.category-package /
-      # calserver.status-package, CATEGORY-*/STATUS-*): Manifest gegen das
+      # calserver.status-package / calserver.ticket-config-package,
+      # CATEGORY-*/STATUS-*/TICKET-CONFIG-*): Manifest gegen das
       # jeweilige Schema, sha256-Parität in beide Richtungen,
       # Eintrags-Allowlist sowie inhaltliche Prüfungen (Schlüssel eindeutig,
-      # parent_key aufloesbar, Folgeaktionen zeigen auf Status des Pakets).
+      # parent_key aufloesbar, Folgeaktionen zeigen auf Status des Pakets,
+      # Risiko-Matrix deckt den erreichbaren Wertebereich ab).
       - name: Check config package manifests
         run: python3 scripts/build_config_manifest.py --check
+
+      # TICKET-CONFIG-DAKKS-3D wird aus der Zwei-Methoden-Fassung abgeleitet,
+      # nicht von Hand gepflegt — sonst laufen die Kataloge auseinander.
+      - name: Check derived three-method ticket configuration
+        run: python3 scripts/build_ticket_config_3d.py --check
 
       # DCC 3.3.0 Export: xmlschema erlaubt echte Validierung gegen dcc-v3.3.0.xsd
       # (mit remote SI-/dsig-Imports). Der Check überspringt die XSD-Prüfung

--- a/README.md
+++ b/README.md
@@ -91,9 +91,15 @@ CATEGORY-INVENTORY-DAKKS/
 └── README.md
 
 STATUS-CALIBRATION-DAKKS/, STATUS-INVENTORY-DAKKS/,
-STATUS-REPAIR-DAKKS/, STATUS-BOOKING-DAKKS/
+STATUS-REPAIR-DAKKS/, STATUS-BOOKING-DAKKS/, STATUS-TICKETS-DAKKS/
 ├── statuses.json       # Statusmodell samt Feldfunktionen je Status
 ├── manifest.json
+└── README.md
+
+TICKET-CONFIG-DAKKS/, TICKET-CONFIG-DAKKS-3D/
+├── ticket-config.json  # Ticketmanagement nach ISO/IEC 17025: Vorgangsarten,
+│                       # Themenfelder, Prioritäten, Risikoskalen, Matrix, Formel
+├── manifest.json       # (3D wird aus 2D abgeleitet, siehe scripts/)
 └── README.md
 
 PRUEFPLAN-*/
@@ -115,12 +121,14 @@ schema/
 ├── procedure-package.schema.json   # Manifest-Schema der Prüfplan-Pakete
 ├── category-package.schema.json    # Manifest-Schema der Kategorie-Pakete
 ├── status-package.schema.json      # Manifest-Schema der Status-Pakete
+├── ticket-config-package.schema.json # Manifest-Schema der Ticketmanagement-Pakete
 └── wiki-package.schema.json        # Manifest-Schema der Wiki-Vorlagen
 
 scripts/
 ├── check_jasper_version.sh         # Prüft JRXML-Versionen auf 6.20.6
 ├── check_parameters_manifest.py    # CI-Validator für parameters.json-Manifeste
-├── build_config_manifest.py        # Manifest-Werkzeug der Kategorie-/Status-Pakete (--write/--check)
+├── build_config_manifest.py        # Manifest-Werkzeug der Kategorie-/Status-/Ticketmanagement-Pakete (--write/--check)
+├── build_ticket_config_3d.py       # Leitet TICKET-CONFIG-DAKKS-3D aus der 2D-Fassung ab (--write/--check)
 ├── generate_parameters_manifest.py # Erzeugt ein parameters.json-Gerüst aus dem Haupt-JRXML
 ├── dakks_upload_sample.bat         # Beispielskript für den automatisierten Report-Upload
 ├── dcc_upload_sample.bat           # Upload-Beispiel für DCC-Reports

--- a/STATUS-TICKETS-DAKKS/README.md
+++ b/STATUS-TICKETS-DAKKS/README.md
@@ -1,0 +1,54 @@
+# Ticket-Status für ein akkreditiertes Labor
+
+Der Ablauf, den ein Vorgang aus Risiko-, Chancen- und Maßnahmenmanagement nach
+ISO/IEC 17025 durchläuft. Gehört zu den Ticketmanagement-Paketen
+[`TICKET-CONFIG-DAKKS`](../TICKET-CONFIG-DAKKS/) (zwei Methoden) bzw.
+[`TICKET-CONFIG-DAKKS-3D`](../TICKET-CONFIG-DAKKS-3D/) (drei Methoden), die
+Vorgangsarten, Themenfelder und die Risikobewertung mitbringen.
+
+## Der Ablauf
+
+| Reihenfolge | Status | Bedeutung |
+|-------------|--------|-----------|
+| 10 | Neu | Erfasst, noch nicht bewertet |
+| 20 | Bewertet | Auswirkung und Wahrscheinlichkeit stehen, der Risikowert ist berechnet |
+| 30 | Maßnahme geplant | Maßnahme, Verantwortliche und Termin sind festgelegt |
+| 40 | In Umsetzung | Die Maßnahme läuft |
+| 50 | Wirksamkeit prüfen | Umgesetzt, Wirksamkeit noch nicht belegt |
+| 60 | Abgeschlossen | Wirksamkeit belegt, Restrisiko akzeptiert |
+| 70 | Kein Handlungsbedarf | Bewertet und bewusst nicht behandelt, mit Begründung |
+
+## Warum die Wirksamkeit einen eigenen Status hat
+
+Abschnitt 8.7 verlangt, die Wirksamkeit ergriffener Korrekturmaßnahmen zu
+bewerten. Wer „umgesetzt" und „wirksam" in einem Status zusammenfasst, hat
+diesen Nachweis nicht — und merkt es erst, wenn in der Begutachtung nach der
+Wirksamkeitsbeurteilung gefragt wird. Der Zwischenstatus macht die offene
+Prüfung sichtbar: Alles in „Wirksamkeit prüfen" ist Arbeit, die noch aussteht.
+
+## Warum „Kein Handlungsbedarf" kein Abschluss ist
+
+Ein akzeptiertes Risiko ist eine Entscheidung, kein Vergessen. 8.5.1 c) erlaubt
+ausdrücklich, ein Risiko zu akzeptieren; verlangt wird, dass die Entscheidung
+nachvollziehbar ist. Als eigener Status bleibt sie auffindbar, statt in der
+Menge der abgeschlossenen Vorgänge zu verschwinden — und die Liste der
+akzeptierten Risiken ist eine brauchbare Eingabe für die Managementbewertung
+(8.9.2).
+
+## Import
+
+**Administration → Statusverwaltung**, Schaltfläche **Paket** (Berechtigung
+`status_import`). Wiedererkannt wird ein Status über Bereich und Titel; ein
+zweiter Import legt keine Zwillinge an.
+
+## Grenzen
+
+- **Keine Feldfunktionen.** Ticket-Status führen in calServer keine
+  Feldregistry, anders als Kalibrier- oder Reparaturstatus. Dass ein Ticket vor
+  dem Abschluss eine Wirksamkeitsbeurteilung trägt, lässt sich damit nicht
+  technisch erzwingen; der Status macht es sichtbar, die Verfahrensanweisung
+  verbindlich.
+- **Keine Folgeaktionen im Paket.** E-Mail-Benachrichtigungen beim
+  Statuswechsel hängen an Mailvorlagen, die je Installation anders heißen. Sie
+  lassen sich nach dem Import in den Statusregeln ergänzen.
+- **Einsprachig (deutsch).** Für eine andere Sprache ein eigenes Paket pflegen.

--- a/STATUS-TICKETS-DAKKS/manifest.json
+++ b/STATUS-TICKETS-DAKKS/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/status-package.schema.json",
+  "format": "calserver.status-package",
+  "format_version": 1,
+  "name": "Status: Risiken, Chancen und Maßnahmen im Ticketsystem",
+  "document": {
+    "format": "calserver.statuses",
+    "version": 1
+  },
+  "content": {
+    "statuses": 7,
+    "field_rules": 0,
+    "types": [
+      "support_tickets"
+    ],
+    "transitions": 0,
+    "processing_times": 0
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "statuses.json",
+      "sha256": "d7a22a56f243daec8df9795c370fb25a9c0889916e82c888db80d27b7e3d498f",
+      "size_bytes": 2967
+    },
+    {
+      "path": "README.md",
+      "sha256": "6a86c4951b9c589ebfb1381941901ebadd9fdfead6e158ba38119a602a76b664",
+      "size_bytes": 2704
+    }
+  ],
+  "description": "Ablauf eines Vorgangs vom Eingang bis zum belegten Wirksamkeitsnachweis, mit eigenem Status für bewusst akzeptierte Risiken.",
+  "created_at": "2026-08-17T12:00:00+00:00",
+  "locale": "de"
+}

--- a/STATUS-TICKETS-DAKKS/statuses.json
+++ b/STATUS-TICKETS-DAKKS/statuses.json
@@ -1,0 +1,101 @@
+{
+  "format": "calserver.statuses",
+  "version": 1,
+  "generator": "calserver-reports",
+  "types": ["support_tickets"],
+  "statuses": [
+    {
+      "key": "support_tickets-neu",
+      "type": "support_tickets",
+      "title": "Neu",
+      "short_title": "NEU",
+      "description": "Erfasst, noch nicht bewertet.",
+      "color": "#64748B",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-inbox",
+      "sort_order": 10,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "support_tickets-bewertet",
+      "type": "support_tickets",
+      "title": "Bewertet",
+      "short_title": "BEW",
+      "description": "Auswirkung und Wahrscheinlichkeit sind eingetragen, der Risikowert steht.",
+      "color": "#0369A1",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-chart-bar",
+      "sort_order": 20,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "support_tickets-massnahme-geplant",
+      "type": "support_tickets",
+      "title": "Maßnahme geplant",
+      "short_title": "PLA",
+      "description": "Maßnahme, Verantwortliche und Termin sind festgelegt.",
+      "color": "#7C3AED",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-calendar",
+      "sort_order": 30,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "support_tickets-in-umsetzung",
+      "type": "support_tickets",
+      "title": "In Umsetzung",
+      "short_title": "UMS",
+      "description": "Die Maßnahme läuft.",
+      "color": "#0891B2",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-cog",
+      "sort_order": 40,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "support_tickets-wirksamkeit-pruefen",
+      "type": "support_tickets",
+      "title": "Wirksamkeit prüfen",
+      "short_title": "WIR",
+      "description": "Maßnahme umgesetzt, die Wirksamkeit ist noch zu belegen (ISO/IEC 17025, 8.7.1 f).",
+      "color": "#CA8A04",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-verified",
+      "sort_order": 50,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "support_tickets-abgeschlossen",
+      "type": "support_tickets",
+      "title": "Abgeschlossen",
+      "short_title": "ABG",
+      "description": "Wirksamkeit belegt, Restrisiko akzeptiert, Vorgang dokumentiert.",
+      "color": "#15803D",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-check-circle",
+      "sort_order": 60,
+      "active": true,
+      "hide": false
+    },
+    {
+      "key": "support_tickets-kein-handlungsbedarf",
+      "type": "support_tickets",
+      "title": "Kein Handlungsbedarf",
+      "short_title": "KHB",
+      "description": "Bewertet und bewusst nicht behandelt: Risiko im grünen Band akzeptiert oder Chance verworfen. Die Begründung steht im Vorgang (8.5.1 c).",
+      "color": "#78716C",
+      "text_color": "#FFFFFF",
+      "icon": "pi pi-ban",
+      "sort_order": 70,
+      "active": true,
+      "hide": false
+    }
+  ],
+  "transitions": [],
+  "processing_times": []
+}

--- a/TICKET-CONFIG-DAKKS-3D/README.md
+++ b/TICKET-CONFIG-DAKKS-3D/README.md
@@ -1,0 +1,88 @@
+# Ticketmanagement für ein akkreditiertes Labor (drei Methoden)
+
+Dieselbe Startvorlage wie [`TICKET-CONFIG-DAKKS`](../TICKET-CONFIG-DAKKS/) — 8
+Vorgangsarten, 20 Themenfelder nach ISO/IEC 17025, vier Prioritäten — nur mit
+**drei** Bewertungsmethoden statt zwei:
+
+```
+Risikowert = Auswirkung × Wahrscheinlichkeit × Erkennbarkeit     (1 … 125)
+```
+
+Die dritte Ebene ist die Erkennbarkeit, wie in der FMEA. Sie beantwortet die
+Frage, die in einem Labor über den tatsächlichen Schaden entscheidet: **Wann
+fällt die Sache auf?** Ein Messfehler, den die Plausibilitätsgrenze am
+Arbeitsplatz abfängt, kostet eine Wiederholmessung. Derselbe Fehler, der erst im
+Ringversuch auffällt, steckt bis dahin in jedem ausgegebenen Kalibrierschein.
+Deshalb steigt das Gewicht, je später etwas auffällt.
+
+| Stufe | Gewicht | Wann es auffällt |
+|-------|---------|------------------|
+| Sofort erkennbar | 1 | bei der Arbeit selbst: Plausibilitätsgrenze, Zwischenprüfung, Warnung im System |
+| Leicht erkennbar | 2 | bei der fachlichen Freigabe (Vier-Augen-Prinzip) |
+| Erkennbar | 3 | über Kontrollkarte, Wiederholmessung oder internes Audit |
+| Schwer erkennbar | 4 | erst beim Ringversuch, bei der Rekalibrierung des Normals oder in der Begutachtung |
+| Kaum erkennbar | 5 | nur durch Kundenreklamation, oder gar nicht |
+
+## Die Bänder
+
+Dieselben vier Stufen und dieselben Prioritäten wie in der
+Zwei-Methoden-Fassung, nur über 1 bis 125 geschnitten:
+
+| Band | Farbe | Priorität |
+|------|-------|-----------|
+| 1–9 | grün | Niedrig |
+| 10–29 | gelb | Normal |
+| 30–59 | orange | Hoch |
+| 60–125 | rot | Kritisch |
+
+Die Entscheidungsregeln je Band (wer entscheidet, welche Frist, welcher
+Nachweis) stehen im README der Zwei-Methoden-Fassung und gelten unverändert.
+
+## Welche Fassung passt
+
+- **Zwei Methoden**, wenn die Risikobetrachtung noch aufgebaut wird oder das
+  Labor eine schlanke Systematik führt. Die klassische Matrix ist in der
+  Begutachtung erklärbar, und jede Bewertung braucht zwei Angaben statt drei.
+- **Drei Methoden**, wenn die Erkennbarkeit real unterschiedlich ist — typisch
+  in Laboren mit vielen Verfahren, langen Kalibrierintervallen der Normale oder
+  ausgeprägter Prozessüberwachung. Der Preis: eine Angabe mehr je Ticket, und
+  drei Skalen, die konsistent bleiben müssen.
+
+Die Fassung lässt sich später wechseln: Die dritte Ebene zählt nur, wenn die
+Formel `[Risk_3]` enthält. Die Bänder der Matrix müssen beim Wechsel aber
+mitgehen, sonst greift kein Band mehr — 1 bis 25 gegen 1 bis 125.
+
+## Import
+
+**Administration → Ticket-Verwaltung**, Schaltfläche **Paket** (Berechtigung
+`support_config_import`). Dazu gehört [`STATUS-TICKETS-DAKKS`](../STATUS-TICKETS-DAKKS/)
+unter Administration → Statusverwaltung.
+
+**Nicht beide Ticketmanagement-Pakete importieren.** Sie tragen dieselben
+Kataloge, aber unterschiedliche Matrixbänder und Formeln; nacheinander
+eingespielt stünden acht Bänder in der Matrix, von denen sich die Hälfte
+überlappt.
+
+## Anpassen
+
+Diese Fassung wird aus der Zwei-Methoden-Fassung **abgeleitet** und nicht von
+Hand bearbeitet — sonst laufen die Kataloge der beiden Pakete auseinander, ohne
+dass es jemand bemerkt. Änderungen an Typen, Kategorien, Prioritäten oder den
+ersten beiden Skalen gehören nach `TICKET-CONFIG-DAKKS`, danach:
+
+```bash
+python3 scripts/build_ticket_config_3d.py --write
+python3 scripts/build_config_manifest.py --write TICKET-CONFIG-DAKKS-3D
+python3 scripts/build_config_manifest.py --check
+```
+
+Die dritte Skala, die Formel und die Bänder stehen im Skript
+(`scripts/build_ticket_config_3d.py`) und werden dort geändert.
+
+## Grenzen
+
+Dieselben wie bei der Zwei-Methoden-Fassung (Fristen setzt calServer nicht
+durch, Ticket-Status tragen keine Pflichtfeldregeln, einsprachig deutsch), und
+eine dazu: **drei Ebenen sind unvollständig schnell.** Solange eine von der
+Formel genutzte Ebene am Ticket nicht ausgewählt ist, hat das Ticket keinen
+Risikowert — mit drei Ebenen passiert das öfter als mit zwei.

--- a/TICKET-CONFIG-DAKKS-3D/manifest.json
+++ b/TICKET-CONFIG-DAKKS-3D/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/ticket-config-package.schema.json",
+  "format": "calserver.ticket-config-package",
+  "format_version": 1,
+  "name": "Ticketmanagement: Risiken und Chancen nach ISO/IEC 17025 (drei Methoden)",
+  "document": {
+    "format": "calserver.ticket-config",
+    "version": 1
+  },
+  "content": {
+    "types": 8,
+    "categories": 20,
+    "priorities": 4,
+    "risk_levels": 15,
+    "matrix": 4,
+    "dimensions": 3,
+    "formula": "[Risk_1] * [Risk_2] * [Risk_3]"
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "ticket-config.json",
+      "sha256": "44eb76fde44163019eeaccca12c9c2f1014a6ca7169ea894a0d5513c5e047a36",
+      "size_bytes": 10726
+    },
+    {
+      "path": "README.md",
+      "sha256": "b587752d33bf125b3e54f91f4c36b5e3c0feb20df82efbbac2db4c64fdae5165",
+      "size_bytes": 4031
+    }
+  ],
+  "description": "Dieselbe Einrichtung wie die Zwei-Methoden-Fassung, bewertet aber mit Auswirkung × Wahrscheinlichkeit × Erkennbarkeit und einer Matrix über 1 bis 125.",
+  "created_at": "2026-08-17T12:00:00+00:00",
+  "locale": "de"
+}

--- a/TICKET-CONFIG-DAKKS-3D/ticket-config.json
+++ b/TICKET-CONFIG-DAKKS-3D/ticket-config.json
@@ -1,0 +1,321 @@
+{
+  "format": "calserver.ticket-config",
+  "version": 1,
+  "generator": "calserver-reports",
+  "risk": {
+    "formula": "[Risk_1] * [Risk_2] * [Risk_3]",
+    "language_code": "de",
+    "dimension_labels": {
+      "risk1": "Auswirkung",
+      "risk2": "Wahrscheinlichkeit",
+      "risk3": "Erkennbarkeit"
+    }
+  },
+  "types": [
+    {
+      "key": "risiko",
+      "title": "Risiko",
+      "description": "Ereignis, das die Gültigkeit der Ergebnisse oder die Unparteilichkeit gefährden kann (ISO/IEC 17025, 8.5.1)."
+    },
+    {
+      "key": "chance",
+      "title": "Chance",
+      "description": "Möglichkeit, die Leistung des Labors zu verbessern: neues Verfahren, kleinere Messunsicherheit, kürzere Durchlaufzeit (8.5.1, 8.6)."
+    },
+    {
+      "key": "abweichung",
+      "title": "Abweichung",
+      "description": "Nichtkonforme Arbeit: eine Tätigkeit oder ein Ergebnis, das die eigenen Verfahren oder die Kundenanforderung nicht erfüllt (7.10)."
+    },
+    {
+      "key": "beschwerde",
+      "title": "Beschwerde",
+      "description": "Äußerung einer Kundin oder eines Kunden zur Laborleistung, die eine Antwort verlangt (7.9)."
+    },
+    {
+      "key": "korrekturmassnahme",
+      "title": "Korrekturmaßnahme",
+      "description": "Maßnahme gegen die Ursache einer Abweichung, damit sie nicht wiederkehrt (8.7). Keine Sofortmaßnahme — die steht in der Abweichung."
+    },
+    {
+      "key": "verbesserung",
+      "title": "Verbesserung",
+      "description": "Umgesetzter Verbesserungsvorschlag aus Personal, Kundenrückmeldung oder Datenauswertung (8.6)."
+    },
+    {
+      "key": "auditfeststellung",
+      "title": "Auditfeststellung",
+      "description": "Feststellung aus internem Audit oder Begutachtung, mit oder ohne Abweichung (8.8)."
+    },
+    {
+      "key": "aenderung",
+      "title": "Änderung",
+      "description": "Geplante Änderung an Verfahren, Ausrüstung, Personal oder Managementsystem, deren Risiken vorher zu bewerten sind (8.5.2, 8.2.4)."
+    }
+  ],
+  "categories": [
+    {
+      "key": "unparteilichkeit",
+      "title": "Unparteilichkeit und Vertraulichkeit (4)",
+      "description": "Interessenkonflikte, Druck auf Ergebnisse, Umgang mit Kundeninformationen."
+    },
+    {
+      "key": "organisation",
+      "title": "Organisation und Zuständigkeiten (5)",
+      "description": "Rechtsform, Leitung, Vertretungsregelungen, Zuständigkeiten im Akkreditierungsbereich."
+    },
+    {
+      "key": "personal",
+      "title": "Personal und Kompetenz (6.2)",
+      "description": "Qualifikation, Einarbeitung, Kompetenznachweise, Vertretung, Schlüsselpersonen."
+    },
+    {
+      "key": "raeume",
+      "title": "Räume und Umgebungsbedingungen (6.3)",
+      "description": "Temperatur, Feuchte, Erschütterung, Netzqualität, Zutritt, Überwachung der Bedingungen."
+    },
+    {
+      "key": "ausruestung",
+      "title": "Ausrüstung und Normale (6.4)",
+      "description": "Verfügbarkeit, Zustand, Zwischenprüfungen, Defekte, Normale außerhalb der Toleranz."
+    },
+    {
+      "key": "rueckfuehrung",
+      "title": "Messtechnische Rückführung (6.5)",
+      "description": "Rückführungskette, Kalibrierintervalle, Anerkennung fremder Kalibrierscheine."
+    },
+    {
+      "key": "externe-dienstleistungen",
+      "title": "Externe Produkte und Dienstleistungen (6.6)",
+      "description": "Unterauftragnehmer, Lieferanten, Kalibrierdienstleister, Softwarelieferanten."
+    },
+    {
+      "key": "auftraege",
+      "title": "Anfragen, Angebote, Aufträge (7.1)",
+      "description": "Machbarkeit, Prüfung der Anforderungen, Abweichungen vom Auftrag, Kundenkommunikation."
+    },
+    {
+      "key": "verfahren",
+      "title": "Verfahren und Validierung (7.2)",
+      "description": "Auswahl, Verifizierung und Validierung von Verfahren, Abweichungen vom Normverfahren."
+    },
+    {
+      "key": "probenahme",
+      "title": "Probenahme und Prüfgegenstände (7.3, 7.4)",
+      "description": "Transport, Annahme, Kennzeichnung, Lagerung und Rückgabe der Kundengeräte."
+    },
+    {
+      "key": "messunsicherheit",
+      "title": "Messunsicherheit und Konformitätsaussagen (7.6, 7.8.6)",
+      "description": "Unsicherheitsbudgets, Entscheidungsregel, Aussagen zur Konformität im Kalibrierschein."
+    },
+    {
+      "key": "validitaet",
+      "title": "Sicherstellung der Validität (7.7)",
+      "description": "Kontrollkarten, Zwischenprüfungen, Ringversuche und Eignungsprüfungen, Wiederholmessungen."
+    },
+    {
+      "key": "berichte",
+      "title": "Berichte und Kalibrierscheine (7.8)",
+      "description": "Inhalt, Freigabe, Änderungen und Rückruf ausgegebener Kalibrierscheine."
+    },
+    {
+      "key": "beschwerden",
+      "title": "Beschwerdeverfahren (7.9)",
+      "description": "Annahme, Bearbeitung und unparteiische Entscheidung über Beschwerden."
+    },
+    {
+      "key": "nichtkonforme-arbeit",
+      "title": "Nichtkonforme Arbeit (7.10)",
+      "description": "Erkennen, Bewerten, Stoppen und Wiederaufnehmen von Arbeit, Rückruf von Ergebnissen."
+    },
+    {
+      "key": "daten-it",
+      "title": "Daten, IT und Informationssicherheit (7.11)",
+      "description": "Datenintegrität, Zugriffsrechte, Sicherungen, Validierung von Software und Berechnungen."
+    },
+    {
+      "key": "managementsystem",
+      "title": "Managementsystem und Dokumentation (8.2 bis 8.4)",
+      "description": "Lenkung von Dokumenten und Aufzeichnungen, Aufbewahrungsfristen, Freigaben."
+    },
+    {
+      "key": "interne-audits",
+      "title": "Interne Audits (8.8)",
+      "description": "Auditprogramm, Durchführung, Nachverfolgung der Feststellungen."
+    },
+    {
+      "key": "managementbewertung",
+      "title": "Managementbewertung (8.9)",
+      "description": "Eingaben und Ergebnisse der Bewertung durch die Leitung, offene Punkte daraus."
+    },
+    {
+      "key": "akkreditierung",
+      "title": "Akkreditierung und Begutachtung",
+      "description": "Fristen, Umfangserweiterungen, Auflagen und Feststellungen der Akkreditierungsstelle."
+    }
+  ],
+  "priorities": [
+    {
+      "key": "niedrig",
+      "title": "Niedrig",
+      "background_color": "#198754",
+      "color": "#FFFFFF"
+    },
+    {
+      "key": "normal",
+      "title": "Normal",
+      "background_color": "#0D6EFD",
+      "color": "#FFFFFF"
+    },
+    {
+      "key": "hoch",
+      "title": "Hoch",
+      "background_color": "#FD7E14",
+      "color": "#FFFFFF"
+    },
+    {
+      "key": "kritisch",
+      "title": "Kritisch",
+      "background_color": "#DC3545",
+      "color": "#FFFFFF"
+    }
+  ],
+  "risk1": [
+    {
+      "key": "unbedeutend",
+      "title": "Unbedeutend",
+      "weight": 1,
+      "color": "00B050",
+      "description": "Intern bemerkt und behoben. Kein ausgegebenes Ergebnis betroffen, keine Kundenwirkung. Bei einer Chance: spürbar nur im eigenen Ablauf."
+    },
+    {
+      "key": "gering",
+      "title": "Gering",
+      "weight": 2,
+      "color": "92D050",
+      "description": "Nacharbeit im Labor, Termin hält. Ergebnisse bleiben gültig. Bei einer Chance: kleine Zeit- oder Kostenersparnis."
+    },
+    {
+      "key": "spuerbar",
+      "title": "Spürbar",
+      "weight": 3,
+      "color": "FFFF00",
+      "description": "Kunde merkt es: Termin reißt, Umfang wird eingeschränkt, Messung ist zu wiederholen. Konformitätsaussagen bleiben richtig. Bei einer Chance: messbar kleinere Unsicherheit oder kürzere Durchlaufzeit."
+    },
+    {
+      "key": "kritisch",
+      "title": "Kritisch",
+      "weight": 4,
+      "color": "FFC000",
+      "description": "Falsche Konformitätsaussage möglich, Kalibrierscheine sind zurückzurufen, Abweichung in der Begutachtung zu erwarten. Bei einer Chance: neues Verfahren oder Erweiterung des Akkreditierungsumfangs."
+    },
+    {
+      "key": "existenzbedrohend",
+      "title": "Existenzbedrohend",
+      "weight": 5,
+      "color": "FF0000",
+      "description": "Systematisch falsche Ergebnisse beim Kunden, Aussetzung oder Entzug der Akkreditierung, Haftung. Bei einer Chance: neues Geschäftsfeld."
+    }
+  ],
+  "risk2": [
+    {
+      "key": "sehr-unwahrscheinlich",
+      "title": "Sehr unwahrscheinlich",
+      "weight": 1,
+      "color": "00B050",
+      "description": "Im Labor noch nie vorgekommen und durch bestehende Vorkehrungen abgedeckt."
+    },
+    {
+      "key": "unwahrscheinlich",
+      "title": "Unwahrscheinlich",
+      "weight": 2,
+      "color": "92D050",
+      "description": "Einzelfall über mehrere Jahre, im Haus oder bei vergleichbaren Laboren bekannt."
+    },
+    {
+      "key": "moeglich",
+      "title": "Möglich",
+      "weight": 3,
+      "color": "FFFF00",
+      "description": "Etwa einmal im Jahr zu erwarten."
+    },
+    {
+      "key": "wahrscheinlich",
+      "title": "Wahrscheinlich",
+      "weight": 4,
+      "color": "FFC000",
+      "description": "Mehrmals im Jahr zu erwarten."
+    },
+    {
+      "key": "fast-sicher",
+      "title": "Fast sicher",
+      "weight": 5,
+      "color": "FF0000",
+      "description": "Monatlich oder häufiger, oder der Zustand liegt bereits vor."
+    }
+  ],
+  "risk3": [
+    {
+      "key": "sofort-erkennbar",
+      "title": "Sofort erkennbar",
+      "weight": 1,
+      "color": "00B050",
+      "description": "Fällt bei der Arbeit selbst auf: Plausibilitätsgrenze, Zwischenprüfung, Warnung im System."
+    },
+    {
+      "key": "leicht-erkennbar",
+      "title": "Leicht erkennbar",
+      "weight": 2,
+      "color": "92D050",
+      "description": "Fällt bei der fachlichen Freigabe des Kalibrierscheins auf (Vier-Augen-Prinzip)."
+    },
+    {
+      "key": "erkennbar",
+      "title": "Erkennbar",
+      "weight": 3,
+      "color": "FFFF00",
+      "description": "Fällt über Kontrollkarte, Wiederholmessung oder internes Audit auf, also Wochen bis Monate später."
+    },
+    {
+      "key": "schwer-erkennbar",
+      "title": "Schwer erkennbar",
+      "weight": 4,
+      "color": "FFC000",
+      "description": "Fällt erst beim Ringversuch, bei der Rekalibrierung des Normals oder in der Begutachtung auf."
+    },
+    {
+      "key": "kaum-erkennbar",
+      "title": "Kaum erkennbar",
+      "weight": 5,
+      "color": "FF0000",
+      "description": "Fällt nur durch eine Kundenreklamation auf oder bleibt unentdeckt."
+    }
+  ],
+  "matrix": [
+    {
+      "risk": "1-9",
+      "color": "00B050",
+      "priority": "Niedrig",
+      "sort_order": 1
+    },
+    {
+      "risk": "10-29",
+      "color": "FFFF00",
+      "priority": "Normal",
+      "sort_order": 2
+    },
+    {
+      "risk": "30-59",
+      "color": "FFC000",
+      "priority": "Hoch",
+      "sort_order": 3
+    },
+    {
+      "risk": "60-125",
+      "color": "FF0000",
+      "priority": "Kritisch",
+      "sort_order": 4
+    }
+  ]
+}

--- a/TICKET-CONFIG-DAKKS/README.md
+++ b/TICKET-CONFIG-DAKKS/README.md
@@ -1,0 +1,142 @@
+# Ticketmanagement für ein akkreditiertes Labor (zwei Methoden)
+
+Startvorlage für das Ticketmanagement von calServer V2, zugeschnitten auf ein
+Labor nach ISO/IEC 17025: die Vorgangsarten, die Themenfelder, die Prioritäten
+und die vollständige Risikobewertung mit **zwei** Methoden
+(Auswirkung × Wahrscheinlichkeit, Werte 1 bis 25).
+
+Wer mit drei Methoden bewertet (zusätzlich die Erkennbarkeit, Werte bis 125),
+nimmt stattdessen [`TICKET-CONFIG-DAKKS-3D`](../TICKET-CONFIG-DAKKS-3D/). Alles
+andere ist in beiden Paketen identisch.
+
+## Was drin ist
+
+| Teil | Inhalt |
+|------|--------|
+| Typen | 8 Vorgangsarten: Risiko, Chance, Abweichung, Beschwerde, Korrekturmaßnahme, Verbesserung, Auditfeststellung, Änderung |
+| Kategorien | 20 Themenfelder entlang der Normabschnitte, von der Unparteilichkeit (4) bis zur Managementbewertung (8.9) |
+| Prioritäten | Niedrig, Normal, Hoch, Kritisch |
+| Auswirkung (`[Risk_1]`) | Skala 1 bis 5, beschrieben in der Sprache des Labors: von „intern bemerkt" bis „Akkreditierung gefährdet" |
+| Wahrscheinlichkeit (`[Risk_2]`) | Skala 1 bis 5, an Häufigkeiten festgemacht statt an Gefühlen |
+| Risiko-Matrix | 4 Bänder über 1 bis 25, je mit Farbe und automatisch gesetzter Priorität |
+| Formel | `[Risk_1] * [Risk_2]` |
+
+Nicht drin: **Ticket-Status**. Die liegen in calServer im gemeinsamen
+Statuskatalog und haben ihr eigenes Format. Der passende Ablauf (Neu, Bewertet,
+Maßnahme geplant, In Umsetzung, Wirksamkeit prüfen, Abgeschlossen, Kein
+Handlungsbedarf) steht in [`STATUS-TICKETS-DAKKS`](../STATUS-TICKETS-DAKKS/) und
+wird unter Administration → Statusverwaltung importiert. Beide Pakete gehören
+zusammen.
+
+Ebenfalls nicht drin: Tickets. Ein Paket trägt die Einrichtung, nicht den
+Bestand.
+
+## Warum Risiken und Chancen in einem System
+
+ISO/IEC 17025 behandelt beide im selben Abschnitt (8.5, „Maßnahmen zum Umgang
+mit Risiken und Chancen"), und beide brauchen denselben Nachweis: erkannt,
+bewertet, entschieden, und bei Handlung wirksam geworden. Ein zweites Werkzeug
+für Chancen hieße nur, den zweiten Nachweis woanders zu suchen.
+
+Die Bewertung funktioniert für Chancen mit derselben Matrix, nur anders
+gelesen:
+
+| Ebene | Beim Risiko | Bei der Chance |
+|-------|-------------|----------------|
+| Auswirkung | Schaden, wenn es eintritt | Nutzen, wenn sie gelingt |
+| Wahrscheinlichkeit | wie oft mit dem Eintritt zu rechnen ist | wie sicher sich der Nutzen einstellt |
+| Ergebnis | Risikowert: hoch heißt „abstellen" | Bedeutung: hoch heißt „einplanen" |
+
+Das ist eine Konvention, keine Rechenregel des Systems. Sie steht hier, damit
+sie im Labor einheitlich angewendet wird, und gehört so in die
+Verfahrensanweisung.
+
+## Die Regeln zum Ergebnis
+
+calServer setzt aus dem Risikowert Farbe und Priorität. Was daraus folgt, ist
+Sache des Labors — hier der Vorschlag, der zu den vier Bändern passt und sich in
+der Begutachtung erklären lässt:
+
+| Band | Priorität | Entscheidung | Frist | Nachweis |
+|------|-----------|--------------|-------|----------|
+| 1–4 | Niedrig | Akzeptieren. Status „Kein Handlungsbedarf" mit Begründung, oder Sammelposten für die Managementbewertung | keine | Eintrag genügt |
+| 5–9 | Normal | Maßnahme durch die fachlich zuständige Person | 3 Monate | Maßnahme dokumentiert, Wirksamkeit beim Abschluss beurteilt |
+| 10–14 | Hoch | Maßnahme mit benannter Verantwortlicher, Freigabe durch die Qualitätsmanagement-Beauftragte | 1 Monat | Wirksamkeit gesondert belegt (Kontrollmessung, Audit, Kennzahl) |
+| 15–25 | Kritisch | Sofortmaßnahme prüfen: Arbeit anhalten, Ergebnisse zurückrufen, Kunden informieren (7.10). Entscheidung durch die Laborleitung | sofort, Maßnahme innerhalb 1 Woche geplant | Wirksamkeit belegt, Vorgang in der Managementbewertung berichtet |
+
+Zwei Punkte, die in der Begutachtung regelmäßig gefragt werden und die diese
+Vorlage deshalb bewusst so schneidet:
+
+- **Ein akzeptiertes Risiko ist eine Entscheidung, kein Vergessen.** Deshalb der
+  Status „Kein Handlungsbedarf" statt „erledigt": Wer die Liste später liest,
+  sieht die Begründung.
+- **Wirksamkeit ist ein eigener Schritt.** Der Status „Wirksamkeit prüfen" liegt
+  zwischen Umsetzung und Abschluss, weil 8.7 genau das verlangt: geprüft wird
+  die Wirkung, nicht die Erledigung.
+
+## Import
+
+**Administration → Ticket-Verwaltung**, Schaltfläche **Paket** (Berechtigung
+`support_config_import`). Wiedererkannt wird ein Eintrag am Titel, eine
+Matrixzeile an ihrem Band; ein zweiter Import legt keine Zwillinge an.
+
+Reihenfolge auf einer frischen Installation:
+
+1. `TICKET-CONFIG-DAKKS` (dieses Paket) unter Ticket-Verwaltung
+2. `STATUS-TICKETS-DAKKS` unter Statusverwaltung
+
+Auf einer Installation, die schon Prioritäten oder Bewertungsstufen führt, gilt
+der Modus:
+
+- **Bestehende behalten** (Vorgabe): ergänzt nur, was fehlt. Formel und
+  Ebenennamen werden übernommen, solange sie noch auf der Werksvorgabe stehen.
+- **Bestehende überschreiben**: zieht zusätzlich Gewichte, Farben und
+  Beschreibungen nach und setzt Formel und Ebenennamen auch dann, wenn dort
+  schon eigene stehen.
+
+Der Bericht nach dem Import nennt jede Zahl einzeln und jede Zeile, die nicht
+durchkam.
+
+## Anpassen
+
+`ticket-config.json` lässt sich direkt bearbeiten und ohne Archiv hochladen.
+Zwei Stellen, an denen ein Labor typischerweise ansetzt:
+
+- **Kategorien kürzen.** 20 Themenfelder sind vollständig, nicht verbindlich.
+  Wer die Liste kürzt, verliert nichts außer Auswahl — die Normabschnitte in
+  den Titeln sind Orientierung für die Anwender, keine Logik.
+- **Skalen umformulieren.** Die Gewichte 1 bis 5 müssen bleiben, damit die
+  Matrixbänder passen; die Beschreibungen sollen die eigene Praxis treffen.
+
+Nach Änderungen am Bundle das Manifest neu schreiben:
+
+```bash
+python3 scripts/build_config_manifest.py --write TICKET-CONFIG-DAKKS
+python3 scripts/build_config_manifest.py --check
+```
+
+Wer die Zwei-Methoden-Fassung ändert, zieht die Drei-Methoden-Fassung nach —
+sie wird daraus abgeleitet:
+
+```bash
+python3 scripts/build_ticket_config_3d.py --write
+python3 scripts/build_config_manifest.py --write TICKET-CONFIG-DAKKS-3D
+```
+
+## Grenzen
+
+- **Die Fristen der Tabelle oben setzt calServer nicht durch.** Das Produkt
+  rechnet den Risikowert, färbt das Ticket und setzt die Priorität. Termine und
+  Zuständigkeiten sind Verfahrensanweisung; wer sie technisch erzwingen will,
+  arbeitet mit Fälligkeitsdatum und Benachrichtigungen im Ticket.
+- **Keine Feldfunktionen.** Ticket-Status tragen in calServer keine
+  Pflichtfeldregeln (anders als Kalibrier- oder Reparaturstatus). Dass ein
+  Ticket vor dem Abschluss eine Wirksamkeitsbeurteilung trägt, ist damit
+  organisatorisch geregelt, nicht technisch erzwungen.
+- **Einsprachig (deutsch).** Die Ebenennamen werden als Übersetzungen der
+  Schlüssel `Risk 1` bis `Risk 3` in der Kategorie `support` geschrieben; für
+  eine weitere Sprache ein eigenes Paket pflegen.
+- **Die Skalen sind ein Vorschlag, keine Norm.** ISO/IEC 17025 verlangt eine
+  Risikobetrachtung, schreibt aber weder Skalen noch Bänder vor. Wer eine
+  bestehende, gelebte Systematik hat, behält sie und importiert dieses Paket
+  nicht.

--- a/TICKET-CONFIG-DAKKS/manifest.json
+++ b/TICKET-CONFIG-DAKKS/manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/ticket-config-package.schema.json",
+  "format": "calserver.ticket-config-package",
+  "format_version": 1,
+  "name": "Ticketmanagement: Risiken und Chancen nach ISO/IEC 17025 (zwei Methoden)",
+  "document": {
+    "format": "calserver.ticket-config",
+    "version": 1
+  },
+  "content": {
+    "types": 8,
+    "categories": 20,
+    "priorities": 4,
+    "risk_levels": 10,
+    "matrix": 4,
+    "dimensions": 2,
+    "formula": "[Risk_1] * [Risk_2]"
+  },
+  "generator": "calserver-reports",
+  "files": [
+    {
+      "path": "ticket-config.json",
+      "sha256": "d5dd63ff6a2dd8e62193fd59b710f86d91e6ac7433245a3306f42f3f25b31fdf",
+      "size_bytes": 9547
+    },
+    {
+      "path": "README.md",
+      "sha256": "46e7f7a1357f0af4f337d39266560093a7fa129473228195d5783deaeb73b4f8",
+      "size_bytes": 7197
+    }
+  ],
+  "description": "Vollständige Einrichtung des Ticketmoduls für ein akkreditiertes Labor: 8 Vorgangsarten, 20 Themenfelder entlang der Normabschnitte, 4 Prioritäten und die Risikobewertung Auswirkung × Wahrscheinlichkeit mit Matrix über 1 bis 25.",
+  "created_at": "2026-08-17T12:00:00+00:00",
+  "locale": "de"
+}

--- a/TICKET-CONFIG-DAKKS/ticket-config.json
+++ b/TICKET-CONFIG-DAKKS/ticket-config.json
@@ -1,0 +1,285 @@
+{
+  "format": "calserver.ticket-config",
+  "version": 1,
+  "generator": "calserver-reports",
+  "risk": {
+    "formula": "[Risk_1] * [Risk_2]",
+    "language_code": "de",
+    "dimension_labels": {
+      "risk1": "Auswirkung",
+      "risk2": "Wahrscheinlichkeit",
+      "risk3": "Erkennbarkeit"
+    }
+  },
+  "types": [
+    {
+      "key": "risiko",
+      "title": "Risiko",
+      "description": "Ereignis, das die Gültigkeit der Ergebnisse oder die Unparteilichkeit gefährden kann (ISO/IEC 17025, 8.5.1)."
+    },
+    {
+      "key": "chance",
+      "title": "Chance",
+      "description": "Möglichkeit, die Leistung des Labors zu verbessern: neues Verfahren, kleinere Messunsicherheit, kürzere Durchlaufzeit (8.5.1, 8.6)."
+    },
+    {
+      "key": "abweichung",
+      "title": "Abweichung",
+      "description": "Nichtkonforme Arbeit: eine Tätigkeit oder ein Ergebnis, das die eigenen Verfahren oder die Kundenanforderung nicht erfüllt (7.10)."
+    },
+    {
+      "key": "beschwerde",
+      "title": "Beschwerde",
+      "description": "Äußerung einer Kundin oder eines Kunden zur Laborleistung, die eine Antwort verlangt (7.9)."
+    },
+    {
+      "key": "korrekturmassnahme",
+      "title": "Korrekturmaßnahme",
+      "description": "Maßnahme gegen die Ursache einer Abweichung, damit sie nicht wiederkehrt (8.7). Keine Sofortmaßnahme — die steht in der Abweichung."
+    },
+    {
+      "key": "verbesserung",
+      "title": "Verbesserung",
+      "description": "Umgesetzter Verbesserungsvorschlag aus Personal, Kundenrückmeldung oder Datenauswertung (8.6)."
+    },
+    {
+      "key": "auditfeststellung",
+      "title": "Auditfeststellung",
+      "description": "Feststellung aus internem Audit oder Begutachtung, mit oder ohne Abweichung (8.8)."
+    },
+    {
+      "key": "aenderung",
+      "title": "Änderung",
+      "description": "Geplante Änderung an Verfahren, Ausrüstung, Personal oder Managementsystem, deren Risiken vorher zu bewerten sind (8.5.2, 8.2.4)."
+    }
+  ],
+  "categories": [
+    {
+      "key": "unparteilichkeit",
+      "title": "Unparteilichkeit und Vertraulichkeit (4)",
+      "description": "Interessenkonflikte, Druck auf Ergebnisse, Umgang mit Kundeninformationen."
+    },
+    {
+      "key": "organisation",
+      "title": "Organisation und Zuständigkeiten (5)",
+      "description": "Rechtsform, Leitung, Vertretungsregelungen, Zuständigkeiten im Akkreditierungsbereich."
+    },
+    {
+      "key": "personal",
+      "title": "Personal und Kompetenz (6.2)",
+      "description": "Qualifikation, Einarbeitung, Kompetenznachweise, Vertretung, Schlüsselpersonen."
+    },
+    {
+      "key": "raeume",
+      "title": "Räume und Umgebungsbedingungen (6.3)",
+      "description": "Temperatur, Feuchte, Erschütterung, Netzqualität, Zutritt, Überwachung der Bedingungen."
+    },
+    {
+      "key": "ausruestung",
+      "title": "Ausrüstung und Normale (6.4)",
+      "description": "Verfügbarkeit, Zustand, Zwischenprüfungen, Defekte, Normale außerhalb der Toleranz."
+    },
+    {
+      "key": "rueckfuehrung",
+      "title": "Messtechnische Rückführung (6.5)",
+      "description": "Rückführungskette, Kalibrierintervalle, Anerkennung fremder Kalibrierscheine."
+    },
+    {
+      "key": "externe-dienstleistungen",
+      "title": "Externe Produkte und Dienstleistungen (6.6)",
+      "description": "Unterauftragnehmer, Lieferanten, Kalibrierdienstleister, Softwarelieferanten."
+    },
+    {
+      "key": "auftraege",
+      "title": "Anfragen, Angebote, Aufträge (7.1)",
+      "description": "Machbarkeit, Prüfung der Anforderungen, Abweichungen vom Auftrag, Kundenkommunikation."
+    },
+    {
+      "key": "verfahren",
+      "title": "Verfahren und Validierung (7.2)",
+      "description": "Auswahl, Verifizierung und Validierung von Verfahren, Abweichungen vom Normverfahren."
+    },
+    {
+      "key": "probenahme",
+      "title": "Probenahme und Prüfgegenstände (7.3, 7.4)",
+      "description": "Transport, Annahme, Kennzeichnung, Lagerung und Rückgabe der Kundengeräte."
+    },
+    {
+      "key": "messunsicherheit",
+      "title": "Messunsicherheit und Konformitätsaussagen (7.6, 7.8.6)",
+      "description": "Unsicherheitsbudgets, Entscheidungsregel, Aussagen zur Konformität im Kalibrierschein."
+    },
+    {
+      "key": "validitaet",
+      "title": "Sicherstellung der Validität (7.7)",
+      "description": "Kontrollkarten, Zwischenprüfungen, Ringversuche und Eignungsprüfungen, Wiederholmessungen."
+    },
+    {
+      "key": "berichte",
+      "title": "Berichte und Kalibrierscheine (7.8)",
+      "description": "Inhalt, Freigabe, Änderungen und Rückruf ausgegebener Kalibrierscheine."
+    },
+    {
+      "key": "beschwerden",
+      "title": "Beschwerdeverfahren (7.9)",
+      "description": "Annahme, Bearbeitung und unparteiische Entscheidung über Beschwerden."
+    },
+    {
+      "key": "nichtkonforme-arbeit",
+      "title": "Nichtkonforme Arbeit (7.10)",
+      "description": "Erkennen, Bewerten, Stoppen und Wiederaufnehmen von Arbeit, Rückruf von Ergebnissen."
+    },
+    {
+      "key": "daten-it",
+      "title": "Daten, IT und Informationssicherheit (7.11)",
+      "description": "Datenintegrität, Zugriffsrechte, Sicherungen, Validierung von Software und Berechnungen."
+    },
+    {
+      "key": "managementsystem",
+      "title": "Managementsystem und Dokumentation (8.2 bis 8.4)",
+      "description": "Lenkung von Dokumenten und Aufzeichnungen, Aufbewahrungsfristen, Freigaben."
+    },
+    {
+      "key": "interne-audits",
+      "title": "Interne Audits (8.8)",
+      "description": "Auditprogramm, Durchführung, Nachverfolgung der Feststellungen."
+    },
+    {
+      "key": "managementbewertung",
+      "title": "Managementbewertung (8.9)",
+      "description": "Eingaben und Ergebnisse der Bewertung durch die Leitung, offene Punkte daraus."
+    },
+    {
+      "key": "akkreditierung",
+      "title": "Akkreditierung und Begutachtung",
+      "description": "Fristen, Umfangserweiterungen, Auflagen und Feststellungen der Akkreditierungsstelle."
+    }
+  ],
+  "priorities": [
+    {
+      "key": "niedrig",
+      "title": "Niedrig",
+      "background_color": "#198754",
+      "color": "#FFFFFF"
+    },
+    {
+      "key": "normal",
+      "title": "Normal",
+      "background_color": "#0D6EFD",
+      "color": "#FFFFFF"
+    },
+    {
+      "key": "hoch",
+      "title": "Hoch",
+      "background_color": "#FD7E14",
+      "color": "#FFFFFF"
+    },
+    {
+      "key": "kritisch",
+      "title": "Kritisch",
+      "background_color": "#DC3545",
+      "color": "#FFFFFF"
+    }
+  ],
+  "risk1": [
+    {
+      "key": "unbedeutend",
+      "title": "Unbedeutend",
+      "weight": 1,
+      "color": "00B050",
+      "description": "Intern bemerkt und behoben. Kein ausgegebenes Ergebnis betroffen, keine Kundenwirkung. Bei einer Chance: spürbar nur im eigenen Ablauf."
+    },
+    {
+      "key": "gering",
+      "title": "Gering",
+      "weight": 2,
+      "color": "92D050",
+      "description": "Nacharbeit im Labor, Termin hält. Ergebnisse bleiben gültig. Bei einer Chance: kleine Zeit- oder Kostenersparnis."
+    },
+    {
+      "key": "spuerbar",
+      "title": "Spürbar",
+      "weight": 3,
+      "color": "FFFF00",
+      "description": "Kunde merkt es: Termin reißt, Umfang wird eingeschränkt, Messung ist zu wiederholen. Konformitätsaussagen bleiben richtig. Bei einer Chance: messbar kleinere Unsicherheit oder kürzere Durchlaufzeit."
+    },
+    {
+      "key": "kritisch",
+      "title": "Kritisch",
+      "weight": 4,
+      "color": "FFC000",
+      "description": "Falsche Konformitätsaussage möglich, Kalibrierscheine sind zurückzurufen, Abweichung in der Begutachtung zu erwarten. Bei einer Chance: neues Verfahren oder Erweiterung des Akkreditierungsumfangs."
+    },
+    {
+      "key": "existenzbedrohend",
+      "title": "Existenzbedrohend",
+      "weight": 5,
+      "color": "FF0000",
+      "description": "Systematisch falsche Ergebnisse beim Kunden, Aussetzung oder Entzug der Akkreditierung, Haftung. Bei einer Chance: neues Geschäftsfeld."
+    }
+  ],
+  "risk2": [
+    {
+      "key": "sehr-unwahrscheinlich",
+      "title": "Sehr unwahrscheinlich",
+      "weight": 1,
+      "color": "00B050",
+      "description": "Im Labor noch nie vorgekommen und durch bestehende Vorkehrungen abgedeckt."
+    },
+    {
+      "key": "unwahrscheinlich",
+      "title": "Unwahrscheinlich",
+      "weight": 2,
+      "color": "92D050",
+      "description": "Einzelfall über mehrere Jahre, im Haus oder bei vergleichbaren Laboren bekannt."
+    },
+    {
+      "key": "moeglich",
+      "title": "Möglich",
+      "weight": 3,
+      "color": "FFFF00",
+      "description": "Etwa einmal im Jahr zu erwarten."
+    },
+    {
+      "key": "wahrscheinlich",
+      "title": "Wahrscheinlich",
+      "weight": 4,
+      "color": "FFC000",
+      "description": "Mehrmals im Jahr zu erwarten."
+    },
+    {
+      "key": "fast-sicher",
+      "title": "Fast sicher",
+      "weight": 5,
+      "color": "FF0000",
+      "description": "Monatlich oder häufiger, oder der Zustand liegt bereits vor."
+    }
+  ],
+  "risk3": [],
+  "matrix": [
+    {
+      "risk": "1-4",
+      "color": "00B050",
+      "priority": "Niedrig",
+      "sort_order": 1
+    },
+    {
+      "risk": "5-9",
+      "color": "FFFF00",
+      "priority": "Normal",
+      "sort_order": 2
+    },
+    {
+      "risk": "10-14",
+      "color": "FFC000",
+      "priority": "Hoch",
+      "sort_order": 3
+    },
+    {
+      "risk": "15-25",
+      "color": "FF0000",
+      "priority": "Kritisch",
+      "sort_order": 4
+    }
+  ]
+}

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -93,6 +93,10 @@
           note: "Statusmodelle je Modul: Statusliste, Feldfunktionen, Folgeaktionen. Import unter Administration → Statusverwaltung.",
         },
         {
+          name: "Ticketmanagement",
+          note: "Vorgangsarten, Themenfelder, Prioritäten und die Risikobewertung samt Matrix und Formel. Import unter Administration → Ticket-Verwaltung.",
+        },
+        {
           name: "Wiki-Vorlagen",
           note: "Wiki-Pakete, keine Berichte. Import unter Wiki → Importieren.",
         },
@@ -118,6 +122,7 @@
         if (name.startsWith("wiki-")) return "Wiki-Vorlagen";
         if (name.startsWith("category-")) return "Kategorien";
         if (name.startsWith("status-")) return "Status";
+        if (name.startsWith("ticket-config-")) return "Ticketmanagement";
 
         // Alles Übrige ist ein Report-Bundle. V2 (JSON-Datenquelle, Suffix
         // -json-sample) ist der Standard und wird thematisch einsortiert,

--- a/robots.md
+++ b/robots.md
@@ -240,38 +240,41 @@ in calhelp/calServer-yii.
 
 ---
 
-## 0.5) Konfigurationspakete (`calserver.category-package` / `calserver.status-package`) — MUST
+## 0.5) Konfigurationspakete (`calserver.category-package` / `calserver.status-package` / `calserver.ticket-config-package`) — MUST
 
 This repo also hosts **configuration packages** for calServer V2: category
-trees and status models. Like the Prüfplan and Wiki bundles they are a
-**separate bundle class**: NO JasperReports involved, none of the report rules
-(sections 0.1, 1, 2, 6) apply. An AI agent should be able to author a valid
-configuration bundle end-to-end from this section alone.
+trees, status models and the ticket-management setup. Like the Prüfplan and
+Wiki bundles they are a **separate bundle class**: NO JasperReports involved,
+none of the report rules (sections 0.1, 1, 2, 6) apply. An AI agent should be
+able to author a valid configuration bundle end-to-end from this section alone.
 
-**Why they live here and not in the product:** a category tree and a status
-model are editorial content of a laboratory, not product code. They change when
-a lab's scope or process changes, not when calServer ships a release. calServer
-imports; this repo maintains the content.
+**Why they live here and not in the product:** a category tree, a status model
+and a lab's risk scales are editorial content of a laboratory, not product
+code. They change when a lab's scope or process changes, not when calServer
+ships a release. calServer imports; this repo maintains the content.
 
 ### Naming and structure (MUST)
 
-- Folder `CATEGORY-<SLUG>/` or `STATUS-<SLUG>/` (e.g. `CATEGORY-INVENTORY-DAKKS`,
-  `STATUS-CALIBRATION-DAKKS`, `STATUS-REPAIR-DAKKS`); ZIP name is the lowercased
-  form. Never use the `-JSON-SAMPLE` suffix — that triggers the report (APEX)
-  packaging rules and the JRXML assertion.
+- Folder `CATEGORY-<SLUG>/`, `STATUS-<SLUG>/` or `TICKET-CONFIG-<SLUG>/` (e.g.
+  `CATEGORY-INVENTORY-DAKKS`, `STATUS-CALIBRATION-DAKKS`, `STATUS-REPAIR-DAKKS`,
+  `TICKET-CONFIG-DAKKS`); ZIP name is the lowercased form. Never use the
+  `-JSON-SAMPLE` suffix — that triggers the report (APEX) packaging rules and
+  the JRXML assertion.
 - **One package per module.** A status package carries one `type`; a lab that
   only wants the calibration statuses must not have to take the order module
   with it. The four shipped sets (`calibration`, `inventory`, `repair`,
   `booking`) are the pattern for any further one.
 - Required files at the bundle root, and **nothing else**: `manifest.json`,
-  `README.md`, plus `categories.json` (CATEGORY-*) or `statuses.json`
-  (STATUS-*). NO subfolders, NO images, NO `main_reports/`, NO `*.jrxml`.
+  `README.md`, plus `categories.json` (CATEGORY-*), `statuses.json` (STATUS-*)
+  or `ticket-config.json` (TICKET-CONFIG-*). NO subfolders, NO images, NO
+  `main_reports/`, NO `*.jrxml`.
 - The format owner is calServer V2
-  (`laravel/app/Services/Category/CategoryPackageService.php` and
-  `laravel/app/Services/Status/StatusPackageService.php` in
+  (`laravel/app/Services/Category/CategoryPackageService.php`,
+  `laravel/app/Services/Status/StatusPackageService.php` and
+  `laravel/app/Services/Ticket/TicketConfigPackageService.php` in
   calhelp/calServer-yii); the machine-readable manifest schemas are
-  `schema/category-package.schema.json` and `schema/status-package.schema.json`
-  (published to Pages).
+  `schema/category-package.schema.json`, `schema/status-package.schema.json`
+  and `schema/ticket-config-package.schema.json` (published to Pages).
 
 ### Content rules (MUST)
 
@@ -296,7 +299,31 @@ imports; this repo maintains the content.
   factory fields (`database/data/default_field_definitions.json` in
   calhelp/calServer-yii) unless the README explains the prerequisite.
 - Statuses that carry no field rules are allowed and useful; a package whose
-  every status is decoration should say in its README why.
+  every status is decoration should say in its README why. Ticket statuses
+  (`support_tickets`) carry NONE — that module has no field registry, and a
+  field rule on it is reported as a warning on import.
+- **Ticket configuration:** one document carries the whole setup — `types`,
+  `categories`, `priorities`, the scales `risk1`/`risk2`/`risk3`, the `matrix`
+  and `risk` (formula plus `dimension_labels`). Rules that the manifest script
+  enforces, because they are the failure modes that survive an import
+  unnoticed:
+  - Every level needs an integer `weight` >= 1. A level without weight counts
+    as 0 and drags every ticket carrying it down to risk value 0.
+  - `matrix` bands reference a priority by **title**, and that priority MUST be
+    in the same document. A band is `5` or `10-29`, at most 10 characters
+    (the column is `varchar(10)`), and bands MUST cover the whole reachable
+    range 1 … (product of the highest weights of the dimensions the formula
+    uses). Two-method bands under a three-method formula leave everything above
+    25 without colour and without priority.
+  - The formula and `risk3` must agree: `[Risk_3]` in the formula requires a
+    non-empty `risk3` and vice versa.
+  - Ticket **statuses** do NOT belong in this document. They live in the shared
+    status catalogue and ship as a `STATUS-*` package next to it
+    (`STATUS-TICKETS-DAKKS`); the two READMEs point at each other.
+  - `TICKET-CONFIG-DAKKS-3D` is **derived** from `TICKET-CONFIG-DAKKS` by
+    `scripts/build_ticket_config_3d.py`. Never hand-edit it — change the
+    two-method package or the delta in the script and regenerate (`--write`),
+    verify with `--check`. CI runs that check.
 
 ### Manifest (MUST)
 
@@ -316,12 +343,13 @@ imports; this repo maintains the content.
   and a `create_config_zip "<BUNDLE>" "<zip-name>" "<document>"` call (NOT
   `create_zip()` — that stages `main_reports/` and fails without a JRXML).
 - `publish-downloads.yml`: add a `get_last_modified` line plus `README_MAP`
-  and `TITLE_MAP` entries (`Kategorien: <Thema>` / `Status: <Thema>`); no
-  `SCHEMA_MAP`.
+  and `TITLE_MAP` entries (`Kategorien: <Thema>` / `Status: <Thema>` /
+  `Ticketmanagement: <Thema>`); no `SCHEMA_MAP`.
 - Category on the downloads page is automatic: a ZIP name starting with
   `category-` lands in **"Kategorien"**, one starting with `status-` in
-  **"Status"** (`downloads/index.html`, `getCategory()`). Both rules sit above
-  the report rules on purpose — `status-…` would otherwise fall through to the
+  **"Status"**, one starting with `ticket-config-` in **"Ticketmanagement"**
+  (`downloads/index.html`, `getCategory()`). All three rules sit above the
+  report rules on purpose — `status-…` would otherwise fall through to the
   legacy bucket.
 - Downloads-page only: NO `/api/report/<uuid>` upload step, NO
   `release-reports.yml` entry.
@@ -329,9 +357,12 @@ imports; this repo maintains the content.
 ### Verify locally
 
 - `python3 scripts/build_config_manifest.py --check` is green
+- for TICKET-CONFIG-*: `python3 scripts/build_ticket_config_3d.py --check` is
+  green as well
 - `cd <BUNDLE> && zip -r /tmp/<zip-name>.zip .` produces a ZIP that calServer
-  V2 imports as-is (Administration → Kategorien bzw. Statusverwaltung →
-  Paket; permissions `category_import` / `status_import`)
+  V2 imports as-is (Administration → Kategorien, Statusverwaltung bzw.
+  Ticket-Verwaltung → Paket; permissions `category_import` / `status_import` /
+  `support_config_import`)
 
 ---
 

--- a/schema/ticket-config-package.schema.json
+++ b/schema/ticket-config-package.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calhelp.github.io/calServer-reports/schema/ticket-config-package.schema.json",
+  "title": "calServer Ticketmanagement-Paket (calserver.ticket-config-package)",
+  "description": "Manifest eines Ticketmanagement-Pakets: ein ZIP mit ticket-config.json (calserver.ticket-config) und optionalem README.md. Das Manifest listet jeden Paket-Eintrag mit SHA-256-Prüfsumme und ist damit der Manipulationsanker des Formats. Ein Paket trägt die Einrichtung des Ticketmoduls (Vorgangsarten, Kategorien, Prioritäten, die Skalen der bis zu drei Bewertungsebenen, die Risiko-Matrix, die Formel und die Namen der Ebenen), nicht die Tickets und nicht die Ticket-Status — die liegen im gemeinsamen Statuskatalog und haben mit calserver.status-package ihr eigenes Format. Zusätzliche, hier nicht beschriebene Felder sind erlaubt und werden von älteren Lesern ignoriert (Vorwärtskompatibilität); die verbindliche Lese-Semantik gehört calServer V2 (laravel/app/Services/Ticket/TicketConfigPackageService.php).",
+  "type": "object",
+  "required": [
+    "format",
+    "format_version",
+    "name",
+    "document",
+    "files"
+  ],
+  "properties": {
+    "format": {
+      "const": "calserver.ticket-config-package"
+    },
+    "format_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Version des Paketformats. Leser lehnen Versionen oberhalb der eigenen ab, statt unbekannte Inhalte still zu verlieren. Aktuelle Version: 1."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Anzeigename des Pakets. Rein deklarativ: die Einträge tragen ihre Titel in ticket-config.json."
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optionale Kurzbeschreibung (ein Absatz)."
+    },
+    "document": {
+      "type": "object",
+      "required": [
+        "format",
+        "version"
+      ],
+      "description": "Deklarative Angabe zum eingebetteten ticket-config.json, damit Werkzeuge ohne Öffnen der Datei entscheiden können. Beim Import bleibt der Leser die letzte Instanz.",
+      "properties": {
+        "format": {
+          "const": "calserver.ticket-config"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "description": "Abgeleitete Kennzahlen für die Anzeige. Nicht verbindlich — maßgeblich ist ticket-config.json.",
+      "properties": {
+        "types": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "categories": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "priorities": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "risk_levels": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Stufen über alle Bewertungsebenen zusammen."
+        },
+        "matrix": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dimensions": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3,
+          "description": "Zahl der Bewertungsebenen, die die Formel tatsächlich nutzt (zwei oder drei Methoden)."
+        },
+        "formula": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Die Risiko-Formel des Pakets, z. B. [Risk_1] * [Risk_2]."
+        }
+      }
+    },
+    "created_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Zeitpunkt der Paketerstellung (ISO 8601). Provenienz, keine Semantik beim Import."
+    },
+    "generator": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Erzeuger des Pakets, z. B. calserver-reports oder calserver-v2."
+    },
+    "locale": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Sprache der Bezeichnungen im Paket (z. B. de). Die Kataloge sind einsprachig; wer eine andere Sprache braucht, pflegt ein eigenes Paket."
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Jeder Eintrag des Archivs mit Prüfsumme. Fehlt eine gelistete Datei, taucht eine ungelistete auf oder weicht eine Prüfsumme ab, wird das Paket abgelehnt.",
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "sha256",
+          "size_bytes"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^(ticket-config\\.json|README\\.md)$",
+            "description": "Pfad relativ zur Paketwurzel. Erlaubt sind nur ticket-config.json und README.md — ein Ticketmanagement-Paket trägt keine Binärdateien."
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build_config_manifest.py
+++ b/scripts/build_config_manifest.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Manifest-Werkzeug für Konfigurationspakete.
 
-Deckt beide Klassen ab, weil sie dieselbe Bauart haben — ein JSON-Dokument,
+Deckt alle drei Klassen ab, weil sie dieselbe Bauart haben — ein JSON-Dokument,
 ein optionales README, kein Binärinhalt:
 
-  calserver.category-package   CATEGORY-*/categories.json
-  calserver.status-package     STATUS-*/statuses.json
+  calserver.category-package      CATEGORY-*/categories.json
+  calserver.status-package        STATUS-*/statuses.json
+  calserver.ticket-config-package TICKET-CONFIG-*/ticket-config.json
 
 Zwei Modi:
 
@@ -15,7 +16,7 @@ Zwei Modi:
       (name, description, created_at, generator, locale) bleiben erhalten.
       sha256-Werte werden NIE von Hand gepflegt — immer über diesen Modus.
 
-  --check [BUNDLE_DIR ...]   (Default; ohne Argumente: alle CATEGORY-*/STATUS-*)
+  --check [BUNDLE_DIR ...]   (Default; ohne Argumente: alle Konfigurationspakete)
       Validiert jedes Manifest gegen das zugehörige Schema (Paket `jsonschema`,
       falls installiert; sonst strukturelle Minimalprüfung), rechnet alle
       sha256 nach, prüft Vollständigkeit in beide Richtungen (jede Datei
@@ -30,12 +31,19 @@ Zwei Modi:
         Folgeaktionen und Zeitvariablen verweisen auf Status des Pakets,
         Feldfunktion nennt ein Feld.
 
+        Ticketmanagement — Titel je Liste eindeutig, jede Bewertungsstufe mit
+        ganzzahligem Gewicht, Formel arithmetisch und mit mindestens einer
+        Ebene, dritte Ebene und Formel stimmen überein, Matrixbänder eindeutig
+        und lückenlos über den erreichbaren Wertebereich, jede Matrixzeile
+        verweist auf eine Priorität desselben Pakets.
+
       Exit 1 bei Abweichung.
 
 Die verbindliche Lese-Semantik gehört calServer V2
-(laravel/app/Services/Category/CategoryPackageService.php bzw.
-laravel/app/Services/Status/StatusPackageService.php in calhelp/calServer-yii);
-dieses Skript hält die Bundles dazu kompatibel.
+(laravel/app/Services/Category/CategoryPackageService.php,
+laravel/app/Services/Status/StatusPackageService.php bzw.
+laravel/app/Services/Ticket/TicketConfigPackageService.php in
+calhelp/calServer-yii); dieses Skript hält die Bundles dazu kompatibel.
 """
 
 from __future__ import annotations
@@ -43,6 +51,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -60,6 +69,18 @@ KINDS = {
         "schema": "category-package.schema.json",
         "collection": "categories",
         "types": ("inventory", "calibration", "repair", "booking"),
+    },
+    "ticket-config": {
+        # Vor "status" bewusst nicht noetig (kein gemeinsamer Praefix), aber
+        # eigene Klasse: das Dokument traegt keine Sammlung gleichartiger
+        # Eintraege, sondern eine ganze Einrichtung.
+        "prefix": "TICKET-CONFIG-",
+        "package_format": "calserver.ticket-config-package",
+        "document_format": "calserver.ticket-config",
+        "document_name": "ticket-config.json",
+        "schema": "ticket-config-package.schema.json",
+        "collection": "types",
+        "types": (),
     },
     "status": {
         "prefix": "STATUS-",
@@ -137,7 +158,42 @@ def file_entries(bundle: Path, spec: dict) -> list[dict]:
     return entries
 
 
+# Die drei Bewertungsebenen des Ticketmanagements (Reihenfolge = Formel-Token).
+RISK_DIMENSIONS = ("risk1", "risk2", "risk3")
+
+# Dieselbe Pruefung, die calServer V2 auf die Formel anwendet.
+FORMULA_PATTERN = re.compile(r"^[\s\d+\-*/().]*(\[Risk_[123]\][\s\d+\-*/().]*)+$", re.IGNORECASE)
+
+BAND_PATTERN = re.compile(r"^\d+(-\d+)?$")
+
+
+def ticket_config_summary(document: dict) -> dict:
+    """Kennzahlen fuer das Manifest eines Ticketmanagement-Pakets."""
+    formula = document.get("risk", {}).get("formula") if isinstance(document.get("risk"), dict) else None
+
+    def count(key: str) -> int:
+        value = document.get(key)
+        return len(value) if isinstance(value, list) else 0
+
+    dimensions = 0
+    if isinstance(formula, str):
+        dimensions = sum(1 for index in (1, 2, 3) if f"[risk_{index}]" in formula.lower())
+
+    return {
+        "types": count("types"),
+        "categories": count("categories"),
+        "priorities": count("priorities"),
+        "risk_levels": sum(count(dimension) for dimension in RISK_DIMENSIONS),
+        "matrix": count("matrix"),
+        "dimensions": dimensions,
+        "formula": formula if isinstance(formula, str) else None,
+    }
+
+
 def content_summary(document: dict, spec: dict, kind: str) -> dict:
+    if kind == "ticket-config":
+        return ticket_config_summary(document)
+
     items = document.get(spec["collection"], [])
     items = items if isinstance(items, list) else []
 
@@ -333,6 +389,224 @@ def check_statuses(document: dict, spec: dict, bundle: Path, problems: list[str]
             )
 
 
+def check_ticket_config(document: dict, bundle: Path, problems: list[str]) -> None:
+    """Die Einrichtung eines Ticketmoduls — ein Dokument, mehrere Listen.
+
+    Anders als Kategorie- und Statuspaket traegt dieses Dokument Teile, die
+    aufeinander zeigen: die Matrix auf die Prioritaeten, die Formel auf die
+    Bewertungsebenen. Genau dort entstehen die Fehler, die beim Import nicht
+    auffallen — ein Paket mit dritter Ebene und Baendern bis 25 laesst jedes
+    Ticket oberhalb von 25 ohne Farbe und ohne Prioritaet.
+    """
+    priorities = check_ticket_lists(document, bundle, problems)
+    max_weights = check_ticket_dimensions(document, bundle, problems)
+    formula = check_ticket_formula(document, bundle, problems)
+
+    reachable = 1
+    used_dimensions = []
+    for index, dimension in enumerate(RISK_DIMENSIONS, start=1):
+        if formula is not None and f"[risk_{index}]" not in formula.lower():
+            continue
+        used_dimensions.append(dimension)
+        reachable *= max_weights.get(dimension, 0)
+
+    check_ticket_matrix(document, bundle, problems, priorities, reachable if used_dimensions else 0)
+
+
+def check_ticket_lists(document: dict, bundle: Path, problems: list[str]) -> set[str]:
+    """Titel je Liste eindeutig; liefert die Prioritaetstitel zurueck."""
+    priorities: set[str] = set()
+
+    for key in ("types", "categories", "priorities", *RISK_DIMENSIONS):
+        entries = document.get(key)
+        if entries is None:
+            continue
+
+        if not isinstance(entries, list):
+            problems.append(f"{bundle.name}: {key} ist keine Liste")
+            continue
+
+        seen: set[str] = set()
+        for index, entry in enumerate(entries, start=1):
+            if not isinstance(entry, dict):
+                problems.append(f"{bundle.name}: Eintrag {index} in {key} ist kein Objekt")
+                continue
+
+            title = entry.get("title")
+            if not isinstance(title, str) or title.strip() == "":
+                problems.append(f"{bundle.name}: Eintrag {index} in {key} hat keinen title")
+                continue
+
+            # calServer erkennt einen Eintrag am Titel wieder, ohne Ruecksicht
+            # auf Gross- und Kleinschreibung — zweimal derselbe Titel waere im
+            # Ziel eine Kollision.
+            folded = title.strip().casefold()
+            if folded in seen:
+                problems.append(f"{bundle.name}: Titel doppelt in {key}: {title!r}")
+            seen.add(folded)
+
+            if len(title) > 125:
+                problems.append(f"{bundle.name}: Titel laenger als 125 Zeichen in {key}: {title!r}")
+
+            if key == "priorities":
+                priorities.add(folded)
+
+    for key in ("types", "categories", "priorities"):
+        if not isinstance(document.get(key), list) or document.get(key) == []:
+            problems.append(f"{bundle.name}: {key} fehlt oder ist leer")
+
+    return priorities
+
+
+def check_ticket_dimensions(document: dict, bundle: Path, problems: list[str]) -> dict[str, int]:
+    """Jede Stufe braucht ein ganzzahliges Gewicht; liefert das je Ebene groesste."""
+    max_weights: dict[str, int] = {}
+
+    for dimension in RISK_DIMENSIONS:
+        entries = document.get(dimension)
+        if not isinstance(entries, list):
+            continue
+
+        highest = 0
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+
+            weight = entry.get("weight")
+            title = entry.get("title")
+
+            # Ohne Gewicht rechnet die Stufe als 0 und zieht jedes Ticket, das
+            # sie traegt, auf den Risikowert 0 — das ist keine Bewertung mehr.
+            if not isinstance(weight, int) or isinstance(weight, bool) or weight < 1:
+                problems.append(
+                    f"{bundle.name}: {dimension}-Stufe {title!r} hat kein ganzzahliges Gewicht >= 1"
+                )
+                continue
+
+            highest = max(highest, weight)
+
+        max_weights[dimension] = highest
+
+    return max_weights
+
+
+def check_ticket_formula(document: dict, bundle: Path, problems: list[str]) -> str | None:
+    risk = document.get("risk")
+    if not isinstance(risk, dict):
+        problems.append(f"{bundle.name}: risk fehlt oder ist kein Objekt")
+        return None
+
+    formula = risk.get("formula")
+    if not isinstance(formula, str) or formula.strip() == "":
+        problems.append(f"{bundle.name}: risk.formula fehlt")
+        return None
+
+    formula = formula.strip()
+    if not FORMULA_PATTERN.match(formula):
+        problems.append(
+            f"{bundle.name}: risk.formula {formula!r} ist unbrauchbar — erlaubt sind [Risk_1], "
+            "[Risk_2], [Risk_3], Zahlen, + - * / und Klammern, und mindestens eine Ebene"
+        )
+        return None
+
+    # Die dritte Ebene und die Formel muessen dasselbe sagen: eine Liste, die
+    # die Formel nicht nutzt, wird am Ticket nie abgefragt, und eine Formel
+    # ohne Liste laesst jede Bewertung unvollstaendig.
+    uses_third = "[risk_3]" in formula.lower()
+    has_third = isinstance(document.get("risk3"), list) and document.get("risk3") != []
+
+    if uses_third and not has_third:
+        problems.append(f"{bundle.name}: Die Formel nutzt [Risk_3], aber risk3 ist leer")
+    if has_third and not uses_third:
+        problems.append(f"{bundle.name}: risk3 traegt Stufen, die Formel nutzt [Risk_3] aber nicht")
+
+    labels = risk.get("dimension_labels")
+    if labels is not None and not isinstance(labels, dict):
+        problems.append(f"{bundle.name}: risk.dimension_labels ist kein Objekt")
+    elif isinstance(labels, dict):
+        for key in labels:
+            if key not in RISK_DIMENSIONS:
+                problems.append(f"{bundle.name}: unbekannte Bewertungsebene in dimension_labels: {key!r}")
+
+    return formula
+
+
+def check_ticket_matrix(
+    document: dict,
+    bundle: Path,
+    problems: list[str],
+    priorities: set[str],
+    reachable: int,
+) -> None:
+    matrix = document.get("matrix")
+    if not isinstance(matrix, list) or matrix == []:
+        problems.append(f"{bundle.name}: matrix fehlt oder ist leer")
+        return
+
+    covered: set[int] = set()
+    seen: set[str] = set()
+
+    for index, row in enumerate(matrix, start=1):
+        if not isinstance(row, dict):
+            problems.append(f"{bundle.name}: Eintrag {index} in matrix ist kein Objekt")
+            continue
+
+        band = row.get("risk")
+        if isinstance(band, int):
+            band = str(band)
+
+        if not isinstance(band, str) or not BAND_PATTERN.match(band.strip()):
+            problems.append(
+                f"{bundle.name}: Eintrag {index} in matrix hat kein Band (Einzelwert wie \"5\" "
+                f"oder Bereich wie \"10-29\"): {row.get('risk')!r}"
+            )
+            continue
+
+        band = band.strip()
+        # `support_risks.risk` fasst zehn Zeichen; ein laengeres Band kaeme
+        # gekappt in der Datenbank an und traefe dann ein anderes Intervall.
+        if len(band) > 10:
+            problems.append(f"{bundle.name}: Band laenger als 10 Zeichen: {band!r}")
+
+        if band in seen:
+            problems.append(f"{bundle.name}: Band doppelt in matrix: {band!r}")
+        seen.add(band)
+
+        low, _, high = band.partition("-")
+        low_value = int(low)
+        high_value = int(high) if high else low_value
+
+        if high_value < low_value:
+            problems.append(f"{bundle.name}: Band {band!r} laeuft rueckwaerts")
+            continue
+
+        covered.update(range(low_value, high_value + 1))
+
+        priority = row.get("priority")
+        if priority is None:
+            continue
+
+        if not isinstance(priority, str) or priority.strip() == "":
+            problems.append(f"{bundle.name}: Band {band!r} hat eine leere Prioritaet")
+        elif priority.strip().casefold() not in priorities:
+            # Beim Import waere das nur eine Warnung; in einem gepflegten Paket
+            # ist es ein Tippfehler, denn die Prioritaeten stehen daneben.
+            problems.append(
+                f"{bundle.name}: Band {band!r} verweist auf die Prioritaet {priority!r}, "
+                "die das Paket nicht mitbringt"
+            )
+
+    if reachable <= 0:
+        return
+
+    missing = [value for value in range(1, reachable + 1) if value not in covered]
+    if missing:
+        problems.append(
+            f"{bundle.name}: die Matrix deckt den erreichbaren Wertebereich 1 bis {reachable} "
+            f"nicht ab — es fehlen {len(missing)} Werte, erster: {missing[0]}"
+        )
+
+
 def check_field_rules(rules: object, label: str, problems: list[str]) -> None:
     if rules is None:
         return
@@ -435,6 +709,8 @@ def check_bundle(bundle: Path) -> list[str]:
 
     if kind == "category":
         check_categories(document, spec, bundle, problems)
+    elif kind == "ticket-config":
+        check_ticket_config(document, bundle, problems)
     else:
         check_statuses(document, spec, bundle, problems)
 

--- a/scripts/build_ticket_config_3d.py
+++ b/scripts/build_ticket_config_3d.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Derive TICKET-CONFIG-DAKKS-3D from the two-method TICKET-CONFIG-DAKKS.
+
+Beide Pakete richten dasselbe Ticketmanagement für ein akkreditiertes Labor
+ein. Der Unterschied ist allein die Bewertungssystematik: zwei Methoden
+(Auswirkung × Wahrscheinlichkeit, 1…25) gegen drei (zusätzlich Erkennbarkeit,
+1…125, die Risikoprioritätszahl der FMEA).
+
+Alles andere — Typen, Kategorien, Prioritäten und die Skalen der ersten beiden
+Ebenen — ist in beiden Paketen identisch und wird deshalb nicht zweimal
+gepflegt, sondern hier abgeleitet. Ein Kategoriebaum, der in der 3D-Fassung
+still hinterherhinkt, wäre sonst genau die Art Abweichung, die niemand bemerkt,
+bis ein Labor beide Pakete vergleicht.
+
+Erlaubte Abweichungen (nichts sonst):
+  1. `risk.formula` → [Risk_1] * [Risk_2] * [Risk_3]
+  2. `risk3` → die Skala der Erkennbarkeit (1…5)
+  3. `matrix` → die vier Bänder über 1…125 statt über 1…25
+
+Usage:
+  python3 scripts/build_ticket_config_3d.py --write   # Paket neu erzeugen
+  python3 scripts/build_ticket_config_3d.py --check   # committete Fassung prüfen
+
+Danach immer das Manifest nachziehen:
+  python3 scripts/build_config_manifest.py --write TICKET-CONFIG-DAKKS-3D
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SOURCE = ROOT / "TICKET-CONFIG-DAKKS" / "ticket-config.json"
+TARGET = ROOT / "TICKET-CONFIG-DAKKS-3D" / "ticket-config.json"
+
+FORMULA = "[Risk_1] * [Risk_2] * [Risk_3]"
+
+# Die dritte Ebene: Wie früh fällt die Sache auf? Ein Fehler, den erst der
+# Ringversuch zeigt, ist gefährlicher als derselbe Fehler, den die
+# Plausibilitätsprüfung am Arbeitsplatz abfängt — das ist der ganze Sinn der
+# dritten Methode, und deshalb steigt das Gewicht mit sinkender Erkennbarkeit.
+RISK3 = [
+    {
+        "key": "sofort-erkennbar",
+        "title": "Sofort erkennbar",
+        "weight": 1,
+        "color": "00B050",
+        "description": "Fällt bei der Arbeit selbst auf: Plausibilitätsgrenze, Zwischenprüfung, Warnung im System.",
+    },
+    {
+        "key": "leicht-erkennbar",
+        "title": "Leicht erkennbar",
+        "weight": 2,
+        "color": "92D050",
+        "description": "Fällt bei der fachlichen Freigabe des Kalibrierscheins auf (Vier-Augen-Prinzip).",
+    },
+    {
+        "key": "erkennbar",
+        "title": "Erkennbar",
+        "weight": 3,
+        "color": "FFFF00",
+        "description": "Fällt über Kontrollkarte, Wiederholmessung oder internes Audit auf, also Wochen bis Monate später.",
+    },
+    {
+        "key": "schwer-erkennbar",
+        "title": "Schwer erkennbar",
+        "weight": 4,
+        "color": "FFC000",
+        "description": "Fällt erst beim Ringversuch, bei der Rekalibrierung des Normals oder in der Begutachtung auf.",
+    },
+    {
+        "key": "kaum-erkennbar",
+        "title": "Kaum erkennbar",
+        "weight": 5,
+        "color": "FF0000",
+        "description": "Fällt nur durch eine Kundenreklamation auf oder bleibt unentdeckt.",
+    },
+]
+
+# Bänder über das Produkt dreier Skalen (1…125). Dieselben vier Stufen und
+# dieselben Prioritäten wie in der Zwei-Methoden-Fassung, nur anders geschnitten.
+MATRIX = [
+    {"risk": "1-9", "color": "00B050", "priority": "Niedrig", "sort_order": 1},
+    {"risk": "10-29", "color": "FFFF00", "priority": "Normal", "sort_order": 2},
+    {"risk": "30-59", "color": "FFC000", "priority": "Hoch", "sort_order": 3},
+    {"risk": "60-125", "color": "FF0000", "priority": "Kritisch", "sort_order": 4},
+]
+
+
+def build() -> str:
+    document = json.loads(SOURCE.read_text(encoding="utf-8"))
+
+    document["risk"]["formula"] = FORMULA
+    document["risk3"] = RISK3
+    document["matrix"] = MATRIX
+
+    return json.dumps(document, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "--check"
+    generated = build()
+
+    if mode == "--write":
+        TARGET.parent.mkdir(parents=True, exist_ok=True)
+        TARGET.write_text(generated, encoding="utf-8")
+        print(f"wrote {TARGET.relative_to(ROOT)}")
+        print("Manifest nachziehen: python3 scripts/build_config_manifest.py --write TICKET-CONFIG-DAKKS-3D")
+        return 0
+
+    if mode == "--check":
+        if not TARGET.exists():
+            print(f"MISSING {TARGET.relative_to(ROOT)}")
+            return 1
+
+        if TARGET.read_text(encoding="utf-8") != generated:
+            print(f"DIVERGES {TARGET.relative_to(ROOT)} (mit --write neu erzeugen)")
+            return 1
+
+        print(f"ok {TARGET.relative_to(ROOT)}")
+        return 0
+
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Neue Bundle-Klasse `calserver.ticket-config-package` (`TICKET-CONFIG-*`) plus die passenden DAkkS-Startvorlagen. Gegenstück im Produkt: calhelp/calServer-yii (Branch `claude/ticketmanagement-v2-dakks-bym05z`), das dieses Format liest und schreibt.

## Warum

Eine frische calServer-Installation hat ein leeres Ticketmodul. Die eingebaute Vorlage im Produkt legt Skalen und Matrix an, aber keine Vorgangsarten, keine Themenfelder und keine Prioritäten. Ein Labor, das seine Risiken und Chancen nach 8.5 führen will, fängt damit trotzdem bei der Hälfte an. Die fehlende Hälfte ist redaktioneller Inhalt eines Labors, kein Produktcode, und gehört deshalb hierher.

## Was drin ist

| Bundle | Inhalt |
|--------|--------|
| `TICKET-CONFIG-DAKKS` | Vollständige Einrichtung, Bewertung mit zwei Methoden (Auswirkung × Wahrscheinlichkeit, 1…25) |
| `TICKET-CONFIG-DAKKS-3D` | Dieselbe Einrichtung, Bewertung mit drei Methoden (zusätzlich Erkennbarkeit, 1…125) |
| `STATUS-TICKETS-DAKKS` | Der Ablauf im Statuskatalog: Neu → Bewertet → Maßnahme geplant → In Umsetzung → Wirksamkeit prüfen → Abgeschlossen, dazu „Kein Handlungsbedarf" |

Beide Ticketmanagement-Pakete bringen 8 Vorgangsarten (Risiko, Chance, Abweichung, Beschwerde, Korrekturmaßnahme, Verbesserung, Auditfeststellung, Änderung), 20 Themenfelder entlang der Normabschnitte 4 bis 8.9 und 4 Prioritäten mit.

Drei Entscheidungen, die im Diff nicht selbsterklärend sind:

- **Ein Dokument statt vier Einzelpaketen.** Die Matrix zeigt auf Prioritäten, die Formel entscheidet, welche Ebenen abgefragt werden, und ein Band `10-29` ergibt nur Sinn zu Skalen, deren Produkt dort landet. Getrennte Pakete wären vier Gelegenheiten, eine halbe Einrichtung zu importieren.
- **Ticket-Status bleiben draußen.** Sie liegen in der geteilten `status`-Tabelle, für die es mit `calserver.status-package` bereits ein Format samt Werkzeug gibt. Zwei Formate für dieselbe Tabelle wären zwei Wahrheiten — daher `STATUS-TICKETS-DAKKS` daneben.
- **Die 3D-Fassung wird abgeleitet, nicht gepflegt.** `scripts/build_ticket_config_3d.py` erzeugt sie aus der 2D-Fassung; abweichen dürfen nur Formel, dritte Skala und Matrixbänder. Sonst hinkt ein Kategoriebaum in einer der beiden Fassungen still hinterher.

## Prüfungen

`scripts/build_config_manifest.py` kennt die neue Klasse und prüft inhaltlich, was einen Import unbemerkt passiert:

- Bewertungsstufe ohne ganzzahliges Gewicht (rechnet als 0 und zieht jedes Ticket auf Risikowert 0)
- Matrixbänder, die den erreichbaren Wertebereich nicht abdecken — der Fall „2D-Bänder unter 3D-Formel" lässt alles über 25 ohne Farbe und ohne Priorität
- Matrixzeile, die auf eine Priorität zeigt, die das Paket nicht mitbringt
- Formel und dritte Ebene, die sich widersprechen
- Bänder rückwärts, doppelt oder länger als die Spalte (`varchar(10)`)

Alle sieben Wächter sind gegen mutierte Kopien der Pakete gegengeprüft; jeder schlägt an. `validate-reports.yml` fährt zusätzlich `build_ticket_config_3d.py --check`.

Beide Pakete wurden gegen calServer V2 tatsächlich importiert (Feature-Testlauf gegen die echten Dateien): 8 Typen, 20 Kategorien, 4 Prioritäten, 10 bzw. 15 Bewertungsstufen, 4 Matrixbänder, jede Zeile mit aufgelöster Priorität, null Warnungen.

## Nicht enthalten

Fristen und Zuständigkeiten je Risikoband setzt calServer nicht durch — das Produkt rechnet den Wert, färbt das Ticket und setzt die Priorität. Die READMEs schlagen die Eskalationsregeln vor, verbindlich wird das über die Verfahrensanweisung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2GXNMbZmsZuaWLL9RRBTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2GXNMbZmsZuaWLL9RRBTf)_