### PR TITLE
feat(free-delivery): Referenz-Bundle für den freien Versandschein (V2)

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -264,6 +264,16 @@ jobs:
             PRICE-LIST-JSON-SAMPLE/parameters.json
           if-no-files-found: error
 
+      - name: Upload FREE-DELIVERY-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FREE-DELIVERY-JSON-SAMPLE
+          path: |
+            FREE-DELIVERY-JSON-SAMPLE/main_reports
+            FREE-DELIVERY-JSON-SAMPLE/subreports
+            FREE-DELIVERY-JSON-SAMPLE/parameters.json
+          if-no-files-found: error
+
       # Konfigurationspakete (calserver.category-package /
       # calserver.status-package / calserver.ticket-config-package,
       # robots.md §0.5): eigene Bundle-Klasse ohne JRXML, der ganze Ordner ist
@@ -599,6 +609,7 @@ jobs:
           create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"
           create_zip "LOCATION-JSON-SAMPLE" "location-json-sample"
           create_zip "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
+          create_zip "FREE-DELIVERY-JSON-SAMPLE" "free-delivery-json-sample"
 
 
       - name: Upload report ZIPs as artifact

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -111,6 +111,7 @@ jobs:
           get_last_modified "REPAIR-JSON-SAMPLE" "repair-json-sample"
           get_last_modified "LOCATION-JSON-SAMPLE" "location-json-sample"
           get_last_modified "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
+          get_last_modified "FREE-DELIVERY-JSON-SAMPLE" "free-delivery-json-sample"
           get_last_modified "CATEGORY-INVENTORY-DAKKS" "category-inventory-dakks"
           get_last_modified "STATUS-CALIBRATION-DAKKS" "status-calibration-dakks"
           get_last_modified "STATUS-INVENTORY-DAKKS" "status-inventory-dakks"
@@ -225,6 +226,7 @@ jobs:
               "repair-json-sample":                 "REPAIR-JSON-SAMPLE/README.md",
               "location-json-sample":               "LOCATION-JSON-SAMPLE/README.md",
               "price-list-json-sample":             "PRICE-LIST-JSON-SAMPLE/README.md",
+              "free-delivery-json-sample":          "FREE-DELIVERY-JSON-SAMPLE/README.md",
               "pruefplan-fluke-23":                 "PRUEFPLAN-FLUKE-23/README.md",
               "pruefplan-messschieber-150mm":       "PRUEFPLAN-MESSSCHIEBER-150MM/README.md",
               "wiki-iso-17025":                     "WIKI-ISO-17025/README.md",
@@ -268,6 +270,7 @@ jobs:
               "repair-json-sample":                 "Reparaturbericht",
               "location-json-sample":               "Standort-/Leihbericht",
               "price-list-json-sample":             "Preisliste",
+              "free-delivery-json-sample":          "Versandschein (ohne Auftrag)",
               "pruefplan-fluke-23":                 "Prüfplan: Fluke 23 Series II mit Fluke 5520A",
               "pruefplan-messschieber-150mm":       "Prüfplan: Messschieber 150 mm mit Endmaßsatz",
               "wiki-iso-17025":                     "Wiki: QM-Handbuch nach ISO/IEC 17025 (Startvorlage)",

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -136,6 +136,7 @@ jobs:
           create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"
           create_zip "LOCATION-JSON-SAMPLE" "location-json-sample"
           create_zip "PRICE-LIST-JSON-SAMPLE" "price-list-json-sample"
+          create_zip "FREE-DELIVERY-JSON-SAMPLE" "free-delivery-json-sample"
 
       - name: Determine release metadata
         id: release_meta

--- a/FREE-DELIVERY-JSON-SAMPLE/README.md
+++ b/FREE-DELIVERY-JSON-SAMPLE/README.md
@@ -1,0 +1,91 @@
+# FREE-DELIVERY-JSON-SAMPLE — Freier Versandschein (V2)
+
+Das Lieferpapier für Geräte, zu denen es **keinen Auftrag gibt**: Warenannahme,
+Rücksendung, Übergabe an ein Fremdlabor. Gedruckt aus dem Arbeitsplatz
+„Schnellerfassung > Versandschein", nicht aus einem Datensatz — gefüllt aus
+einem **JSON-Datensatz** (Contract `free-delivery-note` v1.0) statt aus SQL.
+
+V2-Nachfolger von `DELIVERY-STANDALONE/main_reports/Free_Delivery.jrxml` (V1,
+SQL mit `MTAG IN (…)`). Die V1-Vorlage bleibt im Repository: Sie läuft auf
+V1-Installationen weiter, solange dort die alte Maske benutzt wird.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/free-delivery-json-sample.jrxml` | Hauptbericht: Fensterbrief nach DIN 5008 Form B, Informationsblock (Nummer/Datum/Kunden-Nr./Ansprechpartner/Sendungsnummer), Empfängerblock, Abhakliste, Prüfvermerk |
+| `subreports/devices.jrxml` | Geräteliste als Abhakliste; `devices`-Array via `subDataSource("devices")` |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `free-delivery-note` v1.0, vier Positionen) |
+| `main_reports/free-delivery-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+| `parameters.json` | Parameter-Manifest für die Berichtsvariablen in calServer V2 |
+
+## Contract `free-delivery-note` (v1.0)
+
+Dataset-Builder: Laravel `FreeDeliveryNoteDataBuilder`. Blöcke:
+
+| Block | Inhalt | Herkunft |
+|-------|--------|----------|
+| `meta` | `contract`, `schema_version`, `generated_at`, `generated_date`, `locale` | Server |
+| `document` | `number`, `date`, `subject`, `customer_number`, `item_count` | Maske (Nummer/Datum/Betreff), Kundennummer fällt auf den Kunden zurück |
+| `sender` | `contact_name`, `email`, `phone` | Maske, vorbelegt aus dem angemeldeten Benutzer |
+| `customer` | Name, Nummer, Anschrift, `custom_fields` | gewählter Kunde |
+| `customer_contact` | Name, Anschrift, E-Mail, Telefon | gewählter Lieferkontakt, roh |
+| `delivery` | **aufgelöste** Versandanschrift: `name`, `contact_name`, `street`, `zip`, `city`, `country`, `email`, `phone` | Server |
+| `devices[]` | `asset_number`, `serial_number`, `description`, `manufacturer`, `model`, `type_code`, `next_calibration_date`, `custom_fields` | gewählte Geräte, in der Reihenfolge der Erfassung |
+| `shipping` | `tracking_number`, `note`, `item_count` | Maske; `item_count` zählt der Server |
+
+**Warum `delivery` aufgelöst ankommt.** Ein Lieferkontakt ist in calServer oft
+eine *Adresse* und keine Person („Wareneingang, Tor 3"). Ob die Sendung dorthin
+geht oder an die Kundenanschrift, entscheidet deshalb der Server: Trägt der
+Kontakt eine Anschrift, gewinnt sie; sonst steht die des Kunden im Fenster. Der
+Empfängername ist immer der Kunde — ein Tor ist kein Rechtssubjekt. Die Vorlage
+bindet damit **einen** Block statt einer Fallback-Kette, die sie richtig
+erraten müsste.
+
+**`devices[]` ist zeichengleich mit `location-report` v1.2.** Dieselbe Frage
+(was liegt im Karton), dieselbe Antwort — deshalb ist der Unterbericht derselbe
+wie beim Leihschein. Wer die Spalten anpasst, kopiert die Änderung ins andere
+Bündel.
+
+## Geometrie (Fensterbrief)
+
+Wie beim Leihschein, siehe ADR `2026-08-16-der-leihschein-ist-ein-versanddokument`:
+
+```
+Anschriftfeld        20 mm von links, 45 mm von oben, 85 × 45 mm
+Zusatz-/Vermerkzone  obere 17,7 mm  (Rücksendeangabe)
+Anschriftzone        untere 27,3 mm (Lieferanschrift)
+Betreffzeile         98,4 mm von oben
+```
+
+Umgerechnet (1 mm = 2,8346 pt, Seitenränder links 17 pt / oben 12 pt) liegt das
+Anschriftfeld im Titelband bei `x=40, y=116, 241 × 128 pt` — **ein** Frame. Für
+DIN 676 Form A (kurzer Briefkopf) wird `y=116` zu `y=64`, sonst nichts.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle bleibt die Seite leer bzw. bricht auf `subDataSource(...)`
+ab. Vorschau: mitgelieferter Adapter (Default über
+`com.jaspersoft.studio.data.defadapter`) → „Open → Preview".
+
+Live (calServer V2): Report-Setting-Variable `data_contract = free-delivery-note`
+— auf dem Systembericht-Platz „Versandschein" ist das der Vorgabewert des Grids,
+eine Variable braucht es dort also nur, wenn davon abgewichen wird. Den
+Datensatz zum Mitentwickeln liefert
+`POST /api/v2/free-delivery-notes/reports/dataset` (Rumpf wie beim Drucken:
+`report_id`, `inventory_ids`, Kopffelder). JasperReports **6.20.6** verbindlich.
+
+## Einrichtung in calServer V2
+
+1. Administration > Berichte: Der Platz **„Versandschein"** (Grid
+   `free_delivery`, Ordner `individual_delivery`) existiert auf jeder
+   Installation und ist nicht löschbar.
+2. Dieses Bündel als ZIP hochladen.
+3. Briefkopf wie bei jedem Bericht über das Overlay zuweisen.
+4. Absenderangaben pflegen: `company_name`, `company_street`, `company_zip`,
+   `company_city`, `company_country` (oder `company_sender_line`) — dieselben
+   Variablen wie beim Auftragsbeleg. Ohne sie bleibt die Rücksendeangabe leer;
+   das ist kein Fehler, der Umschlag trägt sie dann selbst.
+5. Rechte: Der Arbeitsplatz hängt an der Operation
+   `individual_delivery_report`. Die Auswahllisten der Maske folgen den
+   gewöhnlichen Leserechten (`customers_view`, `inventory_view`).

--- a/FREE-DELIVERY-JSON-SAMPLE/main_reports/free-delivery-json-sample.jrxml
+++ b/FREE-DELIVERY-JSON-SAMPLE/main_reports/free-delivery-json-sample.jrxml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 freier Versandschein (ADR 2026-08-17, Contract "free-delivery-note" v1.0).
+  Gefüllt aus einem JSON-Datensatz — KEIN SQL.
+
+  Das Papier für Geräte OHNE Auftrag: Warenannahme, Rücksendung, Übergabe an
+  ein Fremdlabor. Alles, was das Dokument über sich selbst sagt (Nummer,
+  Datum, Betreff, Ansprechpartner), kommt aus der Maske; alles über die Ware
+  aus den ausgewählten Geräten.
+
+  Geometrie wie beim Leihschein (LOCATION-JSON-SAMPLE): Fensterbrief nach
+  DIN 5008 Form B, Anschriftfeld 20 mm von links, 45 mm von oben, 85 × 45 mm
+  (im Titelband x=40, y=116, 241 × 128 pt), Betreffzeile bei 98,4 mm. Ein
+  DIN-lang-Umschlag nach DIN 680 zeigt damit genau die Anschrift. Wer auf
+  Form A umstellt, ändert eine Zahl: y=116 wird zu y=64.
+
+  Bewusst dieselbe Sprache wie der Leihschein: `devices[]` trägt exakt
+  dieselben Schlüssel, deshalb ist der Unterbericht derselbe. Wer beide
+  Papiere im eigenen Layout pflegt, pflegt eine Gerätetabelle.
+
+  Der Absender kommt NICHT aus dem Datensatz, sondern aus den
+  company_*-Berichtsvariablen — dieselben, die Auftragsbeleg und Leihschein
+  nutzen. Ohne gepflegte Variablen bleibt die Rücksendeangabe leer und der
+  Umschlag trägt sie selbst. Siehe main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="free-delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="c4aab700-0700-4e80-af70-000000000700">
+	<property name="com.jaspersoft.studio.data.defadapter" value="free-delivery-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Value" fontSize="9"/>
+	<style name="SectionTitle" fontSize="10" isBold="true"/>
+	<style name="Small" fontSize="8"/>
+	<style name="Address" fontSize="10"/>
+	<style name="SenderLine" fontSize="6"/>
+	<parameter name="Reportpath" class="java.lang.String">
+		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
+	</parameter>
+	<parameter name="Company_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_sender_line" class="java.lang.String">
+		<parameterDescription><![CDATA[Rücksendeangabe über der Anschrift (die kleine einzeilige Absenderzeile im Fenster). Leer = aus Name/Straße/PLZ/Ort zusammengesetzt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_name" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Firmenname. Fällt in die Rücksendeangabe ein, wenn Company_sender_line leer ist.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_street" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Straße und Hausnummer.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_zip" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Postleitzahl.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_city" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Ort.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Company_country" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender: Land. Steuert zugleich, ob die Empfängeranschrift eine Landzeile bekommt — gedruckt wird sie nur bei abweichendem Land.]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Show_fold_marks" class="java.lang.String">
+		<parameterDescription><![CDATA[Falz- und Lochmarken am linken Rand drucken (105 mm, 148,5 mm, 210 mm). "0" = aus, z. B. bei vorgedrucktem Briefpapier, das sie schon trägt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Document_title" class="java.lang.String">
+		<parameterDescription><![CDATA[Überschrift des Dokuments. Voreinstellung "Versandschein"; wer das Papier anders nennt (z. B. "Lieferschein"), setzt die Berichtsvariable document_title.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Versandschein"]]></defaultValueExpression>
+	</parameter>
+	<field name="document_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
+	<field name="document_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
+	<field name="document_subject" class="java.lang.String"><fieldDescription><![CDATA[document.subject]]></fieldDescription></field>
+	<field name="document_customer_number" class="java.lang.String"><fieldDescription><![CDATA[document.customer_number]]></fieldDescription></field>
+	<field name="sender_name" class="java.lang.String"><fieldDescription><![CDATA[sender.contact_name]]></fieldDescription></field>
+	<field name="sender_email" class="java.lang.String"><fieldDescription><![CDATA[sender.email]]></fieldDescription></field>
+	<field name="sender_phone" class="java.lang.String"><fieldDescription><![CDATA[sender.phone]]></fieldDescription></field>
+	<field name="customer_name" class="java.lang.String"><fieldDescription><![CDATA[customer.name]]></fieldDescription></field>
+	<field name="customer_street" class="java.lang.String"><fieldDescription><![CDATA[customer.street]]></fieldDescription></field>
+	<field name="customer_zip" class="java.lang.String"><fieldDescription><![CDATA[customer.zip]]></fieldDescription></field>
+	<field name="customer_city" class="java.lang.String"><fieldDescription><![CDATA[customer.city]]></fieldDescription></field>
+	<!--
+	  Die aufgelöste Versandanschrift: Der Server hat schon entschieden, ob die
+	  Anschrift vom Lieferkontakt oder vom Kunden kommt. Die Vorlage bindet
+	  deshalb EINEN Block und keine Fallback-Kette.
+	-->
+	<field name="delivery_name" class="java.lang.String"><fieldDescription><![CDATA[delivery.name]]></fieldDescription></field>
+	<field name="delivery_contact_name" class="java.lang.String"><fieldDescription><![CDATA[delivery.contact_name]]></fieldDescription></field>
+	<field name="delivery_street" class="java.lang.String"><fieldDescription><![CDATA[delivery.street]]></fieldDescription></field>
+	<field name="delivery_zip" class="java.lang.String"><fieldDescription><![CDATA[delivery.zip]]></fieldDescription></field>
+	<field name="delivery_city" class="java.lang.String"><fieldDescription><![CDATA[delivery.city]]></fieldDescription></field>
+	<field name="delivery_country" class="java.lang.String"><fieldDescription><![CDATA[delivery.country]]></fieldDescription></field>
+	<field name="delivery_email" class="java.lang.String"><fieldDescription><![CDATA[delivery.email]]></fieldDescription></field>
+	<field name="delivery_phone" class="java.lang.String"><fieldDescription><![CDATA[delivery.phone]]></fieldDescription></field>
+	<field name="tracking_number" class="java.lang.String"><fieldDescription><![CDATA[shipping.tracking_number]]></fieldDescription></field>
+	<field name="shipping_note" class="java.lang.String"><fieldDescription><![CDATA[shipping.note]]></fieldDescription></field>
+	<field name="item_count" class="java.lang.Integer"><fieldDescription><![CDATA[shipping.item_count]]></fieldDescription></field>
+	<!--
+	  Falz- und Lochmarken gehören auf JEDE Seite (gefalzt wird der ganze
+	  Stapel), deshalb ins Hintergrundband.
+	-->
+	<background>
+		<band height="818">
+			<line>
+				<reportElement x="0" y="286" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="409" width="14" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="583" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+		</band>
+	</background>
+	<title>
+		<band height="364">
+			<!-- Anschriftfeld (DIN 676 Form B): der Frame IST das Feld. -->
+			<frame>
+				<reportElement x="40" y="116" width="241" height="128"/>
+				<textField isBlankWhenNull="true">
+					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
+					<textFieldExpression><![CDATA[($P{Company_sender_line} != null && !$P{Company_sender_line}.trim().isEmpty())
+	? $P{Company_sender_line}
+	: (
+		($P{Company_name} == null ? "" : $P{Company_name})
+		+ (($P{Company_street} == null || $P{Company_street}.trim().isEmpty()) ? "" : " · " + $P{Company_street})
+		+ ((($P{Company_zip} == null || $P{Company_zip}.trim().isEmpty()) && ($P{Company_city} == null || $P{Company_city}.trim().isEmpty()))
+			? ""
+			: " · " + ($P{Company_zip} == null ? "" : $P{Company_zip}) + " " + ($P{Company_city} == null ? "" : $P{Company_city}))
+	).trim()]]></textFieldExpression>
+				</textField>
+				<!--
+				  Die Anschrift ist EIN Textfeld mit \n-Zeilen: Fehlt der
+				  Ansprechpartner, rückt die Straße auf, statt eine Lücke im
+				  Fenster zu lassen. Die Landzeile druckt nur bei abweichendem
+				  Land (Company_country).
+				-->
+				<textField isBlankWhenNull="true">
+					<reportElement style="Address" x="0" y="50" width="241" height="78"/>
+					<textElement><paragraph lineSpacing="Fixed" lineSpacingSize="12.5"/></textElement>
+					<textFieldExpression><![CDATA[(($F{delivery_name} == null || $F{delivery_name}.trim().isEmpty()) ? "" : $F{delivery_name} + "\n")
++ (($F{delivery_contact_name} == null || $F{delivery_contact_name}.trim().isEmpty()) ? "" : $F{delivery_contact_name} + "\n")
++ (($F{delivery_street} == null || $F{delivery_street}.trim().isEmpty()) ? "" : $F{delivery_street} + "\n")
++ (($F{delivery_zip} == null ? "" : $F{delivery_zip}) + " " + ($F{delivery_city} == null ? "" : $F{delivery_city})).trim()
++ (($F{delivery_country} == null || $F{delivery_country}.trim().isEmpty()
+		|| ($P{Company_country} != null && $F{delivery_country}.trim().equalsIgnoreCase($P{Company_country}.trim())))
+	? ""
+	: "\n" + $F{delivery_country})]]></textFieldExpression>
+				</textField>
+			</frame>
+			<!--
+			  Informationsblock rechts (DIN 5008: ab 125 mm, außerhalb des
+			  Fensters). Er trägt, was der Empfänger beim Auspacken braucht:
+			  welche Nummer die Sendung hat, wann sie raus ist und wen er
+			  anruft — und das ist hier der ABSENDER, nicht sein eigener
+			  Kontakt: Auf einem Papier ohne Auftrag ist die Rückfrage die
+			  wahrscheinlichste Handlung.
+			-->
+			<frame>
+				<reportElement x="337" y="116" width="224" height="91"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Lieferschein-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Datum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_date}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="26" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_customer_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="39" width="104" height="12"/><text><![CDATA[Ansprechpartner]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="39" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_name}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="52" width="104" height="12"/><text><![CDATA[Telefon]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="52" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_phone}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="65" width="104" height="12"/><text><![CDATA[E-Mail]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="65" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_email}]]></textFieldExpression></textField>
+				<staticText>
+					<reportElement style="Label" x="0" y="78" width="104" height="12">
+						<printWhenExpression><![CDATA[$F{tracking_number} != null && !$F{tracking_number}.trim().isEmpty()]]></printWhenExpression>
+					</reportElement>
+					<text><![CDATA[Sendungsnummer]]></text>
+				</staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="78" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tracking_number}]]></textFieldExpression></textField>
+			</frame>
+			<!-- Dokumenttitel (DIN 5008: Betreffzeile bei 98,4 mm ab Oberkante) -->
+			<textField>
+				<reportElement x="12" y="267" width="549" height="18"/>
+				<textElement><font size="13" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$P{Document_title}]]></textFieldExpression>
+			</textField>
+			<!--
+			  Der Betreff aus der Maske („Rücksendung nach Kalibrierung").
+			  Kollabiert, wenn keiner gepflegt ist — eine leere Zeile unter der
+			  Überschrift sieht aus wie ein Fehler im Druck.
+			-->
+			<textField isBlankWhenNull="true">
+				<reportElement style="Value" x="12" y="286" width="549" height="13" isRemoveLineWhenBlank="true"/>
+				<textFieldExpression><![CDATA[$F{document_subject}]]></textFieldExpression>
+			</textField>
+			<staticText><reportElement style="SectionTitle" x="12" y="310" width="270" height="14"/><text><![CDATA[Empfänger]]></text></staticText>
+			<textField>
+				<reportElement style="Value" x="12" y="326" width="270" height="13"/>
+				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{document_customer_number} == null || $F{document_customer_number}.isEmpty()) ? "" : ("  (" + $F{document_customer_number} + ")"))]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement style="Small" x="12" y="339" width="270" height="12"/>
+				<textFieldExpression><![CDATA[(($F{customer_street} == null ? "" : $F{customer_street} + ", ")
+	+ ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})).trim()]]></textFieldExpression>
+			</textField>
+			<!--
+			  Die Lieferanschrift steht schon im Fenster — hier wiederholt sie
+			  niemand. Daneben steht nur, was das Anschriftfeld nicht trägt:
+			  die E-Mail des Lieferkontakts für die Rückfrage zur Sendung.
+			-->
+			<staticText>
+				<reportElement style="SectionTitle" x="291" y="310" width="270" height="14">
+					<printWhenExpression><![CDATA[$F{delivery_email} != null && !$F{delivery_email}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<text><![CDATA[Rückfragen zur Sendung]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement style="Value" x="291" y="326" width="270" height="13"/>
+				<textFieldExpression><![CDATA[$F{delivery_email}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<detail>
+		<band height="180">
+			<!-- Hinweis zur Sendung. Kollabiert vollständig, wenn keiner gepflegt
+			     ist — alles darunter schwimmt (positionType Float). -->
+			<frame>
+				<reportElement x="12" y="0" width="549" height="30" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{shipping_note} != null && !$F{shipping_note}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<staticText><reportElement style="Label" x="0" y="0" width="549" height="12"/><text><![CDATA[Hinweis zur Sendung]]></text></staticText>
+				<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="13" width="549" height="13"/><textFieldExpression><![CDATA[$F{shipping_note}]]></textFieldExpression></textField>
+			</frame>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="12" y="36" width="300" height="14"/><text><![CDATA[Sendungsinhalt]]></text></staticText>
+			<textField>
+				<reportElement style="Small" positionType="Float" x="300" y="37" width="261" height="13"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[($F{item_count} == null ? "" : ($F{item_count} + ($F{item_count}.intValue() == 1 ? " Position" : " Positionen")))]]></textFieldExpression>
+			</textField>
+			<!--
+			  Eine Zeile je Gerät, als Abhakliste. Der Unterbericht ist derselbe
+			  wie beim Leihschein: `devices[]` trägt in beiden Verträgen
+			  dieselben Schlüssel.
+			-->
+			<subreport>
+				<reportElement positionType="Float" x="12" y="54" width="549" height="14" isRemoveLineWhenBlank="true"/>
+				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("devices")]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/devices.jasper"]]></subreportExpression>
+			</subreport>
+			<!--
+			  Prüfvermerk statt Unterschrift: Das Blatt reist mit der Sendung.
+			  Wer es doch am Tresen übergibt, hat mit Datum und Haken dieselbe
+			  Quittung — nur verlangt das Papier sie nicht von jemandem, der
+			  nicht da ist.
+			-->
+			<line><reportElement positionType="Float" x="12" y="80" width="549" height="1"/></line>
+			<rectangle>
+				<reportElement positionType="Float" x="12" y="88" width="9" height="9"/>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</rectangle>
+			<staticText><reportElement style="Small" positionType="Float" x="26" y="87" width="280" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="341" y="87" width="40" height="12"/><text><![CDATA[Datum]]></text></staticText>
+			<line><reportElement positionType="Float" x="381" y="98" width="180" height="1"/></line>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="36">
+			<line><reportElement x="12" y="0" width="549" height="1"/></line>
+			<textField><reportElement x="12" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Document_title} + " · calServer V2"]]></textFieldExpression></textField>
+			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="12" y="18" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/FREE-DELIVERY-JSON-SAMPLE/main_reports/free-delivery-json-sample_adapter.xml
+++ b/FREE-DELIVERY-JSON-SAMPLE/main_reports/free-delivery-json-sample_adapter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the free delivery note V2 sample.
+
+  Bundled so the report previews out-of-the-box: opening
+  free-delivery-json-sample.jrxml and hitting "Preview" fills it from the
+  sibling sample-data.json (contract free-delivery-note v1.0) via this adapter,
+  referenced by the report property com.jaspersoft.studio.data.defadapter.
+
+  This is an AUTHORING/PREVIEW aid only. It is a Studio-namespaced property and
+  is inert in the report-runner: at runtime the calServer V2 backend supplies
+  the JSON datasource itself (see README → "Datenanbindung"). If your Studio
+  version does not auto-apply it, pick this adapter manually in the preview
+  data-adapter dropdown.
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Free Delivery JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/FREE-DELIVERY-JSON-SAMPLE/main_reports/sample-data.json
+++ b/FREE-DELIVERY-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,95 @@
+{
+  "meta": {
+    "contract": "free-delivery-note",
+    "schema_version": "1.0",
+    "generated_at": "2026-08-17T09:30:00+00:00",
+    "generated_date": "2026-08-17",
+    "locale": "de-DE"
+  },
+  "document": {
+    "number": "VS-2026-0007",
+    "date": "2026-08-17",
+    "subject": "Rücksendung nach Kalibrierung",
+    "customer_number": "K-1001",
+    "item_count": 4
+  },
+  "sender": {
+    "contact_name": "Anna Weber",
+    "email": "anna.weber@labor.example",
+    "phone": "+49 30 1234500"
+  },
+  "customer": {
+    "name": "Muster GmbH",
+    "customer_number": "K-1001",
+    "street": "Musterstraße 1",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE",
+    "custom_fields": {}
+  },
+  "customer_contact": {
+    "name": "Erika Musterfrau",
+    "street": "Wareneingang, Tor 3",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "email": "erika@muster.example",
+    "phone": "+49 30 1234501"
+  },
+  "delivery": {
+    "name": "Muster GmbH",
+    "contact_name": "Erika Musterfrau",
+    "street": "Wareneingang, Tor 3",
+    "zip": "54321",
+    "city": "Beispielstadt",
+    "country": "DE",
+    "email": "erika@muster.example",
+    "phone": "+49 30 1234501"
+  },
+  "devices": [
+    {
+      "asset_number": "INV-9001",
+      "serial_number": "SN-12345",
+      "description": "Digitalmultimeter Fluke 87V",
+      "manufacturer": "Fluke",
+      "model": "87V",
+      "type_code": "DMM",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    },
+    {
+      "asset_number": "INV-9002",
+      "serial_number": "SN-22450",
+      "description": "Kalibrator Fluke 5522A",
+      "manufacturer": "Fluke",
+      "model": "5522A",
+      "type_code": "CALSTD",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    },
+    {
+      "asset_number": "INV-9003",
+      "serial_number": "SN-33110",
+      "description": "Isolationsmessgerät",
+      "manufacturer": "Fluke",
+      "model": "1507",
+      "type_code": "ISO",
+      "next_calibration_date": "2027-03-31",
+      "custom_fields": {}
+    },
+    {
+      "asset_number": "INV-9004",
+      "serial_number": "SN-44870",
+      "description": "Klemmzange",
+      "manufacturer": "Keysight",
+      "model": "U1194A",
+      "type_code": "CLM",
+      "next_calibration_date": "2027-06-30",
+      "custom_fields": {}
+    }
+  ],
+  "shipping": {
+    "tracking_number": "00340434161094022838",
+    "note": "Vier Geräte in einem Karton, Kalibrierscheine liegen bei.",
+    "item_count": 4
+  }
+}

--- a/FREE-DELIVERY-JSON-SAMPLE/parameters.json
+++ b/FREE-DELIVERY-JSON-SAMPLE/parameters.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://calhelp.github.io/calServer-reports/schema/report-parameters.schema.json",
+  "version": 1,
+  "parameters": [
+    {
+      "name": "Document_title",
+      "label": {
+        "de": "Dokumenttitel",
+        "en": "Document title"
+      },
+      "description": {
+        "de": "Überschrift des Papiers und Text in der Fußzeile. Voreinstellung „Versandschein\"; wer das Dokument im Haus anders nennt (etwa „Lieferschein\" oder „Warenbegleitschein\"), setzt es hier einmal für alle Drucke.",
+        "en": "Heading of the document and the text in its footer. Defaults to \"Versandschein\"; set it once here if your organisation calls the paper something else."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Dokument",
+      "order": 1,
+      "default": "Versandschein",
+      "example": "Lieferschein"
+    },
+    {
+      "name": "Company_sender_line",
+      "label": {
+        "de": "Rücksendeangabe",
+        "en": "Return address line"
+      },
+      "description": {
+        "de": "Die kleine einzeilige Absenderangabe über der Empfängeranschrift im Briefumschlagfenster. Leer lassen, um sie aus Firmenname, Straße, PLZ und Ort zusammensetzen zu lassen. Dieselbe Variable nutzen Leihschein und Auftragsbeleg.",
+        "en": "The small one-line sender note printed above the recipient address in the envelope window. Leave empty to have it composed from company name, street, postcode and city. The loan receipt and the order document use the same variable."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 2,
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt"
+    },
+    {
+      "name": "Company_name",
+      "label": {
+        "de": "Absender: Firmenname",
+        "en": "Sender: company name"
+      },
+      "description": {
+        "de": "Firmenname des Absenders. Wird für die Rücksendeangabe verwendet, wenn keine eigene Rücksendeangabe gepflegt ist.",
+        "en": "Sender company name. Used for the return address line when no explicit one is configured."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 3,
+      "example": "Musterfirma GmbH"
+    },
+    {
+      "name": "Company_street",
+      "label": {
+        "de": "Absender: Straße",
+        "en": "Sender: street"
+      },
+      "description": {
+        "de": "Straße und Hausnummer des Absenders, für die Rücksendeangabe.",
+        "en": "Sender street and number, used for the return address line."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 4,
+      "example": "Musterstraße 1"
+    },
+    {
+      "name": "Company_zip",
+      "label": {
+        "de": "Absender: PLZ",
+        "en": "Sender: postcode"
+      },
+      "description": {
+        "de": "Postleitzahl des Absenders, für die Rücksendeangabe.",
+        "en": "Sender postcode, used for the return address line."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 5,
+      "example": "12345"
+    },
+    {
+      "name": "Company_city",
+      "label": {
+        "de": "Absender: Ort",
+        "en": "Sender: city"
+      },
+      "description": {
+        "de": "Ort des Absenders, für die Rücksendeangabe.",
+        "en": "Sender city, used for the return address line."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 6,
+      "example": "Musterstadt"
+    },
+    {
+      "name": "Company_country",
+      "label": {
+        "de": "Absender: Land",
+        "en": "Sender: country"
+      },
+      "description": {
+        "de": "Land des Absenders. Steuert zugleich die Landzeile der Empfängeranschrift: Sie wird nur gedruckt, wenn das Land der Lieferadresse davon abweicht — eine Inlandsanschrift bekommt also keine überflüssige Landzeile ins Fenster.",
+        "en": "Sender country. It also controls the recipient's country line: that line is printed only when the delivery country differs, so a domestic address gets no redundant country line in the window."
+      },
+      "role": "variable",
+      "scope": "global",
+      "input": "text",
+      "required": false,
+      "group": "Absender",
+      "order": 7,
+      "example": "DE"
+    },
+    {
+      "name": "Show_fold_marks",
+      "label": {
+        "de": "Falz- und Lochmarken",
+        "en": "Fold and punch marks"
+      },
+      "description": {
+        "de": "Druckt die Falzmarken bei 105 mm und 210 mm sowie die Lochmarke bei 148,5 mm an den linken Blattrand. Auf \"0\" setzen, wenn auf vorgedrucktem Briefpapier gedruckt wird, das die Marken bereits trägt.",
+        "en": "Prints the fold marks at 105 mm and 210 mm plus the punch mark at 148.5 mm on the left edge of the sheet. Set to \"0\" when printing on pre-printed stationery that already carries them."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Layout",
+      "order": 8,
+      "default": "1",
+      "example": "1"
+    },
+    {
+      "name": "Company_footer",
+      "label": {
+        "de": "Fußzeile",
+        "en": "Footer line"
+      },
+      "description": {
+        "de": "Optionale Fußzeile am unteren Rand jeder Seite, unterhalb von Dokumenttitel und Seitenzählung — z. B. Firmenname, Anschrift und Kontaktdaten. Leer lassen, wenn keine zusätzliche Fußzeile gedruckt werden soll.",
+        "en": "Optional footer at the bottom of every page, below the document title and page count — e.g. company name, address and contact details. Leave empty to omit the extra footer line."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "textarea",
+      "required": false,
+      "group": "Layout",
+      "order": 9,
+      "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
+    },
+    {
+      "name": "Reportpath",
+      "label": {
+        "de": "Bundle-Wurzelpfad",
+        "en": "Bundle root path"
+      },
+      "description": {
+        "de": "Wurzelpfad zur Auflösung der Subreports (/subreports/*.jasper). Wird von calServer automatisch gesetzt.",
+        "en": "Root path for resolving the subreports (/subreports/*.jasper). Supplied automatically by calServer."
+      },
+      "role": "system"
+    }
+  ]
+}

--- a/FREE-DELIVERY-JSON-SAMPLE/subreports/devices.jrxml
+++ b/FREE-DELIVERY-JSON-SAMPLE/subreports/devices.jrxml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 Geräte-Subreport (Contract free-delivery-note v1.0): bekommt das
+  "devices"-Array über subDataSource("devices").
+
+  Zeichengleich mit LOCATION-JSON-SAMPLE/subreports/devices.jrxml, und das ist
+  Absicht: Beide Verträge führen `devices[]` mit denselben Schlüsseln, weil es
+  in beiden Fällen dieselbe Frage beantwortet — was liegt im Karton. Wer die
+  Spalten für sein Haus anpasst, kopiert die Änderung in das jeweils andere
+  Bündel; getrennte Dateien, weil ein Bündel für sich hochladbar bleiben muss.
+
+  Die Liste ist eine ABHAKLISTE: jede Zeile beginnt mit einem Ankreuzfeld und
+  trägt eine Positionsnummer, damit Packerei und Empfänger die Sendung Stück
+  für Stück gegen das Papier prüfen können. Die Spaltenköpfe liegen deshalb
+  hier im columnHeader und nicht im Hauptbericht — eine Sendung mit 40
+  Positionen läuft über den Seitenumbruch, und auf Seite 2 stünde sonst eine
+  Ankreuzliste ohne Kopf.
+
+  Die Reihenfolge ist die, in der der Anwender die Geräte eingesammelt hat —
+  der Server sortiert sie nicht um.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
+	<style name="Label" fontSize="8" isBold="true"/>
+	<style name="Small" fontSize="8"/>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[asset_number]]></fieldDescription></field>
+	<field name="serial_number" class="java.lang.String"><fieldDescription><![CDATA[serial_number]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[model]]></fieldDescription></field>
+	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[description]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
+	<columnHeader>
+		<band height="16">
+			<staticText><reportElement style="Label" x="12" y="0" width="22" height="13"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" x="34" y="0" width="88" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="122" y="0" width="94" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="216" y="0" width="128" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<staticText><reportElement style="Label" x="344" y="0" width="140" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><text><![CDATA[Nächste Kal.]]></text></staticText>
+			<line><reportElement x="0" y="14" width="549" height="1"/></line>
+		</band>
+	</columnHeader>
+	<!--
+	  splitType="Prevent": Eine Zeile darf den Seitenumbruch nicht in der Mitte
+	  erwischen. Ohne das rutscht bei einer mehrzeiligen Beschreibung deren
+	  zweite Zeile allein auf die Folgeseite — dort steht sie ohne Ankreuzfeld,
+	  ohne Positionsnummer und ohne Inventarnummer, also als Position, die
+	  niemand abhaken kann.
+	-->
+	<detail>
+		<band height="16" splitType="Prevent">
+			<!-- Ankreuzfeld zum Abhaken der Position beim Packen bzw. Auspacken. -->
+			<rectangle>
+				<reportElement x="0" y="1" width="9" height="9"/>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</rectangle>
+			<textField><reportElement style="Small" x="12" y="0" width="22" height="13"/><textFieldExpression><![CDATA[String.valueOf($V{REPORT_COUNT})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="34" y="0" width="88" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="122" y="0" width="94" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="216" y="0" width="128" height="13"/><textFieldExpression><![CDATA[(($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})).trim()]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="344" y="0" width="140" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<!-- Zeilentrenner: eine Abhakliste braucht die Führung fürs Auge. -->
+			<line><reportElement positionType="Float" x="0" y="14" width="549" height="1"/><graphicElement><pen lineWidth="0.25" lineColor="#BBBBBB"/></graphicElement></line>
+		</band>
+	</detail>
+</jasperReport>

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ calServer V2 verwendet ein neues Datenbankschema mit **lesbaren Feldnamen** (`se
   | Leihschein | [`LOCATION-JSON-SAMPLE`](LOCATION-JSON-SAMPLE/) | Beim Buchen einer Ausleihe, als Anhang der Leihschein-E-Mail |
   | Preisliste | [`PRICE-LIST-JSON-SAMPLE`](PRICE-LIST-JSON-SAMPLE/) | Auf der Preislisten-Seite, je Preisgruppe und Stichtag |
   | Auftragsbeleg | [`ORDER-JSON-SAMPLE`](ORDER-JSON-SAMPLE/) | Angebot, Auftragsbestätigung, Lieferschein und Rechnung aus dem Auftrag — und die Quelle der E-Rechnung nach ZUGFeRD/EN 16931 |
+  | Versandschein | [`FREE-DELIVERY-JSON-SAMPLE`](FREE-DELIVERY-JSON-SAMPLE/) | Im Arbeitsplatz „Schnellerfassung > Versandschein": das Lieferpapier für Geräte **ohne** Auftrag (V2-Nachfolger von [`DELIVERY-STANDALONE`](DELIVERY-STANDALONE/)) |
 
   Details: [Systemberichte](https://github.com/calhelp/calServer-yii/blob/develop/docs-v2/admin/berichte/systemberichte.md).
 - Bestehende Vorlagen bitte **nicht** auf das V2-Schema-SQL umschreiben — die Strategie und der Migrationspfad sind hier dokumentiert: [Evaluierung: JasperReports-Strategie für calServer V2](https://github.com/calhelp/calServer-yii/blob/develop/docs/evaluierung-jasper-reports-v2.md).


### PR DESCRIPTION
Das Gegenstück zum V2-Arbeitsplatz „Schnellerfassung > Versandschein"
(calServer-yii, ADR 2026-08-17): das Lieferpapier für Geräte, zu denen es
**keinen Auftrag gibt** — Warenannahme, Rücksendung, Übergabe an ein
Fremdlabor.

## Was drin ist

`FREE-DELIVERY-JSON-SAMPLE/`

| Datei | Zweck |
|-------|-------|
| `main_reports/free-delivery-json-sample.jrxml` | Hauptbericht: Fensterbrief nach DIN 5008 Form B, Informationsblock (Nummer/Datum/Kunden-Nr./Ansprechpartner/Sendungsnummer), Empfängerblock, Abhakliste, Prüfvermerk |
| `subreports/devices.jrxml` | Geräteliste als Abhakliste (`subDataSource("devices")`) |
| `main_reports/sample-data.json` | Beispieldatensatz, Contract `free-delivery-note` v1.0 |
| `main_reports/free-delivery-json-sample_adapter.xml` | Studio-Adapter für die Vorschau |
| `parameters.json` | Parameter-Manifest (Dokumenttitel, Absenderangaben, Layout) |

Dazu: Registrierung in `package-reports.yml`, `release-reports.yml` und
`publish-downloads.yml` sowie eine Zeile in der Systembericht-Tabelle des
README.

## Entscheidungen

- **Geometrie geerbt.** Anschriftfeld, Falzmarken und Betreffzeile sitzen wie
  beim Leihschein (ADR 2026-08-16); für DIN 676 Form A ändert sich eine Zahl
  (`y=116` → `y=64`).
- **`devices[]` zeichengleich mit `location-report` v1.2**, deshalb ist der
  Unterbericht derselbe. Es ist dieselbe Frage — was liegt im Karton —, und
  zwei Vokabulare dafür bezahlt am Ende der Betreiber, der beide Vorlagen
  pflegt.
- **`delivery` kommt aufgelöst vom Server.** Ob die Anschrift vom Lieferkontakt
  oder vom Kunden stammt, entscheidet das Backend; die Vorlage bindet einen
  Block statt einer Fallback-Kette, die sie richtig erraten müsste.
- **`DELIVERY-STANDALONE` bleibt.** Die V1-Vorlage `Free_Delivery.jrxml` läuft
  auf V1-Installationen weiter; V1 sucht ihre Berichtszeile über
  `booking`/`individual_delivery`/`Free_Delivery.jrxml` und wird nicht angefasst.

## Geprüft

- `python3 scripts/check_parameters_manifest.py FREE-DELIVERY-JSON-SAMPLE` — grün
- `scripts/check_jasper_version.sh` — alle JRXML auf 6.20.6
- JSON- und XML-Wohlgeformtheit, YAML der drei geänderten Workflows

Ein Renderlauf gegen den report-runner steht aus (keine Java-Umgebung in der
Session) — die pixelgenaue Abnahme bleibt wie üblich der maßgebliche Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN18Ht2TbzeA6GqXSQJ27c


---
_Generated by [Claude Code](https://claude.ai/code/session_01XN18Ht2TbzeA6GqXSQJ27c)_