### PR TITLE
feat(preisliste): Vorlage druckt die Kalibrierarten als Spalten

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/README.md
+++ b/PRICE-LIST-JSON-SAMPLE/README.md
@@ -3,8 +3,9 @@
 Die **Preisliste**, wie ein Labor sie seinem Kunden übergibt: Kategoriebaum mit
 den geltenden Kalibrierpreisen (Typausnahmen eingerückt), Zusatzleistungen mit
 Mengenstaffel, Standardartikel und die Konditions-Fußnoten. Gefüllt aus einem
-**JSON-Datensatz** (Contract `price-list` v1.1) statt aus SQL — DB-agnostisch,
-keine V1-Codespalten. **Zweisprachig**, wenn der Datensatz es ist.
+**JSON-Datensatz** (Contract `price-list` v1.2) statt aus SQL — DB-agnostisch,
+keine V1-Codespalten. **Zweisprachig**, wenn der Datensatz es ist, und
+**mehrspaltig**, wenn Kalibrierarten gepflegt sind.
 
 ## Der Briefkopf steht nicht in dieser Vorlage
 
@@ -24,13 +25,13 @@ ist ein Layout-Eingriff und gehört in die Vorlage.
 | Datei | Zweck |
 |-------|-------|
 | `main_reports/price-list-json-sample.jrxml` | Hauptbericht: Briefkopf-Freiraum, Kopf (Titel, Preisgruppe, Stichtag, Währung, Ableitungsregel), Abschnittsüberschriften, Fußzeile |
-| `subreports/price-list-categories.jrxml` | Kategoriebaum aus `list.calibration`; Obergruppen fett, Untergruppen eingerückt |
+| `subreports/price-list-categories.jrxml` | Kategoriebaum aus `list.calibration`; Obergruppen fett, Untergruppen eingerückt, Grundpreis plus bis zu drei Kalibrierart-Spalten |
 | `subreports/price-list-exceptions.jrxml` | Typausnahmen einer Kategorie (`exceptions`) — die einzige zweistufige Stelle des Bündels |
 | `subreports/price-list-services.jrxml` | Zusatzleistungen aus `list.services` |
 | `subreports/price-list-scales.jrxml` | Mengenstaffel einer Zeile (`scales`), als Kondition unter dem Betrag |
 | `subreports/price-list-articles.jrxml` | Standardartikel aus `list.articles` |
 | `subreports/price-list-surcharges.jrxml` | Konditions-Fußnoten aus `list.surcharges` |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.0) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.2) |
 | `main_reports/price-list-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
 ## Zweisprachig, ohne Fallunterscheidung in der Vorlage
@@ -60,7 +61,57 @@ Eine Fallunterscheidung in JRXML wäre der teuerste Ort dafür: drei Fassungen i
 einer Vorlage sind drei Vorlagen in einer, und jede Änderung müsste sie alle
 treffen.
 
-## Contract `price-list` (v1.1)
+## Kalibrierarten sind Spalten, nicht Zeilen
+
+Die Kalibrierart (ISO, DAkkS, …) ist in calServer normalerweise ein **Zuschlag**
+— „DAkkS +30 %" — und steht dann als Fußnote unter „Konditionen". Das reicht,
+solange der Zuschlag gleichmäßig ist.
+
+Wer ihn nicht gleichmäßig hat, pflegt je Kalibrierart eine eigene Preiszeile
+(Kategorie PK100.01: ISO 89,00, DAkkS 189,00). Die Preisfindung nimmt diese
+Zeile immer vor dem Zuschlag; die Liste zeigte sie bis 1.2 gar nicht, und das
+Kundendokument nannte damit einen anderen Betrag als die Rechnung.
+
+Seit 1.2 druckt der Abschnitt Kalibrierpreise deshalb bis zu **drei zusätzliche
+Betragsspalten**, eine je gepflegter Kalibrierart:
+
+| Datensatz | Rolle |
+|---|---|
+| `list.complexities[]` | alle gepflegten Kalibrierarten mit `value` und `label`, in Reihenfolge des Feldmanagements |
+| `list.complexity_1_label` … `_3_label` | die drei druckbaren Überschriften; **leer = Spalte gibt es nicht** und die Vorlage blendet sie weg |
+| `amount_1` … `amount_3` an jeder Kategorie- und Ausnahmezeile | die Beträge, positionsgleich zu den Überschriften |
+| `amounts` an denselben Zeilen | dieselben Beträge nach Kalibrierart benannt, mit `derived` und `inherited_from` |
+| `list.complexities_truncated` | mehr als drei gepflegt: die Vorlage schreibt es unter die Konditionen |
+
+**Warum beides, Position und Name.** Ein JRXML-Feldpfad steht zur Entwurfszeit
+fest; der Schlüssel „DAkkS" entsteht erst beim Kunden. Die mitgelieferte Vorlage
+liest deshalb die Positionen. Eine selbst gebaute Vorlage für **eine**
+Installation kennt ihre Kalibrierarten und liest bequemer `amounts.DAkkS.amount`.
+
+**Ohne gepflegte Zeilen ändert sich nichts.** `complexities` ist dann leer, alle
+Überschriften sind leer, keine Spalte wird gedruckt — die Liste sieht aus wie vor
+1.2, und die Fußnote macht wie gehabt ihre Arbeit.
+
+**Eine leere Spalte zeigt nichts, nicht „0,00".** „Für diese Kalibrierart ist
+nichts gepflegt" und „kostet nichts" sind verschiedene Aussagen; auf einem
+Dokument, das man aus der Hand gibt, ist die Verwechslung teuer.
+
+**Die Kappung bei drei ist Geometrie, keine Meinung.** JRXML kann Spalten nicht
+zur Laufzeit einfügen, und mehr als vier Betragsspalten lassen auf A4 hoch
+keinen Platz für Nummer und Bezeichnung. Wer mehr braucht, nimmt den CSV-Export
+oder baut eine Querformat-Vorlage über `amounts`. Gekappt wird sichtbar: die
+Vorlage schreibt es unter die Konditionen, statt so zu tun, als sei das alles.
+
+## Die Währung steht im Kopf
+
+Seit 1.2 nennt die Spaltenüberschrift die Währung („Betrag (EUR)"), und die
+Zeilen des Abschnitts Kalibrierpreise drucken sie nicht mehr einzeln. Vier
+Betragsspalten und daneben viermal „EUR" passen nicht auf die Seite, und echte
+Laborlisten nennen die Währung ohnehin einmal oben. Die Abschnitte
+Zusatzleistungen und Standardartikel haben nur einen Betrag und behalten ihre
+Währungsangabe an der Zeile.
+
+## Contract `price-list` (v1.2)
 
 Dataset-Builder: Laravel `PriceListReportDataBuilder`; derselbe Aufbau, den die
 Preislisten-Seite liest (`PriceListService`). Datensatz zum Vorlagenbau:
@@ -78,6 +129,18 @@ wenn der Mandant nur eine Sprache führt — dann ist `mode` immer `primary`.
 
 **Neu in 1.1** (additiv, 1.0-Vorlagen laufen unverändert weiter):
 `list.language` und `name_secondary` an jeder benannten Zeile.
+
+**Neu in 1.2** (additiv, 1.1-Vorlagen laufen unverändert weiter):
+`list.complexities[]`, `list.complexity_1_label` … `_3_label`,
+`list.complexities_truncated` sowie `amounts` und `amount_1` … `amount_3` an
+jeder Kategorie-, Ausnahme- und Typzeile. Eine 1.1-Vorlage liest weiter nur
+`amount` und druckt den Grundpreis wie bisher.
+
+Eine Änderung ist **nicht** rein additiv und gehört auf den Zettel: `amount`
+einer **Typzeile** (`exceptions[]`, `other_type_prices.entries[]`) kann jetzt
+`null` sein. Ein Gerätetyp, für den nur eine DAkkS-Zeile gepflegt ist, hat
+keinen Grundpreis; bis 1.1 fiel er komplett aus der Liste, jetzt steht er drin
+und die Betragsspalte bleibt leer.
 
 Zwei Feinheiten, die man beim Lesen des Datensatzes leicht übersieht:
 
@@ -135,6 +198,15 @@ einsprachige Liste also keinen Millimeter. Der mitgelieferte
 `sample-data.json` steht bewusst auf `mode: both` und lässt zwei Zeilen
 unübersetzt (`Klimaschrank / Ofen`, `Express-Bearbeitung`), damit beide Fälle
 in der Vorschau sichtbar sind.
+
+Für 1.2 kam ein dritter Lauf dazu, jeweils Kompilat **und** Füllung gegen
+JasperReports 6.20.6: derselbe Datensatz mit zwei Kalibrierart-Spalten, mit
+drei plus gesetztem `complexities_truncated`, und ganz ohne. **Ohne** stehen
+Inhalt und Position jedes Textelements des Abschnitts A wieder dort, wo eine
+einspaltige Liste sie hat; die Spalten kosten also nichts, solange niemand sie
+pflegt. Mit Spalten wurde geprüft, dass die Überschriften vollständig stehen
+(„DAkkS-Kalibrierung" passt nur zweizeilig in 64 pt) und dass die Beträge im
+selben Raster fluchten wie die Kategorie darüber.
 
 Die pixelgenaue Abnahme des Layouts (report-runner) bleibt wie gehabt
 maßgeblich.

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 Preisliste (customer-facing), Contract "price-list" v1.1. Gefüllt aus einem
+  V2 Preisliste (customer-facing), Contract "price-list" v1.2. Gefüllt aus einem
   JSON-Datensatz — kein SQL, keine V1-Codespalten.
 
   DER BRIEFKOPF STEHT NICHT IN DIESER VORLAGE. Er kommt je Mandant über das
@@ -21,6 +21,29 @@
   was sie bekommt; eine Vorlage, die selbst zwischen drei Fassungen
   unterscheidet, wäre drei Vorlagen in einer. Der Kopf nennt die Fassung, damit
   man einem ausgedruckten Blatt ansieht, welche Liste man in der Hand hält.
+
+  KALIBRIERARTEN ALS SPALTEN (Contract 1.2): Neben dem Grundpreis druckt der
+  Abschnitt Kalibrierpreise bis zu DREI weitere Betragsspalten — je eine
+  gepflegte Kalibrierart (ISO, DAkkS, …). Wie sie heißen, steht in
+  `list.complexity_1_label` … `_3_label`; leer heißt „diese Spalte gibt es
+  nicht" und blendet sie weg. Die Beträge stehen positionsgleich als
+  `amount_1` … `amount_3` an jeder Kategorie- und Ausnahmezeile.
+
+  Warum Position statt Name: `list.calibration[].amounts` ist nach der
+  Kalibrierart benannt („DAkkS"), und dieser Schlüssel entsteht erst beim
+  Kunden — ein JRXML-Feldpfad steht zur Entwurfszeit fest. Der
+  Datensatz-Builder legt deshalb beides bei.
+
+  Führt eine Installation mehr als drei Kalibrierarten, druckt die Vorlage die
+  ersten drei und sagt es unter den Konditionen (`complexities_truncated`).
+  Vollständig ist der CSV-Export. Und wer die Kalibrierart wie üblich über
+  einen Zuschlag abbildet, hat gar keine Spalten: die Liste sieht aus wie vor
+  1.2, der Zuschlag steht als Fußnote unter „Konditionen".
+
+  DIE WÄHRUNG STEHT IM KOPF, NICHT AN JEDER ZEILE. Vier Betragsspalten und
+  daneben viermal „EUR" passen auf A4 hoch nicht — und echte Laborlisten
+  nennen die Währung ohnehin einmal oben. Die Spaltenüberschrift trägt sie
+  zusätzlich in Klammern.
 
   Bewusst NICHT gedruckt: `list.other_type_prices`. Das ist die gekappte Liste
   der Typpreise ohne Kategorie (Obergrenze 200) — ein Übergangsbestand auf dem
@@ -55,6 +78,10 @@
 	<field name="language_mode" class="java.lang.String"><fieldDescription><![CDATA[list.language.mode]]></fieldDescription></field>
 	<field name="language_primary_label" class="java.lang.String"><fieldDescription><![CDATA[list.language.primary_label]]></fieldDescription></field>
 	<field name="language_secondary_label" class="java.lang.String"><fieldDescription><![CDATA[list.language.secondary_label]]></fieldDescription></field>
+	<field name="complexity_1_label" class="java.lang.String"><fieldDescription><![CDATA[list.complexity_1_label]]></fieldDescription></field>
+	<field name="complexity_2_label" class="java.lang.String"><fieldDescription><![CDATA[list.complexity_2_label]]></fieldDescription></field>
+	<field name="complexity_3_label" class="java.lang.String"><fieldDescription><![CDATA[list.complexity_3_label]]></fieldDescription></field>
+	<field name="complexities_truncated" class="java.lang.Boolean"><fieldDescription><![CDATA[list.complexities_truncated]]></fieldDescription></field>
 	<!--
 		Die oberen 128 pt (≈ 45 mm) des Titelbandes bleiben leer: dort stempelt
 		das PDF-Overlay den Briefkopf des Mandanten. Der Freiraum ist bewusst
@@ -104,48 +131,74 @@
 		<band height="0"/>
 	</pageHeader>
 	<detail>
-		<band height="60">
+		<band height="68">
 			<staticText>
-				<reportElement style="Section" x="0" y="0" width="404" height="14">
+				<reportElement style="Section" x="0" y="8" width="250" height="14">
 					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<text><![CDATA[Kalibrierpreise]]></text>
 			</staticText>
-			<staticText>
-				<reportElement style="Label" x="410" y="2" width="80" height="11">
+			<!--
+				Vier Betragsspalten in einem Raster von 68 pt: Grundpreis, dann
+				bis zu drei Kalibrierarten. Eine Spalte ohne Namen wird nicht
+				gedruckt — dann steht rechts vom Grundpreis nichts, wie vor 1.2.
+			-->
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" x="256" y="0" width="64" height="22">
 					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Betrag]]></text>
-			</staticText>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA["Betrag" + ($F{currency} == null || $F{currency}.isEmpty() ? "" : " (" + $F{currency} + ")")]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" x="324" y="0" width="64" height="22">
+					<printWhenExpression><![CDATA[$F{complexity_1_label} != null && !$F{complexity_1_label}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$F{complexity_1_label}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" x="392" y="0" width="64" height="22">
+					<printWhenExpression><![CDATA[$F{complexity_2_label} != null && !$F{complexity_2_label}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$F{complexity_2_label}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" x="460" y="0" width="64" height="22">
+					<printWhenExpression><![CDATA[$F{complexity_3_label} != null && !$F{complexity_3_label}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$F{complexity_3_label}]]></textFieldExpression>
+			</textField>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="16" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="24" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.calibration")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-categories.jasper"]]></subreportExpression>
 			</subreport>
 			<staticText>
-				<reportElement style="Section" positionType="Float" x="0" y="20" width="404" height="14" isRemoveLineWhenBlank="true">
+				<reportElement style="Section" positionType="Float" x="0" y="28" width="404" height="14" isRemoveLineWhenBlank="true">
 					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<text><![CDATA[Zusatzleistungen]]></text>
 			</staticText>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="36" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="44" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.services")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-services.jasper"]]></subreportExpression>
 			</subreport>
 			<staticText>
-				<reportElement style="Section" positionType="Float" x="0" y="40" width="404" height="14" isRemoveLineWhenBlank="true">
+				<reportElement style="Section" positionType="Float" x="0" y="48" width="404" height="14" isRemoveLineWhenBlank="true">
 					<printWhenExpression><![CDATA[$F{count_articles} != null && $F{count_articles}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<text><![CDATA[Standardartikel]]></text>
 			</staticText>
 			<subreport>
-				<reportElement positionType="Float" x="0" y="56" width="561" height="1" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="0" y="64" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.articles")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-articles.jasper"]]></subreportExpression>
@@ -167,7 +220,7 @@
 		</band>
 	</pageFooter>
 	<summary>
-		<band height="40">
+		<band height="54">
 			<line><reportElement positionType="Float" x="0" y="4" width="561" height="1"/></line>
 			<staticText><reportElement style="Label" positionType="Float" x="0" y="8" width="200" height="11"/><text><![CDATA[Konditionen]]></text></staticText>
 			<subreport>
@@ -176,6 +229,18 @@
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.surcharges")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-surcharges.jasper"]]></subreportExpression>
 			</subreport>
+			<!--
+				Gekappt wird sichtbar, nicht still: eine Liste, die drei von
+				fünf Kalibrierarten zeigt und darüber schweigt, liest sich wie
+				eine vollständige.
+			-->
+			<textField isBlankWhenNull="true">
+				<reportElement positionType="Float" x="0" y="34" width="561" height="10" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{complexities_truncated} != null && $F{complexities_truncated}.booleanValue()]]></printWhenExpression>
+				</reportElement>
+				<textElement><font size="7" isItalic="true"/></textElement>
+				<textFieldExpression><![CDATA["Weitere Kalibrierarten sind gepflegt, aber auf diesem Dokument nicht abgebildet. Die vollständige Aufstellung liefert der CSV-Export."]]></textFieldExpression>
+			</textField>
 		</band>
 	</summary>
 </jasperReport>

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "price-list",
-    "schema_version": "1.1",
+    "schema_version": "1.2",
     "generated_at": "2026-08-10T09:00:00+02:00",
     "locale": "de-DE"
   },
@@ -23,6 +23,20 @@
       "mode": "percent",
       "value": -15
     },
+    "complexities": [
+      {
+        "value": "ISO",
+        "label": "ISO-Kalibrierung"
+      },
+      {
+        "value": "DAkkS",
+        "label": "DAkkS-Kalibrierung"
+      }
+    ],
+    "complexities_truncated": false,
+    "complexity_1_label": "ISO-Kalibrierung",
+    "complexity_2_label": "DAkkS-Kalibrierung",
+    "complexity_3_label": "",
     "surcharges": [
       {
         "reference_id": "DAkkS",
@@ -51,7 +65,11 @@
         "derived": false,
         "inherited_from": null,
         "exceptions": [],
-        "scales": []
+        "scales": [],
+        "amounts": {},
+        "amount_1": null,
+        "amount_2": null,
+        "amount_3": null
       },
       {
         "id": "pk-100-01",
@@ -69,10 +87,35 @@
             "type_label": "Keithley DMM6500",
             "amount": 110.0,
             "derived": false,
-            "scales": []
+            "scales": [],
+            "amounts": {
+              "DAkkS": {
+                "amount": 209.0,
+                "derived": false,
+                "inherited_from": null
+              }
+            },
+            "amount_1": null,
+            "amount_2": 209.0,
+            "amount_3": null
           }
         ],
-        "scales": []
+        "scales": [],
+        "amounts": {
+          "ISO": {
+            "amount": 75.74,
+            "derived": false,
+            "inherited_from": null
+          },
+          "DAkkS": {
+            "amount": 176.72,
+            "derived": false,
+            "inherited_from": null
+          }
+        },
+        "amount_1": 75.74,
+        "amount_2": 176.72,
+        "amount_3": null
       },
       {
         "id": "pk-100-02",
@@ -91,7 +134,17 @@
             "price": null,
             "discount": 10
           }
-        ]
+        ],
+        "amounts": {
+          "DAkkS": {
+            "amount": 212.42,
+            "derived": false,
+            "inherited_from": null
+          }
+        },
+        "amount_1": null,
+        "amount_2": 212.42,
+        "amount_3": null
       },
       {
         "id": "pk-200",
@@ -104,7 +157,11 @@
         "derived": false,
         "inherited_from": null,
         "exceptions": [],
-        "scales": []
+        "scales": [],
+        "amounts": {},
+        "amount_1": null,
+        "amount_2": null,
+        "amount_3": null
       },
       {
         "id": "pk-200-01",
@@ -117,7 +174,17 @@
         "derived": true,
         "inherited_from": null,
         "exceptions": [],
-        "scales": []
+        "scales": [],
+        "amounts": {
+          "DAkkS": {
+            "amount": 105.31,
+            "derived": false,
+            "inherited_from": null
+          }
+        },
+        "amount_1": null,
+        "amount_2": 105.31,
+        "amount_3": null
       },
       {
         "id": "pk-200-02",
@@ -134,7 +201,17 @@
           "name_secondary": "Temperature"
         },
         "exceptions": [],
-        "scales": []
+        "scales": [],
+        "amounts": {
+          "DAkkS": {
+            "amount": 622.97,
+            "derived": false,
+            "inherited_from": null
+          }
+        },
+        "amount_1": null,
+        "amount_2": 622.97,
+        "amount_3": null
       }
     ],
     "other_type_prices": {

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-articles.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-articles.jrxml
@@ -18,16 +18,16 @@
 	<detail>
 		<band height="23">
 			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="404" height="12"/>
+				<reportElement x="0" y="0" width="250" height="12"/>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
-				<reportElement x="410" y="0" width="80" height="12"/>
+				<reportElement x="256" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="494" y="0" width="67" height="12">
+				<reportElement x="324" y="0" width="67" height="12">
 					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
 				</reportElement>
 				<textFieldExpression><![CDATA[$P{Currency} + ($F{unit} != null ? " / " + $F{unit} : "")]]></textFieldExpression>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  Kategoriebaum der Preisliste, Contract "price-list" v1.1. Eine Zeile je
+  Kategoriebaum der Preisliste, Contract "price-list" v1.2. Eine Zeile je
   Preiskategorie aus `list.calibration`; die Baumtiefe steckt als Zahl in
   `depth` und wird als Einrückung gerechnet (der Datensatz ist bereits in
   Baumreihenfolge sortiert — hier wird nicht umsortiert).
@@ -11,6 +11,17 @@
 
   Typausnahmen hängen als Array `exceptions` an der Kategorie und laufen über
   einen eingebetteten Subreport — die einzige zweistufige Stelle des Bündels.
+
+  KALIBRIERARTEN (Contract 1.2): Rechts vom Grundpreis stehen bis zu drei
+  weitere Betragsspalten — `amount_1` … `amount_3`, positionsgleich zu den
+  Überschriften `list.complexity_1_label` … im Hauptbericht. Eine Spalte ohne
+  gepflegte Zeile bleibt LEER und zeigt kein "0,00": „nicht gepflegt" und
+  „kostet nichts" sind verschiedene Aussagen, und auf einer Kundenliste ist die
+  Verwechslung teuer.
+
+  Die Währung steht seit 1.2 im Spaltenkopf des Hauptberichts, nicht mehr an
+  jeder Zeile — vier Betragsspalten und viermal "EUR" daneben passen auf A4
+  hoch nicht.
 
   ZWEISPRACHIG (Contract 1.1): `name` trägt bereits die angeforderte Sprache —
   der Datensatz-Builder löst das auf, nicht diese Vorlage. `name_secondary` ist
@@ -30,53 +41,65 @@
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
 	<field name="derived" class="java.lang.Boolean"><fieldDescription><![CDATA[derived]]></fieldDescription></field>
 	<field name="inherited_from_name" class="java.lang.String"><fieldDescription><![CDATA[inherited_from.name]]></fieldDescription></field>
+	<field name="amount_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_1]]></fieldDescription></field>
+	<field name="amount_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_2]]></fieldDescription></field>
+	<field name="amount_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_3]]></fieldDescription></field>
 	<detail>
 		<band height="25">
 			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="70" height="12">
+				<reportElement x="0" y="0" width="58" height="12">
 					<printWhenExpression><![CDATA[$F{depth} != null && $F{depth}.intValue() == 0]]></printWhenExpression>
 				</reportElement>
 				<textElement><font isBold="true" size="9"/></textElement>
 				<textFieldExpression><![CDATA[$F{number}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="70" height="12">
+				<reportElement x="0" y="0" width="58" height="12">
 					<printWhenExpression><![CDATA[$F{depth} == null || $F{depth}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<textElement><font size="8"/></textElement>
 				<textFieldExpression><![CDATA[$F{number}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="74" y="0" width="330" height="12">
+				<reportElement x="62" y="0" width="184" height="12">
 					<printWhenExpression><![CDATA[$F{depth} != null && $F{depth}.intValue() == 0]]></printWhenExpression>
 				</reportElement>
 				<textElement><font isBold="true" size="9"/></textElement>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="86" y="0" width="318" height="12">
+				<reportElement x="74" y="0" width="172" height="12">
 					<printWhenExpression><![CDATA[$F{depth} == null || $F{depth}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
-				<reportElement x="410" y="0" width="80" height="12"/>
+				<reportElement x="256" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="494" y="0" width="30" height="12">
-					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
-				</reportElement>
-				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="324" y="0" width="64" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount_1}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="392" y="0" width="64" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount_2}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="460" y="0" width="64" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount_3}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="527" y="0" width="34" height="12"/>
+				<reportElement x="528" y="0" width="33" height="12"/>
 				<textElement textAlignment="Right"><font size="6"/></textElement>
 				<textFieldExpression><![CDATA[($F{derived} != null && $F{derived}.booleanValue() ? "abgel." : "") + ($F{inherited_from_name} != null ? " geerbt" : "")]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement positionType="Float" x="86" y="12" width="318" height="10" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="74" y="12" width="172" height="10" isRemoveLineWhenBlank="true"/>
 				<textElement><font size="8" isItalic="true"/></textElement>
 				<textFieldExpression><![CDATA[$F{name_secondary}]]></textFieldExpression>
 			</textField>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-exceptions.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-exceptions.jrxml
@@ -1,42 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  Typausnahmen einer Preiskategorie, Contract "price-list" v1.0. Läuft über
+  Typausnahmen einer Preiskategorie, Contract "price-list" v1.2. Läuft über
   `exceptions` der jeweiligen Kategoriezeile (zweite Stufe, aufgerufen aus
   price-list-categories).
 
   Eine Ausnahme ist ein echter Preis, den der Kunde zahlt — sie gehört auf das
   Papier, eingerückt unter ihre Kategorie, damit erkennbar bleibt, wovon sie
   die Ausnahme ist.
+
+  KALIBRIERARTEN (Contract 1.2): dieselben bis zu drei Spalten wie in der
+  Kategoriezeile darüber (`amount_1` … `amount_3`), im selben Raster — sonst
+  stünde die Ausnahme unter der falschen Überschrift. Seit 1.2 kann `amount`
+  einer Ausnahme LEER sein: ein Gerätetyp, für den nur eine DAkkS-Zeile
+  gepflegt ist, hat keinen Grundpreis und ist trotzdem eine Ausnahme.
+
+  Die Währung steht im Spaltenkopf des Hauptberichts, nicht mehr an der Zeile.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="price-list-exceptions" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a1b2c3d4-0002-4000-8000-000000000002">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
 	<field name="type_label" class="java.lang.String"><fieldDescription><![CDATA[type_label]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
+	<field name="amount_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_1]]></fieldDescription></field>
+	<field name="amount_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_2]]></fieldDescription></field>
+	<field name="amount_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_3]]></fieldDescription></field>
 	<detail>
 		<band height="12">
 			<staticText>
-				<reportElement x="98" y="0" width="8" height="11"/>
+				<reportElement x="86" y="0" width="8" height="11"/>
 				<textElement><font size="8"/></textElement>
 				<text><![CDATA[↳]]></text>
 			</staticText>
 			<textField isBlankWhenNull="true">
-				<reportElement x="108" y="0" width="296" height="11"/>
+				<reportElement x="96" y="0" width="150" height="11"/>
 				<textElement><font size="8"/></textElement>
 				<textFieldExpression><![CDATA[$F{type_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
-				<reportElement x="410" y="0" width="80" height="11"/>
+				<reportElement x="256" y="0" width="64" height="11"/>
 				<textElement textAlignment="Right"><font size="8"/></textElement>
 				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="494" y="0" width="30" height="11">
-					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
-				</reportElement>
-				<textElement><font size="8"/></textElement>
-				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="324" y="0" width="64" height="11"/>
+				<textElement textAlignment="Right"><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$F{amount_1}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="392" y="0" width="64" height="11"/>
+				<textElement textAlignment="Right"><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$F{amount_2}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="460" y="0" width="64" height="11"/>
+				<textElement textAlignment="Right"><font size="8"/></textElement>
+				<textFieldExpression><![CDATA[$F{amount_3}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-scales.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-scales.jrxml
@@ -16,7 +16,7 @@
 	<detail>
 		<band height="11">
 			<textField isBlankWhenNull="true">
-				<reportElement x="108" y="0" width="416" height="10"/>
+				<reportElement x="96" y="0" width="428" height="10"/>
 				<textElement><font size="7" isItalic="true"/></textElement>
 				<textFieldExpression><![CDATA["ab " + ($F{min_quantity} == null ? "" : new java.text.DecimalFormat("#,##0.##").format($F{min_quantity})) + ": " + ($F{price} != null ? new java.text.DecimalFormat("#,##0.00").format($F{price}) + " " + $P{Currency} : ($F{discount} != null ? "−" + new java.text.DecimalFormat("#,##0.##").format($F{discount}) + " %" : ""))]]></textFieldExpression>
 			</textField>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
@@ -22,16 +22,16 @@
 	<detail>
 		<band height="25">
 			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="404" height="12"/>
+				<reportElement x="0" y="0" width="250" height="12"/>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
-				<reportElement x="410" y="0" width="80" height="12"/>
+				<reportElement x="256" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="494" y="0" width="30" height="12">
+				<reportElement x="324" y="0" width="30" height="12">
 					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
 				</reportElement>
 				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>


### PR DESCRIPTION
Contract `price-list` auf **1.2**. Der Abschnitt Kalibrierpreise bekommt neben dem Grundpreis bis zu drei weitere Betragsspalten, eine je gepflegter Kalibrierart (ISO, DAkkS, …).

Gegenstück zu calhelp/calServer-yii#3810, das den Datensatz liefert.

## Warum

Die Kalibrierart war bis hierher nur ein Zuschlag und damit eine Fußnote unter „Konditionen". Das reicht, solange der Zuschlag gleichmäßig ist. Wo je Kalibrierart eine eigene Preiszeile gepflegt ist (PK100.01: ISO 89,00, DAkkS 189,00), ist es kein Satz mehr, den man in eine Fußnote schreibt — und die Preisfindung nimmt diese Zeile ohnehin vor jedem Zuschlag. Das Dokument nannte damit einen anderen Betrag als die Rechnung.

## Wie gelesen wird

Positionsgleich: `complexity_1_label` … `_3_label` als Überschriften, `amount_1` … `amount_3` an jeder Kategorie- und Ausnahmezeile. Ein JRXML-Feldpfad steht zur Entwurfszeit fest, der Schlüssel „DAkkS" entsteht erst beim Kunden — deshalb Position statt Name. Wer eine eigene Vorlage für **eine** Installation baut, liest bequemer `amounts.DAkkS.amount`; beides liegt im Datensatz.

- **Leere Überschrift blendet die Spalte weg.** Ohne gepflegte Zeilen steht jedes Textelement des Abschnitts A wieder dort, wo es vor 1.2 stand.
- **Eine leere Spalte zeigt nichts, nicht „0,00".** „Nicht gepflegt" und „kostet nichts" sind verschiedene Aussagen, und auf einem Dokument, das man aus der Hand gibt, ist die Verwechslung teuer.
- **Mehr als drei gepflegt:** die ersten drei werden gedruckt, und `complexities_truncated` schreibt es unter die Konditionen. Gekappt wird sichtbar. Die Grenze ist Geometrie, keine Meinung — mehr als vier Betragsspalten lassen auf A4 hoch keinen Platz für Nummer und Bezeichnung, und JRXML kann Spalten nicht zur Laufzeit einfügen.
- **`amount` einer Typausnahme kann leer sein.** Ein Gerätetyp, für den nur eine DAkkS-Zeile gepflegt ist, hat keinen Grundpreis; bis 1.1 fiel er ganz aus der Liste.

## Layout

- Die **Währung steht im Spaltenkopf** („Betrag (EUR)") statt an jeder Zeile des Abschnitts A. Vier Betragsspalten und daneben viermal „EUR" passen nicht auf die Seite, und echte Laborlisten nennen die Währung ohnehin einmal oben. Zusatzleistungen und Standardartikel haben nur einen Betrag, behalten ihre Angabe an der Zeile und rücken auf dieselbe Betragsspalte, damit nicht drei Beträge an drei Stellen stehen.
- **Lange Überschriften brechen zweizeilig um.** „DAkkS-Kalibrierung" wurde in 64 pt sonst stumm abgeschnitten (fiel erst im Füllprotokoll auf: gedruckt stand da „DAkkS-").
- `textAdjust="StretchHeight"` statt des veralteten `isStretchWithOverflow`, wie in den übrigen Bündeln des Repos.

## Geprüft

Mit JasperReports **6.20.6**, jeweils Kompilat **und** Füllung:

| Lauf | Ergebnis |
|---|---|
| Zwei Spalten (ISO, DAkkS) | alle sieben JRXML kompilieren, eine Seite, Überschriften vollständig, Beträge fluchten mit der Kategorie darüber |
| Drei Spalten plus `complexities_truncated` | dritte Spalte gedruckt, Hinweis steht unter den Konditionen |
| Ohne Spalten | Inhalt und Position jedes Textelements des Abschnitts A wie in einer einspaltigen Liste |

Dazu `scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py`: sauber (die beiden `DAKKS-JSON-SAMPLE`-Warnungen bestehen unverändert und gehören nicht zu diesem Bündel).

`sample-data.json` steht auf 1.2 mit zwei Spalten, damit die Vorschau in Jaspersoft Studio den Fall zeigt. Die pixelgenaue Abnahme über den report-runner bleibt wie gehabt maßgeblich.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DEXrT8apqxevUD5RWjs7L)_