### PR TITLE
feat(leihschein): Standortblock raus, er trug den Namen des Buchenden

### DIFF
--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -52,7 +52,7 @@ setzt sie nicht auf `x=0`, sonst läuft die Lochmarke bei 148,5 mm hindurch.
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/location-json-sample.jrxml` | Hauptbericht: Anschriftfeld mit Rücksendeangabe, Informationsblock rechts (Kunden-Nr., Ansprechpartner, Telefon, Versanddatum, Rückgabe, Status, Sendungsnummer), Betreffzeile, Entleiher-Block, Versandhinweis, Prüfvermerk, Standortblock (`location_1..5`), Falzmarken, Seiten-Footer |
+| `main_reports/location-json-sample.jrxml` | Hauptbericht: Anschriftfeld mit Rücksendeangabe, Informationsblock rechts (Kunden-Nr., Ansprechpartner, Telefon, Versanddatum, Rückgabe, Status, Sendungsnummer), Betreffzeile, Entleiher-Block, Versandhinweis, Prüfvermerk, Falzmarken, Seiten-Footer |
 | `subreports/devices.jrxml` | Sendungsinhalt als Abhakliste — je Gerät eine Zeile mit Ankreuzfeld, Positionsnummer und nächster Kalibrierung; Spaltenköpfe wiederholen sich auf Folgeseiten |
 | `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `location-report` **v1.2**) |
 | `main_reports/location-json-sample_adapter.xml` | Mitgelieferter Jaspersoft-Studio-**JSON-Data-Adapter** auf `sample-data.json` — macht die Vorschau turnkey (siehe „Vorschau ohne Backend") |
@@ -71,6 +71,11 @@ setzt sie nicht auf `x=0`, sonst läuft die Lochmarke bei 148,5 mm hindurch.
 - **Sendungsdaten.** Sendungsverfolgungsnummer im Informationsblock,
   Versandhinweis (Bemerkung der Buchung) über der Tabelle. Beide fehlen
   spurlos, wenn sie leer sind.
+- **Kein Standortblock.** `location_1..5` sind auf einer Leihe interne
+  Platzierungsfelder, und eines davon ist auf vielen Anlagen als
+  `[CURRENT_USER]` konfiguriert — unter „Standort" stand dann der Name des
+  Buchenden. Der Contract liefert die Felder weiter, das Referenz-Layout
+  druckt sie nicht.
 
 ## Datenanbindung
 
@@ -87,14 +92,18 @@ setzt sie nicht auf `x=0`, sonst läuft die Lochmarke bei 148,5 mm hindurch.
   `subreports/devices.jrxml`. Ein Set (Koffer) wird als **ein** Objekt
   verliehen und auf **einem** Schein quittiert, also stehen seine Teile mit
   darauf. `device` bleibt daneben bestehen, damit eine gegen v1.0 geschriebene
-  Vorlage weiterläuft.
+  Vorlage weiterläuft. Welche Geräte zum Koffer gehören, beantwortet
+  serverseitig ein einziger Resolver über die Elternkette — bis August 2026
+  hing das an einem Pfad-Cache, und auf Anlagen mit importierten Beständen kam
+  der Koffer als eine Position auf dem Papier an.
 - **Sendungsnummer und Bemerkung** liest das Backend, nicht das Template: Der
   Block `shipping` kommt gefüllt an, unabhängig davon, unter welchem `api_name`
   die Installation die beiden Felder führt (Details unten).
 - `location_1..5` und `status` liefern **lesbaren Text**, keine uIDs: Ist ein
   Standortfeld als `[CURRENT_USER]` konfiguriert, hält die Spalte eine
-  Benutzer-uID — der Bericht bekommt den Namen. Genauso wird der Status-uID zum
-  Status-Titel.
+  Benutzer-uID — der Datensatz trägt den Namen. Genauso wird der Status-uID zum
+  Status-Titel. (Das Referenz-Layout druckt `location_1..5` nicht, siehe oben —
+  ein eigenes Layout bekommt sie aufbereitet.)
 - Die Lieferadresse (`delivery_customer`) fällt **serverseitig** auf den
   Kunden zurück, wenn kein eigener Lieferkunde hinterlegt ist — das Template
   braucht keine Fallback-Logik.

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
@@ -24,6 +24,13 @@
   Wer auf Form A umstellen muss (Anschriftfeld ab 27 mm, kurzer Briefkopf),
   ändert genau eine Zahl — y=116 wird zu y=64.
 
+  Was NICHT drauf steht: die Standortfelder location_1..5. Auf einer Leihe sind
+  das interne Platzierungsangaben, und eines davon ist auf vielen Anlagen als
+  [CURRENT_USER] konfiguriert — auf dem Papier stand dann der Name des
+  Buchenden unter der Überschrift „Standort". Für den Empfänger einer Sendung
+  ist beides ohne Wert. Der Contract liefert die Felder weiter; wer sie braucht,
+  bindet sie im eigenen Layout.
+
   Der Absender kommt NICHT aus dem Datensatz, sondern aus den
   company_*-Berichtsvariablen (dieselben, die der Auftragsbeleg nutzt); ohne
   gepflegte Variablen bleibt die Rücksendeangabe leer und der Umschlag trägt sie
@@ -74,11 +81,6 @@
 		<parameterDescription><![CDATA[Falz- und Lochmarken am linken Rand drucken (105 mm, 148,5 mm, 210 mm). "0" = aus, z. B. bei vorgedrucktem Briefpapier, das sie schon trägt.]]></parameterDescription>
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<field name="location_1" class="java.lang.String"><fieldDescription><![CDATA[location.location_1]]></fieldDescription></field>
-	<field name="location_2" class="java.lang.String"><fieldDescription><![CDATA[location.location_2]]></fieldDescription></field>
-	<field name="location_3" class="java.lang.String"><fieldDescription><![CDATA[location.location_3]]></fieldDescription></field>
-	<field name="location_4" class="java.lang.String"><fieldDescription><![CDATA[location.location_4]]></fieldDescription></field>
-	<field name="location_5" class="java.lang.String"><fieldDescription><![CDATA[location.location_5]]></fieldDescription></field>
 	<field name="location_date" class="java.lang.String"><fieldDescription><![CDATA[location.location_date]]></fieldDescription></field>
 	<field name="location_time" class="java.lang.String"><fieldDescription><![CDATA[location.location_time]]></fieldDescription></field>
 	<field name="location_status" class="java.lang.String"><fieldDescription><![CDATA[location.status]]></fieldDescription></field>
@@ -248,7 +250,7 @@
 		</band>
 	</title>
 	<detail>
-		<band height="210">
+		<band height="112">
 			<!--
 			  Versandhinweis (Bemerkung der Buchung). Kollabiert vollständig, wenn
 			  keiner gepflegt ist — alles darunter schwimmt (positionType Float).
@@ -294,31 +296,6 @@
 			<staticText><reportElement style="Small" positionType="Float" x="26" y="87" width="280" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
 			<staticText><reportElement style="Label" positionType="Float" x="341" y="87" width="40" height="12"/><text><![CDATA[Datum]]></text></staticText>
 			<line><reportElement positionType="Float" x="381" y="98" width="180" height="1"/></line>
-			<!--
-			  Standortangaben der Leihe. Rein interne Felder — der Block
-			  verschwindet, wenn keines gepflegt ist, statt einen Kasten aus
-			  Beschriftungen ohne Werte auf ein Kundendokument zu setzen.
-			-->
-			<frame>
-				<reportElement positionType="Float" x="12" y="112" width="549" height="66" isRemoveLineWhenBlank="true">
-					<printWhenExpression><![CDATA[($F{location_1} != null && !$F{location_1}.trim().isEmpty())
-	|| ($F{location_2} != null && !$F{location_2}.trim().isEmpty())
-	|| ($F{location_3} != null && !$F{location_3}.trim().isEmpty())
-	|| ($F{location_4} != null && !$F{location_4}.trim().isEmpty())
-	|| ($F{location_5} != null && !$F{location_5}.trim().isEmpty())]]></printWhenExpression>
-				</reportElement>
-				<staticText><reportElement style="SectionTitle" x="0" y="0" width="549" height="14"/><text><![CDATA[Standort]]></text></staticText>
-				<staticText><reportElement style="Label" x="0" y="18" width="130" height="13"/><text><![CDATA[Standort 1]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="18" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_1}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="290" y="18" width="120" height="13"/><text><![CDATA[Standort 4]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="18" width="139" height="13"/><textFieldExpression><![CDATA[$F{location_4}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="34" width="130" height="13"/><text><![CDATA[Standort 2]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="34" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_2}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="290" y="34" width="120" height="13"/><text><![CDATA[Standort 5]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="410" y="34" width="139" height="13"/><textFieldExpression><![CDATA[$F{location_5}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="50" width="130" height="13"/><text><![CDATA[Standort 3]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="130" y="50" width="150" height="13"/><textFieldExpression><![CDATA[$F{location_3}]]></textFieldExpression></textField>
-			</frame>
 		</band>
 	</detail>
 	<pageFooter>


### PR DESCRIPTION
`location_1..5` sind auf einer Leihe interne Platzierungsfelder, und eines davon ist auf vielen Anlagen als `[CURRENT_USER]` konfiguriert. Auf dem Papier stand unter der Überschrift „Standort" deshalb der Name des Buchenden, daneben vier leere Zeilen. Für den Empfänger einer Sendung ist beides ohne Wert.

Der Block fällt aus dem Referenz-Layout. Der Contract liefert die Felder unverändert weiter, inklusive der serverseitigen Auflösung der Benutzer-uID auf den Namen — wer sie braucht, bindet sie im eigenen Layout.

## Was noch fehlte

Der Koffer stand als **eine** Position auf dem Schein, obwohl der Dialog 17 Teile versprochen hatte. Das lag nicht am Template: Die Set-Zugehörigkeit kam aus einem Cache, den importierte Bestände nicht tragen. Behoben in [calhelp/calServer-yii#3769](https://github.com/calhelp/calServer-yii/pull/3769) — dieses Bundle brauchte dafür keine Änderung, `devices[]` war schon richtig gebunden.

## Geprüft

Gegen JasperReports 6.20.6 kompiliert, aus dem Beispieldatensatz gefüllt und als PDF gerendert. `scripts/check_parameters_manifest.py` und `scripts/check_jasper_version.sh` sind grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QS4CJuoK9BgaFqrKTR256R)_