### PR TITLE
Ticketmanagement: DAkkS-Vorlagen bringen die Fristen mit

### DIFF
--- a/TICKET-CONFIG-DAKKS-3D/README.md
+++ b/TICKET-CONFIG-DAKKS-3D/README.md
@@ -28,15 +28,19 @@ Deshalb steigt das Gewicht, je später etwas auffällt.
 Dieselben vier Stufen und dieselben Prioritäten wie in der
 Zwei-Methoden-Fassung, nur über 1 bis 125 geschnitten:
 
-| Band | Farbe | Priorität |
-|------|-------|-----------|
-| 1–9 | grün | Niedrig |
-| 10–29 | gelb | Normal |
-| 30–59 | orange | Hoch |
-| 60–125 | rot | Kritisch |
+| Band | Farbe | Priorität | Frist | Vorwarnung |
+|------|-------|-----------|-------|------------|
+| 1–9 | grün | Niedrig | keine | — |
+| 10–29 | gelb | Normal | 90 Tage | 14 Tage |
+| 30–59 | orange | Hoch | 30 Tage | 7 Tage |
+| 60–125 | rot | Kritisch | 7 Tage | 2 Tage |
 
-Die Entscheidungsregeln je Band (wer entscheidet, welche Frist, welcher
-Nachweis) stehen im README der Zwei-Methoden-Fassung und gelten unverändert.
+Die Fristen sind dieselben wie in der Zwei-Methoden-Fassung: Sie folgen der
+Einstufung, nicht der Rechenart. Ein kritischer Vorgang ist kritisch, ob er über
+zwei oder drei Methoden dorthin kommt.
+
+Die Entscheidungsregeln je Band (wer entscheidet, welcher Nachweis) stehen im
+README der Zwei-Methoden-Fassung und gelten unverändert.
 
 ## Welche Fassung passt
 
@@ -81,8 +85,8 @@ Die dritte Skala, die Formel und die Bänder stehen im Skript
 
 ## Grenzen
 
-Dieselben wie bei der Zwei-Methoden-Fassung (Fristen setzt calServer nicht
-durch, Ticket-Status tragen keine Pflichtfeldregeln, einsprachig deutsch), und
-eine dazu: **drei Ebenen sind unvollständig schnell.** Solange eine von der
+Dieselben wie bei der Zwei-Methoden-Fassung (Zuständigkeiten bleiben
+Verfahrensanweisung, Ticket-Status tragen keine Pflichtfeldregeln, einsprachig
+deutsch), und eine dazu: **drei Ebenen sind unvollständig schnell.** Solange eine von der
 Formel genutzte Ebene am Ticket nicht ausgewählt ist, hat das Ticket keinen
 Risikowert — mit drei Ebenen passiert das öfter als mit zwei.

--- a/TICKET-CONFIG-DAKKS-3D/manifest.json
+++ b/TICKET-CONFIG-DAKKS-3D/manifest.json
@@ -5,7 +5,7 @@
   "name": "Ticketmanagement: Risiken und Chancen nach ISO/IEC 17025 (drei Methoden)",
   "document": {
     "format": "calserver.ticket-config",
-    "version": 1
+    "version": 2
   },
   "content": {
     "types": 8,
@@ -20,13 +20,13 @@
   "files": [
     {
       "path": "ticket-config.json",
-      "sha256": "44eb76fde44163019eeaccca12c9c2f1014a6ca7169ea894a0d5513c5e047a36",
-      "size_bytes": 10726
+      "sha256": "9c2b07ae7337e4aec70045f785ce19e2724fa7b8c58e3b0ccd8d40cb08228628",
+      "size_bytes": 10858
     },
     {
       "path": "README.md",
-      "sha256": "b587752d33bf125b3e54f91f4c36b5e3c0feb20df82efbbac2db4c64fdae5165",
-      "size_bytes": 4031
+      "sha256": "b2ba806d86e3c47997b0e86f189339b89c51a67bcba80a47774c05c49ac59bd1",
+      "size_bytes": 4337
     }
   ],
   "description": "Dieselbe Einrichtung wie die Zwei-Methoden-Fassung, bewertet aber mit Auswirkung × Wahrscheinlichkeit × Erkennbarkeit und einer Matrix über 1 bis 125.",

--- a/TICKET-CONFIG-DAKKS-3D/ticket-config.json
+++ b/TICKET-CONFIG-DAKKS-3D/ticket-config.json
@@ -1,6 +1,6 @@
 {
   "format": "calserver.ticket-config",
-  "version": 1,
+  "version": 2,
   "generator": "calserver-reports",
   "risk": {
     "formula": "[Risk_1] * [Risk_2] * [Risk_3]",
@@ -303,19 +303,25 @@
       "risk": "10-29",
       "color": "FFFF00",
       "priority": "Normal",
-      "sort_order": 2
+      "sort_order": 2,
+      "due_days": 90,
+      "warn_days": 14
     },
     {
       "risk": "30-59",
       "color": "FFC000",
       "priority": "Hoch",
-      "sort_order": 3
+      "sort_order": 3,
+      "due_days": 30,
+      "warn_days": 7
     },
     {
       "risk": "60-125",
       "color": "FF0000",
       "priority": "Kritisch",
-      "sort_order": 4
+      "sort_order": 4,
+      "due_days": 7,
+      "warn_days": 2
     }
   ]
 }

--- a/TICKET-CONFIG-DAKKS/README.md
+++ b/TICKET-CONFIG-DAKKS/README.md
@@ -53,16 +53,28 @@ Verfahrensanweisung.
 
 ## Die Regeln zum Ergebnis
 
-calServer setzt aus dem Risikowert Farbe und Priorität. Was daraus folgt, ist
-Sache des Labors — hier der Vorschlag, der zu den vier Bändern passt und sich in
-der Begutachtung erklären lässt:
+calServer setzt aus dem Risikowert Farbe, Priorität und **Frist**. Die Frist ist
+seit Dokumentversion 2 Teil des Pakets (`due_days` je Band) und wird vom Produkt
+gerechnet, nicht nur vorgeschlagen: Ein bewertetes Ticket bekommt ein
+Fälligkeitsdatum, und wer die Frist reißt, hört davon. Was inhaltlich zu tun ist
+und wer entscheidet, bleibt Sache des Labors — hier der Vorschlag, der zu den
+vier Bändern passt und sich in der Begutachtung erklären lässt:
 
-| Band | Priorität | Entscheidung | Frist | Nachweis |
-|------|-----------|--------------|-------|----------|
-| 1–4 | Niedrig | Akzeptieren. Status „Kein Handlungsbedarf" mit Begründung, oder Sammelposten für die Managementbewertung | keine | Eintrag genügt |
-| 5–9 | Normal | Maßnahme durch die fachlich zuständige Person | 3 Monate | Maßnahme dokumentiert, Wirksamkeit beim Abschluss beurteilt |
-| 10–14 | Hoch | Maßnahme mit benannter Verantwortlicher, Freigabe durch die Qualitätsmanagement-Beauftragte | 1 Monat | Wirksamkeit gesondert belegt (Kontrollmessung, Audit, Kennzahl) |
-| 15–25 | Kritisch | Sofortmaßnahme prüfen: Arbeit anhalten, Ergebnisse zurückrufen, Kunden informieren (7.10). Entscheidung durch die Laborleitung | sofort, Maßnahme innerhalb 1 Woche geplant | Wirksamkeit belegt, Vorgang in der Managementbewertung berichtet |
+| Band | Priorität | Entscheidung | Frist (`due_days`) | Vorwarnung (`warn_days`) | Nachweis |
+|------|-----------|--------------|--------------------|--------------------------|----------|
+| 1–4 | Niedrig | Akzeptieren. Status „Kein Handlungsbedarf" mit Begründung, oder Sammelposten für die Managementbewertung | keine | — | Eintrag genügt |
+| 5–9 | Normal | Maßnahme durch die fachlich zuständige Person | 3 Monate (90 Tage) | 14 Tage | Maßnahme dokumentiert, Wirksamkeit beim Abschluss beurteilt |
+| 10–14 | Hoch | Maßnahme mit benannter Verantwortlicher, Freigabe durch die Qualitätsmanagement-Beauftragte | 1 Monat (30 Tage) | 7 Tage | Wirksamkeit gesondert belegt (Kontrollmessung, Audit, Kennzahl) |
+| 15–25 | Kritisch | Sofortmaßnahme prüfen: Arbeit anhalten, Ergebnisse zurückrufen, Kunden informieren (7.10). Entscheidung durch die Laborleitung | 1 Woche (7 Tage) | 2 Tage | Wirksamkeit belegt, Vorgang in der Managementbewertung berichtet |
+
+Kalendertage, gerechnet ab dem Tag der **Bewertung**, nicht ab dem Anlegen: Ein
+Vorgang, der drei Wochen unbewertet lag, bekommt sonst eine Frist, die bei der
+ersten Bewertung schon halb verbraucht ist. Das niedrigste Band bleibt bewusst
+ohne Frist — ein akzeptiertes Risiko hat keinen Termin, es hat eine Begründung.
+
+Verschärft sich die Bewertung, verkürzt sich die Frist; entschärft sie sich,
+bleibt die kürzere stehen. Wer eine Frist von Hand setzt, behält sie auch über
+eine Neubewertung hinweg.
 
 Zwei Punkte, die in der Begutachtung regelmäßig gefragt werden und die diese
 Vorlage deshalb bewusst so schneidet:
@@ -125,10 +137,14 @@ python3 scripts/build_config_manifest.py --write TICKET-CONFIG-DAKKS-3D
 
 ## Grenzen
 
-- **Die Fristen der Tabelle oben setzt calServer nicht durch.** Das Produkt
-  rechnet den Risikowert, färbt das Ticket und setzt die Priorität. Termine und
-  Zuständigkeiten sind Verfahrensanweisung; wer sie technisch erzwingen will,
-  arbeitet mit Fälligkeitsdatum und Benachrichtigungen im Ticket.
+- **Die Fristen setzt calServer durch, die Zuständigkeiten nicht.** Aus der
+  Bewertung folgt ein Fälligkeitsdatum, aus dessen Überschreitung eine Meldung
+  an Bearbeiter und Eskalationsgruppe. Wer entscheidet, wer freigibt und was
+  eine Sofortmaßnahme ist, steht weiter in der Verfahrensanweisung.
+- **Empfänger und Endstatus sind Einstellungen, kein Paketinhalt.** Welche
+  Gruppe eine Überschreitung erfährt und welche Ticket-Status „fertig" heißen,
+  hängt an den Gruppen und Status dieser Installation und wird deshalb einmalig
+  in der Ticket-Verwaltung eingestellt, nicht importiert.
 - **Keine Feldfunktionen.** Ticket-Status tragen in calServer keine
   Pflichtfeldregeln (anders als Kalibrier- oder Reparaturstatus). Dass ein
   Ticket vor dem Abschluss eine Wirksamkeitsbeurteilung trägt, ist damit

--- a/TICKET-CONFIG-DAKKS/manifest.json
+++ b/TICKET-CONFIG-DAKKS/manifest.json
@@ -5,7 +5,7 @@
   "name": "Ticketmanagement: Risiken und Chancen nach ISO/IEC 17025 (zwei Methoden)",
   "document": {
     "format": "calserver.ticket-config",
-    "version": 1
+    "version": 2
   },
   "content": {
     "types": 8,
@@ -20,13 +20,13 @@
   "files": [
     {
       "path": "ticket-config.json",
-      "sha256": "d5dd63ff6a2dd8e62193fd59b710f86d91e6ac7433245a3306f42f3f25b31fdf",
-      "size_bytes": 9547
+      "sha256": "2f1b943a07a491c83e65c684432f07d8c11d7fb1b3265195bf096c5a9849accf",
+      "size_bytes": 9679
     },
     {
       "path": "README.md",
-      "sha256": "46e7f7a1357f0af4f337d39266560093a7fa129473228195d5783deaeb73b4f8",
-      "size_bytes": 7197
+      "sha256": "db12d6c1651dbb7f817896c39ce0a2d800ae9a0c5c1dab96c86c9f299740a543",
+      "size_bytes": 8380
     }
   ],
   "description": "Vollständige Einrichtung des Ticketmoduls für ein akkreditiertes Labor: 8 Vorgangsarten, 20 Themenfelder entlang der Normabschnitte, 4 Prioritäten und die Risikobewertung Auswirkung × Wahrscheinlichkeit mit Matrix über 1 bis 25.",

--- a/TICKET-CONFIG-DAKKS/ticket-config.json
+++ b/TICKET-CONFIG-DAKKS/ticket-config.json
@@ -1,6 +1,6 @@
 {
   "format": "calserver.ticket-config",
-  "version": 1,
+  "version": 2,
   "generator": "calserver-reports",
   "risk": {
     "formula": "[Risk_1] * [Risk_2]",
@@ -267,19 +267,25 @@
       "risk": "5-9",
       "color": "FFFF00",
       "priority": "Normal",
-      "sort_order": 2
+      "sort_order": 2,
+      "due_days": 90,
+      "warn_days": 14
     },
     {
       "risk": "10-14",
       "color": "FFC000",
       "priority": "Hoch",
-      "sort_order": 3
+      "sort_order": 3,
+      "due_days": 30,
+      "warn_days": 7
     },
     {
       "risk": "15-25",
       "color": "FF0000",
       "priority": "Kritisch",
-      "sort_order": 4
+      "sort_order": 4,
+      "due_days": 7,
+      "warn_days": 2
     }
   ]
 }

--- a/robots.md
+++ b/robots.md
@@ -317,6 +317,18 @@ ships a release. calServer imports; this repo maintains the content.
     25 without colour and without priority.
   - The formula and `risk3` must agree: `[Risk_3]` in the formula requires a
     non-empty `risk3` and vice versa.
+  - **Deadlines (document version 2).** A `matrix` row may carry `due_days`
+    (deadline in calendar days from the assessment) and `warn_days` (advance
+    warning). Both are whole days from 1 to 3650 — `0` is not "no deadline",
+    it is a typo, and the script says so. Omitting them is the valid way to
+    say "none", and a version 1 document stays readable. Two rules the script
+    enforces because the matrix sorts by colour, not by days: a deadline must
+    never grow as the band rises (a missing one counts as infinite and is
+    therefore only allowed at the bottom), and `warn_days` needs a `due_days`
+    to warn about and must not exceed it.
+  - Escalation recipients and end statuses are NOT package content. They depend
+    on the groups and statuses of the target installation and are set once in
+    Ticket administration.
   - Ticket **statuses** do NOT belong in this document. They live in the shared
     status catalogue and ship as a `STATUS-*` package next to it
     (`STATUS-TICKETS-DAKKS`); the two READMEs point at each other.
@@ -333,7 +345,7 @@ ships a release. calServer imports; this repo maintains the content.
   CI runs `--check` on every push/PR (validate-reports.yml) and fails on any
   drift: unlisted file, missing file, wrong checksum, disallowed entry,
   duplicate key, unresolvable `parent_key`, transition pointing at a status the
-  package does not carry.
+  package does not carry, deadline that grows with the risk band.
 - Keep `created_at`, `name`, `description` and `locale` stable across `--write`
   runs (the script preserves them).
 

--- a/schema/ticket-config-package.schema.json
+++ b/schema/ticket-config-package.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://calhelp.github.io/calServer-reports/schema/ticket-config-package.schema.json",
   "title": "calServer Ticketmanagement-Paket (calserver.ticket-config-package)",
-  "description": "Manifest eines Ticketmanagement-Pakets: ein ZIP mit ticket-config.json (calserver.ticket-config) und optionalem README.md. Das Manifest listet jeden Paket-Eintrag mit SHA-256-Prüfsumme und ist damit der Manipulationsanker des Formats. Ein Paket trägt die Einrichtung des Ticketmoduls (Vorgangsarten, Kategorien, Prioritäten, die Skalen der bis zu drei Bewertungsebenen, die Risiko-Matrix, die Formel und die Namen der Ebenen), nicht die Tickets und nicht die Ticket-Status — die liegen im gemeinsamen Statuskatalog und haben mit calserver.status-package ihr eigenes Format. Zusätzliche, hier nicht beschriebene Felder sind erlaubt und werden von älteren Lesern ignoriert (Vorwärtskompatibilität); die verbindliche Lese-Semantik gehört calServer V2 (laravel/app/Services/Ticket/TicketConfigPackageService.php).",
+  "description": "Manifest eines Ticketmanagement-Pakets: ein ZIP mit ticket-config.json (calserver.ticket-config) und optionalem README.md. Das Manifest listet jeden Paket-Eintrag mit SHA-256-Prüfsumme und ist damit der Manipulationsanker des Formats. Ein Paket trägt die Einrichtung des Ticketmoduls (Vorgangsarten, Kategorien, Prioritäten, die Skalen der bis zu drei Bewertungsebenen, die Risiko-Matrix samt Fristen, die Formel und die Namen der Ebenen), nicht die Tickets und nicht die Ticket-Status — die liegen im gemeinsamen Statuskatalog und haben mit calserver.status-package ihr eigenes Format. Zusätzliche, hier nicht beschriebene Felder sind erlaubt und werden von älteren Lesern ignoriert (Vorwärtskompatibilität); die verbindliche Lese-Semantik gehört calServer V2 (laravel/app/Services/Ticket/TicketConfigPackageService.php).",
   "type": "object",
   "required": [
     "format",
@@ -18,7 +18,7 @@
     "format_version": {
       "type": "integer",
       "minimum": 1,
-      "description": "Version des Paketformats. Leser lehnen Versionen oberhalb der eigenen ab, statt unbekannte Inhalte still zu verlieren. Aktuelle Version: 1."
+      "description": "Version des Paketformats (des ZIP-Containers). Leser lehnen Versionen oberhalb der eigenen ab, statt unbekannte Inhalte still zu verlieren. Aktuelle Version: 1. Nicht zu verwechseln mit document.version, der Version des eingebetteten Dokuments."
     },
     "name": {
       "type": "string",
@@ -45,7 +45,8 @@
         },
         "version": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "description": "Version des ticket-config.json. Aktuelle Version: 2 (fuehrte due_days und warn_days an der Matrixzeile ein). Version 1 bleibt lesbar, sie bringt eben keine Fristen mit."
         }
       }
     },

--- a/scripts/build_config_manifest.py
+++ b/scripts/build_config_manifest.py
@@ -35,7 +35,9 @@ Zwei Modi:
         ganzzahligem Gewicht, Formel arithmetisch und mit mindestens einer
         Ebene, dritte Ebene und Formel stimmen überein, Matrixbänder eindeutig
         und lückenlos über den erreichbaren Wertebereich, jede Matrixzeile
-        verweist auf eine Priorität desselben Pakets.
+        verweist auf eine Priorität desselben Pakets, Fristen sind ganze Tage
+        ab 1 und werden mit steigendem Risiko kürzer, keine Vorwarnung ohne
+        Frist.
 
       Exit 1 bei Abweichung.
 
@@ -81,6 +83,8 @@ KINDS = {
         "schema": "ticket-config-package.schema.json",
         "collection": "types",
         "types": (),
+        # Version 2 traegt die Fristen an der Matrix (due_days, warn_days).
+        "max_document_version": 2,
     },
     "status": {
         "prefix": "STATUS-",
@@ -102,6 +106,11 @@ KINDS = {
 }
 
 PACKAGE_VERSION = 1
+
+# Hoechste lesbare Dokumentversion, wenn eine Klasse nichts anderes sagt
+# (`max_document_version` im Eintrag oben). Global waere sie falsch: dass das
+# Ticketmanagement-Dokument eine zweite Version hat, sagt nichts darueber, ob
+# ein Kategoriedokument eine haette.
 MAX_DOCUMENT_VERSION = 1
 MANIFEST_NAME = "manifest.json"
 README_NAME = "README.md"
@@ -545,6 +554,8 @@ def check_ticket_matrix(
 
     covered: set[int] = set()
     seen: set[str] = set()
+    # (untere Bandgrenze, Frist) je Zeile — fuer die Monotonie-Pruefung unten.
+    deadlines: list[tuple[int, int | None]] = []
 
     for index, row in enumerate(matrix, start=1):
         if not isinstance(row, dict):
@@ -582,6 +593,21 @@ def check_ticket_matrix(
 
         covered.update(range(low_value, high_value + 1))
 
+        due_days = check_ticket_days(row, band, "due_days", bundle, problems)
+        warn_days = check_ticket_days(row, band, "warn_days", bundle, problems)
+        deadlines.append((low_value, due_days))
+
+        if warn_days is not None and due_days is None:
+            problems.append(
+                f"{bundle.name}: Band {band!r} hat eine Vorwarnzeit, aber keine Frist — "
+                "ohne Frist gibt es nichts, wovor gewarnt werden koennte"
+            )
+        elif warn_days is not None and due_days is not None and warn_days > due_days:
+            problems.append(
+                f"{bundle.name}: Band {band!r} warnt {warn_days} Tage vor einer Frist von "
+                f"{due_days} Tagen — die Vorwarnung laege vor der Bewertung"
+            )
+
         priority = row.get("priority")
         if priority is None:
             continue
@@ -596,6 +622,28 @@ def check_ticket_matrix(
                 "die das Paket nicht mitbringt"
             )
 
+    # Je hoeher das Risiko, desto kuerzer die Frist. Eine fehlende Frist zaehlt
+    # als „unendlich" und ist deshalb nur ganz unten zulaessig (das niedrigste
+    # Band der DAkkS-Vorlagen kommt bewusst ohne aus: Eintrag genuegt). Eine
+    # Vorlage, die dem kritischen Band drei Monate und dem normalen eine Woche
+    # gibt, ist ein Zahlendreher, den beim Lesen niemand bemerkt — die Matrix
+    # sortiert nach Farbe, nicht nach Tagen.
+    previous_band: int | None = None
+    previous_days: int | None = None
+    for low_value, due_days in sorted(deadlines):
+        if previous_band is not None and previous_days is not None:
+            if due_days is None:
+                problems.append(
+                    f"{bundle.name}: Band ab {low_value} hat gar keine Frist, das niedrigere "
+                    f"Band ab {previous_band} aber {previous_days} Tage"
+                )
+            elif due_days > previous_days:
+                problems.append(
+                    f"{bundle.name}: Band ab {low_value} hat mit {due_days} Tagen eine laengere "
+                    f"Frist als das niedrigere Band ab {previous_band} ({previous_days} Tage)"
+                )
+        previous_band, previous_days = low_value, due_days
+
     if reachable <= 0:
         return
 
@@ -605,6 +653,35 @@ def check_ticket_matrix(
             f"{bundle.name}: die Matrix deckt den erreichbaren Wertebereich 1 bis {reachable} "
             f"nicht ab — es fehlen {len(missing)} Werte, erster: {missing[0]}"
         )
+
+
+def check_ticket_days(
+    row: dict,
+    band: str,
+    field: str,
+    bundle: Path,
+    problems: list[str],
+) -> int | None:
+    """Frist oder Vorwarnzeit einer Matrixzeile, in Kalendertagen.
+
+    Fehlt der Wert, heisst das „keine" — das ist gueltig und der Normalfall
+    eines Pakets der Dokumentversion 1. Steht dort aber etwas, muss es eine
+    ganze Zahl ab 1 sein: 0 als „keine Frist" zu lesen hiesse, einen
+    Zahlendreher stillschweigend zu verwerfen.
+    """
+    value = row.get(field)
+    if value is None:
+        return None
+
+    if isinstance(value, bool) or not isinstance(value, int):
+        problems.append(f"{bundle.name}: Band {band!r} hat unter {field} keine Anzahl Tage: {value!r}")
+        return None
+
+    if not 1 <= value <= 3650:
+        problems.append(f"{bundle.name}: Band {band!r}: {field} muss zwischen 1 und 3650 Tagen liegen, ist {value}")
+        return None
+
+    return value
 
 
 def check_field_rules(rules: object, label: str, problems: list[str]) -> None:
@@ -658,11 +735,12 @@ def check_bundle(bundle: Path) -> list[str]:
             f"erwartet {spec['document_format']!r}"
         )
 
+    max_version = spec.get("max_document_version", MAX_DOCUMENT_VERSION)
     document_version = document.get("version")
-    if not isinstance(document_version, int) or document_version > MAX_DOCUMENT_VERSION:
+    if not isinstance(document_version, int) or document_version > max_version:
         problems.append(
             f"{bundle.name}: Dokumentversion {document_version!r} ist unlesbar "
-            f"(hoechstens {MAX_DOCUMENT_VERSION})"
+            f"(hoechstens {max_version})"
         )
 
     # Dateien: Manifest gegen Platte, in beide Richtungen.

--- a/scripts/build_ticket_config_3d.py
+++ b/scripts/build_ticket_config_3d.py
@@ -80,13 +80,14 @@ RISK3 = [
     },
 ]
 
-# Bänder über das Produkt dreier Skalen (1…125). Dieselben vier Stufen und
-# dieselben Prioritäten wie in der Zwei-Methoden-Fassung, nur anders geschnitten.
+# Bänder über das Produkt dreier Skalen (1…125). Dieselben vier Stufen, dieselben
+# Prioritäten und dieselben Fristen wie in der Zwei-Methoden-Fassung, nur anders
+# geschnitten: Die Frist folgt der Einstufung, nicht der Rechenart.
 MATRIX = [
     {"risk": "1-9", "color": "00B050", "priority": "Niedrig", "sort_order": 1},
-    {"risk": "10-29", "color": "FFFF00", "priority": "Normal", "sort_order": 2},
-    {"risk": "30-59", "color": "FFC000", "priority": "Hoch", "sort_order": 3},
-    {"risk": "60-125", "color": "FF0000", "priority": "Kritisch", "sort_order": 4},
+    {"risk": "10-29", "color": "FFFF00", "priority": "Normal", "sort_order": 2, "due_days": 90, "warn_days": 14},
+    {"risk": "30-59", "color": "FFC000", "priority": "Hoch", "sort_order": 3, "due_days": 30, "warn_days": 7},
+    {"risk": "60-125", "color": "FF0000", "priority": "Kritisch", "sort_order": 4, "due_days": 7, "warn_days": 2},
 ]
 
 


### PR DESCRIPTION
Die Fristen standen als Vorschlag im README („3 Monate", „1 Monat"), calServer setzte sie nicht durch. Seit Dokumentversion 2 trägt die Matrixzeile sie selbst — das Produkt rechnet daraus die Fälligkeit und meldet ihre Überschreitung (Produkt-PR: calhelp/calServer-yii#3780).

## Was drin ist

**Fristen je Band** (`due_days` / `warn_days`):

| Band (2 Methoden) | Priorität | Frist | Vorwarnung |
|-------------------|-----------|-------|------------|
| 1–4 | Niedrig | keine | — |
| 5–9 | Normal | 90 Tage | 14 Tage |
| 10–14 | Hoch | 30 Tage | 7 Tage |
| 15–25 | Kritisch | 7 Tage | 2 Tage |

Das niedrigste Band bleibt bewusst ohne Frist — ein akzeptiertes Risiko hat keinen Termin, es hat eine Begründung. Die Drei-Methoden-Fassung trägt dieselben Fristen: Sie folgen der Einstufung, nicht der Rechenart. Ein kritischer Vorgang ist kritisch, ob er über zwei oder drei Methoden dorthin kommt.

**Dokumentversion je Paketklasse.** `MAX_DOCUMENT_VERSION` war global. Dass das Ticketmanagement-Dokument eine zweite Version hat, sagt nichts darüber, ob ein Kategoriedokument eine hätte — die Zahl steht jetzt als `max_document_version` am Eintrag der Klasse, die Konstante bleibt der Fallback.

**Vier neue Inhaltsprüfungen** im Manifest-Skript, jede gegen eine mutierte Kopie verifiziert:

| Prüfung | Warum |
|---------|-------|
| Tage sind ganze Zahlen von 1 bis 3650 | `0` ist nicht „keine Frist", sondern ein Tippfehler. Ihn stillschweigend als „keine" zu lesen, verwirft ihn |
| Keine Vorwarnung ohne Frist | Ohne Frist gibt es nichts, wovor gewarnt werden könnte |
| Vorwarnung nicht länger als die Frist | Sie läge sonst vor der Bewertung |
| Frist wird mit steigendem Risiko nie länger | Eine fehlende zählt als unendlich und darf nur ganz unten stehen. Die Matrix sortiert nach Farbe, nicht nach Tagen — ein Zahlendreher fällt beim Lesen niemandem auf |

Alle sechs Mutationen (inkl. der beiden Formfehler) lösen aus; die echten Pakete bleiben grün.

**Nachgezogen:** beide READMEs (aus „setzt calServer nicht durch" wird „setzt calServer durch, die Zuständigkeiten nicht"), Schema-Beschreibungen und `robots.md`.

## Geprüft

- `python3 scripts/build_config_manifest.py --check` — 8 Pakete, alles konsistent
- `python3 scripts/build_ticket_config_3d.py --check` — die abgeleitete Fassung stimmt
- Beide Vorlagen importieren in eine frische calServer-V2-Installation, null Warnungen, Fristen kommen an allen vier Bändern an

## Grenze

Eskalationsgruppe und Endstatus sind **kein** Paketinhalt. Sie zeigen auf Gruppen und Status der Zielinstallation, die es hier nicht gibt, und werden dort einmalig in der Ticket-Verwaltung eingestellt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2GXNMbZmsZuaWLL9RRBTf)_