### PR TITLE
feat(preisliste): Die Grundpreisspalte heißt, was der Datensatz sagt

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
@@ -22,6 +22,12 @@
   unterscheidet, wäre drei Vorlagen in einer. Der Kopf nennt die Fassung, damit
   man einem ausgedruckten Blatt ansieht, welche Liste man in der Hand hält.
 
+  Die Grundpreisspalte heisst, was `list.base_column_label` sagt: ohne
+  Kalibrierart-Spalten "Betrag", mit ihnen "Standard": dann ist sie eine von
+  ihnen, die ohne besonderen Aufwand. Den Namen entscheidet der
+  Datensatz-Builder, damit Bildschirm, CSV und Papier dieselbe Spalte gleich
+  benennen.
+
   KALIBRIERARTEN ALS SPALTEN (Contract 1.2): Neben dem Grundpreis druckt der
   Abschnitt Kalibrierpreise bis zu DREI weitere Betragsspalten — je eine
   gepflegte Kalibrierart (ISO, DAkkS, …). Wie sie heißen, steht in
@@ -82,6 +88,7 @@
 	<field name="complexity_2_label" class="java.lang.String"><fieldDescription><![CDATA[list.complexity_2_label]]></fieldDescription></field>
 	<field name="complexity_3_label" class="java.lang.String"><fieldDescription><![CDATA[list.complexity_3_label]]></fieldDescription></field>
 	<field name="complexities_truncated" class="java.lang.Boolean"><fieldDescription><![CDATA[list.complexities_truncated]]></fieldDescription></field>
+	<field name="base_column_label" class="java.lang.String"><fieldDescription><![CDATA[list.base_column_label]]></fieldDescription></field>
 	<!--
 		Die oberen 128 pt (≈ 45 mm) des Titelbandes bleiben leer: dort stempelt
 		das PDF-Overlay den Briefkopf des Mandanten. Der Freiraum ist bewusst
@@ -148,7 +155,7 @@
 					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA["Betrag" + ($F{currency} == null || $F{currency}.isEmpty() ? "" : " (" + $F{currency} + ")")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[($F{base_column_label} == null || $F{base_column_label}.isEmpty() ? "Betrag" : $F{base_column_label}) + ($F{currency} == null || $F{currency}.isEmpty() ? "" : " (" + $F{currency} + ")")]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" x="324" y="0" width="64" height="22">

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -34,6 +34,7 @@
       }
     ],
     "complexities_truncated": false,
+    "base_column_label": "Standard",
     "complexity_1_label": "ISO-Kalibrierung",
     "complexity_2_label": "DAkkS-Kalibrierung",
     "complexity_3_label": "",


### PR DESCRIPTION
Neues Feld `list.base_column_label` im Contract `price-list`. Die Vorlage druckt es statt eines fest eingebauten „Betrag".

## Warum

„Standard" als Kalibrierart meint denselben Preis wie ein leeres Feld — die Feldhilfe sagt das seit jeher („Leer = Grundpreis, gilt für jede Kalibrierart"). Seit Abschnitt A Spalten je gepflegter Kalibrierart führt, stand „Standard" damit als eigene Spalte **neben** der Grundpreisspalte: dieselbe Aussage zweimal, mit zwei Beträgen, die auseinanderlaufen können.

calServer-yii räumt die Daten auf und benennt die Grundpreisspalte „Standard", sobald Kalibrierart-Spalten daneben stehen. Ohne sie bleibt es beim schlichteren „Betrag" — dann gibt es keine zweite Spalte, gegen die man sie abgrenzen müsste.

## Warum im Datensatz und nicht in der Vorlage

Drei Flächen zeigen dieselbe Spalte: Seite, CSV-Export und dieses PDF. Die Regel dreimal zu schreiben heißt, dass die Spalte irgendwann auf dem Bildschirm anders heißt als auf dem Papier. Der Datensatz-Builder entscheidet sie einmal, die Vorlage druckt, was sie bekommt.

Eine Vorlage ohne das Feld druckt weiter „Betrag": der Ausdruck fällt darauf zurück, wenn `base_column_label` fehlt oder leer ist.

## Geprüft

Mit JasperReports 6.20.6: alle sieben JRXML kompilieren, der Hauptbericht füllt gegen `sample-data.json` auf einer Seite durch, und die Kopfzeile der Betragsspalte liest „Standard (EUR)".

`scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` sauber (die beiden `DAKKS-JSON-SAMPLE`-Warnungen bestehen unverändert und gehören nicht zu diesem Bündel).

---
_Generated by [Claude Code](https://claude.ai/code/session_014DEXrT8apqxevUD5RWjs7L)_