### PR TITLE
feat(preisliste): Kalibrierart-Spalten auch in Abschnitt B

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/README.md
+++ b/PRICE-LIST-JSON-SAMPLE/README.md
@@ -3,7 +3,7 @@
 Die **Preisliste**, wie ein Labor sie seinem Kunden übergibt: Kategoriebaum mit
 den geltenden Kalibrierpreisen (Typausnahmen eingerückt), Zusatzleistungen mit
 Mengenstaffel, Standardartikel und die Konditions-Fußnoten. Gefüllt aus einem
-**JSON-Datensatz** (Contract `price-list` v1.2) statt aus SQL — DB-agnostisch,
+**JSON-Datensatz** (Contract `price-list` v1.3) statt aus SQL — DB-agnostisch,
 keine V1-Codespalten. **Zweisprachig**, wenn der Datensatz es ist, und
 **mehrspaltig**, wenn Kalibrierarten gepflegt sind.
 
@@ -27,11 +27,11 @@ ist ein Layout-Eingriff und gehört in die Vorlage.
 | `main_reports/price-list-json-sample.jrxml` | Hauptbericht: Briefkopf-Freiraum, Kopf (Titel, Preisgruppe, Stichtag, Währung, Ableitungsregel), Abschnittsüberschriften, Fußzeile |
 | `subreports/price-list-categories.jrxml` | Kategoriebaum aus `list.calibration`; Obergruppen fett, Untergruppen eingerückt, Grundpreis plus bis zu drei Kalibrierart-Spalten |
 | `subreports/price-list-exceptions.jrxml` | Typausnahmen einer Kategorie (`exceptions`) — die einzige zweistufige Stelle des Bündels |
-| `subreports/price-list-services.jrxml` | Zusatzleistungen aus `list.services` |
+| `subreports/price-list-services.jrxml` | Zusatzleistungen aus `list.services`, Grundpreis plus bis zu drei Kalibrierart-Spalten |
 | `subreports/price-list-scales.jrxml` | Mengenstaffel einer Zeile (`scales`), als Kondition unter dem Betrag |
 | `subreports/price-list-articles.jrxml` | Standardartikel aus `list.articles` |
 | `subreports/price-list-surcharges.jrxml` | Konditions-Fußnoten aus `list.surcharges` |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.2) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.3) |
 | `main_reports/price-list-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
 ## Zweisprachig, ohne Fallunterscheidung in der Vorlage
@@ -72,14 +72,15 @@ Wer ihn nicht gleichmäßig hat, pflegt je Kalibrierart eine eigene Preiszeile
 Zeile immer vor dem Zuschlag; die Liste zeigte sie bis 1.2 gar nicht, und das
 Kundendokument nannte damit einen anderen Betrag als die Rechnung.
 
-Seit 1.2 druckt der Abschnitt Kalibrierpreise deshalb bis zu **drei zusätzliche
-Betragsspalten**, eine je gepflegter Kalibrierart:
+Seit 1.2 drucken die Abschnitte Kalibrierpreise und (seit 1.3) Zusatzleistungen
+deshalb bis zu **drei zusätzliche Betragsspalten**, eine je gepflegter
+Kalibrierart:
 
 | Datensatz | Rolle |
 |---|---|
 | `list.complexities[]` | alle gepflegten Kalibrierarten mit `value` und `label`, in Reihenfolge des Feldmanagements |
 | `list.complexity_1_label` … `_3_label` | die drei druckbaren Überschriften; **leer = Spalte gibt es nicht** und die Vorlage blendet sie weg |
-| `amount_1` … `amount_3` an jeder Kategorie- und Ausnahmezeile | die Beträge, positionsgleich zu den Überschriften |
+| `amount_1` … `amount_3` an jeder Kategorie-, Ausnahme- und Leistungszeile | die Beträge, positionsgleich zu den Überschriften |
 | `amounts` an denselben Zeilen | dieselben Beträge nach Kalibrierart benannt, mit `derived` und `inherited_from` |
 | `list.complexities_truncated` | mehr als drei gepflegt: die Vorlage schreibt es unter die Konditionen |
 
@@ -111,7 +112,7 @@ Laborlisten nennen die Währung ohnehin einmal oben. Die Abschnitte
 Zusatzleistungen und Standardartikel haben nur einen Betrag und behalten ihre
 Währungsangabe an der Zeile.
 
-## Contract `price-list` (v1.2)
+## Contract `price-list` (v1.3)
 
 Dataset-Builder: Laravel `PriceListReportDataBuilder`; derselbe Aufbau, den die
 Preislisten-Seite liest (`PriceListService`). Datensatz zum Vorlagenbau:
@@ -129,6 +130,14 @@ wenn der Mandant nur eine Sprache führt — dann ist `mode` immer `primary`.
 
 **Neu in 1.1** (additiv, 1.0-Vorlagen laufen unverändert weiter):
 `list.language` und `name_secondary` an jeder benannten Zeile.
+
+**Neu in 1.3** (additiv): dieselben Kalibrierart-Spalten in **Abschnitt B**
+(`services[]` und ihre `variants[]` tragen `amounts` sowie `amount_1` …
+`amount_3`), dazu `list.base_column_label`. Auch hier eine neue Nullbarkeit:
+`amount` einer **Variante** kann fehlen, wenn für die Achsenkombination
+(Gerätetyp × Preiskategorie) nur eine Kalibrierart-Zeile gepflegt ist. Eine
+Variante ist seit 1.3 **eine** Zeile mit Spalten statt einer Zeile je
+Preiszeile — ISO und DAkkS desselben Gerätetyps standen vorher untereinander.
 
 **Neu in 1.2** (additiv, 1.1-Vorlagen laufen unverändert weiter):
 `list.complexities[]`, `list.complexity_1_label` … `_3_label`,
@@ -153,6 +162,11 @@ Zwei Feinheiten, die man beim Lesen des Datensatzes leicht übersieht:
   so; die Typausnahmen bleiben deshalb einsprachig, auch in der Fassung `both`.
 
 ### Bewusst nicht gedruckt
+
+`list.services[].variants` — die typ- und kategoriebezogenen Zeilen einer
+Leistung. Sie brauchen eine eigene Achsenspalte und damit eine eigene Tabelle;
+das war schon vor 1.3 so und ist ein eigener Schnitt, kein Nebenprodukt der
+Spalten.
 
 `list.other_type_prices` — die bei 200 gekappte Liste der Typpreise **ohne**
 Kategorie. Das ist ein Übergangsbestand auf dem Weg zur Kategorisierung, kein
@@ -207,6 +221,11 @@ einspaltige Liste sie hat; die Spalten kosten also nichts, solange niemand sie
 pflegt. Mit Spalten wurde geprüft, dass die Überschriften vollständig stehen
 („DAkkS-Kalibrierung" passt nur zweizeilig in 64 pt) und dass die Beträge im
 selben Raster fluchten wie die Kategorie darüber.
+
+Für 1.3 kam der Abschnitt B dazu: derselbe Spaltenkopf an denselben x-Werten
+wie in Abschnitt A, damit die Beträge über beide Abschnitte fluchten — sonst
+liest man eine DAkkS-Zahl unter einer ISO-Überschrift. Geprüft mit zwei
+Spalten; die Währung steht auch hier jetzt im Kopf statt an jeder Zeile.
 
 Die pixelgenaue Abnahme des Layouts (report-runner) bleibt wie gehabt
 maßgeblich.

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 Preisliste (customer-facing), Contract "price-list" v1.2. Gefüllt aus einem
+  V2 Preisliste (customer-facing), Contract "price-list" v1.3. Gefüllt aus einem
   JSON-Datensatz — kein SQL, keine V1-Codespalten.
 
   DER BRIEFKOPF STEHT NICHT IN DIESER VORLAGE. Er kommt je Mandant über das
@@ -28,8 +28,9 @@
   Datensatz-Builder, damit Bildschirm, CSV und Papier dieselbe Spalte gleich
   benennen.
 
-  KALIBRIERARTEN ALS SPALTEN (Contract 1.2): Neben dem Grundpreis druckt der
-  Abschnitt Kalibrierpreise bis zu DREI weitere Betragsspalten — je eine
+  KALIBRIERARTEN ALS SPALTEN (Contract 1.2, seit 1.3 auch Abschnitt B): Neben
+  dem Grundpreis drucken die Abschnitte Kalibrierpreise und Zusatzleistungen
+  bis zu DREI weitere Betragsspalten — je eine
   gepflegte Kalibrierart (ISO, DAkkS, …). Wie sie heißen, steht in
   `list.complexity_1_label` … `_3_label`; leer heißt „diese Spalte gibt es
   nicht" und blendet sie weg. Die Beträge stehen positionsgleich als
@@ -186,11 +187,42 @@
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-categories.jasper"]]></subreportExpression>
 			</subreport>
 			<staticText>
-				<reportElement style="Section" positionType="Float" x="0" y="28" width="404" height="14" isRemoveLineWhenBlank="true">
+				<reportElement style="Section" positionType="Float" x="0" y="28" width="250" height="14" isRemoveLineWhenBlank="true">
 					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0]]></printWhenExpression>
 				</reportElement>
 				<text><![CDATA[Zusatzleistungen]]></text>
 			</staticText>
+			<!-- Derselbe Spaltenkopf wie in Abschnitt A, an denselben Stellen:
+			     die Betraege sollen ueber beide Abschnitte fluchten, sonst
+			     liest man eine DAkkS-Zahl unter einer ISO-Ueberschrift. -->
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" positionType="Float" x="256" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[($F{base_column_label} == null || $F{base_column_label}.isEmpty() ? "Betrag" : $F{base_column_label}) + ($F{currency} == null || $F{currency}.isEmpty() ? "" : " (" + $F{currency} + ")")]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" positionType="Float" x="324" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{complexity_1_label} != null && !$F{complexity_1_label}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$F{complexity_1_label}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" positionType="Float" x="392" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{complexity_2_label} != null && !$F{complexity_2_label}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$F{complexity_2_label}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
+				<reportElement style="Label" positionType="Float" x="460" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{complexity_3_label} != null && !$F{complexity_3_label}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
+				<textFieldExpression><![CDATA[$F{complexity_3_label}]]></textFieldExpression>
+			</textField>
 			<subreport>
 				<reportElement positionType="Float" x="0" y="44" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "price-list",
-    "schema_version": "1.2",
+    "schema_version": "1.3",
     "generated_at": "2026-08-10T09:00:00+02:00",
     "locale": "de-DE"
   },
@@ -238,7 +238,17 @@
             "price": null,
             "discount": 20
           }
-        ]
+        ],
+        "amounts": {
+          "DAkkS": {
+            "amount": 42.5,
+            "derived": false,
+            "inherited_from": null
+          }
+        },
+        "amount_1": null,
+        "amount_2": 42.5,
+        "amount_3": null
       },
       {
         "id": "sv-2",
@@ -246,7 +256,17 @@
         "name_secondary": null,
         "amount": 60.0,
         "variants": [],
-        "scales": []
+        "scales": [],
+        "amounts": {
+          "DAkkS": {
+            "amount": 102.0,
+            "derived": false,
+            "inherited_from": null
+          }
+        },
+        "amount_1": null,
+        "amount_2": 102.0,
+        "amount_3": null
       }
     ],
     "articles": [

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  Zusatzleistungen der Preisliste, Contract "price-list" v1.1 (`list.services`).
+  Zusatzleistungen der Preisliste, Contract "price-list" v1.3 (`list.services`).
 
   Die Mengenstaffel steht nicht als eigene Tabelle, sondern als Zusatz hinter
   dem Betrag ("ab 5: −10 %") — auf einer Kundenliste ist sie eine Kondition,
   keine zweite Preiszeile. Gerendert aus `scales` über einen eingebetteten
   Subreport, damit beliebig viele Stufen mitlaufen.
+
+  KALIBRIERARTEN (Contract 1.3): Rechts vom Grundpreis stehen dieselben bis zu
+  drei Spalten wie in Abschnitt A, im selben Raster — ein zusaetzlicher
+  Pruefpunkt kostet in DAkkS mehr als in ISO. Die Waehrung steht dafuer im
+  Spaltenkopf des Hauptberichts statt an jeder Zeile.
+
+  NICHT gedruckt: `variants`, die typ- und kategoriebezogenen Zeilen einer
+  Leistung. Das war vor 1.3 auch schon so; sie brauchen eine eigene
+  Achsenspalte und damit eine eigene Tabelle, und die gehoert in einen eigenen
+  Schnitt statt beilaeufig hier hinein.
 
   ZWEISPRACHIG (Contract 1.1): `name` trägt die angeforderte Sprache,
   `name_secondary` ist nur in der Fassung "beide" gefüllt und fällt sonst als
@@ -19,6 +29,9 @@
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
 	<field name="name_secondary" class="java.lang.String"><fieldDescription><![CDATA[name_secondary]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
+	<field name="amount_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_1]]></fieldDescription></field>
+	<field name="amount_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_2]]></fieldDescription></field>
+	<field name="amount_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_3]]></fieldDescription></field>
 	<detail>
 		<band height="25">
 			<textField isBlankWhenNull="true">
@@ -30,11 +43,20 @@
 				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="324" y="0" width="30" height="12">
-					<printWhenExpression><![CDATA[$F{amount} != null]]></printWhenExpression>
-				</reportElement>
-				<textFieldExpression><![CDATA[$P{Currency}]]></textFieldExpression>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="324" y="0" width="64" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount_1}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="392" y="0" width="64" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount_2}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true" pattern="#,##0.00">
+				<reportElement x="460" y="0" width="64" height="12"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{amount_3}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement positionType="Float" x="12" y="12" width="392" height="10" isRemoveLineWhenBlank="true"/>


### PR DESCRIPTION
Contract `price-list` auf **1.3**. Die Zusatzleistungen bekommen denselben Spaltensatz wie die Kalibrierpreise: Grundpreis plus bis zu drei Kalibrierarten.

Gegenstück zu calhelp/calServer-yii, das den Datensatz liefert.

## Warum

Derselbe Fall wie in Abschnitt A, aus dem Feld: ein zusätzlicher Prüfpunkt kostet in DAkkS mehr als in ISO, weil Verfahren, Unsicherheitsbudget und Dokumentation daran hängen. Das ist kein Prozentaufschlag, sondern zwei gepflegte Zahlen — und bis hierher fielen beide aus dem Kundendokument heraus.

## Layout

Die Spaltenköpfe stehen an **denselben x-Werten** wie in Abschnitt A. Das ist der Punkt, nicht Kosmetik: fluchten sie nicht, liest man eine DAkkS-Zahl unter einer ISO-Überschrift.

Abschnitt B hatte bisher gar keinen Spaltenkopf, weil er nur einen Betrag führte. Er bekommt jetzt denselben wie A, inklusive Währung im Kopf — vier Betragsspalten und viermal „EUR" daneben passen auf A4 hoch nicht.

## Bewusst weiter nicht gedruckt

`list.services[].variants` — die typ- und kategoriebezogenen Zeilen einer Leistung. Sie brauchen eine eigene Achsenspalte und damit eine eigene Tabelle; das war vor 1.3 auch schon so und ist ein eigener Schnitt, kein Nebenprodukt der Spalten. Im Datensatz stehen sie samt Spaltenbeträgen bereit, wer eine eigene Vorlage baut, kommt dran.

## Geprüft

Mit JasperReports 6.20.6: alle sieben JRXML kompilieren, der Hauptbericht füllt gegen `sample-data.json` auf einer Seite durch, und die Beträge des Abschnitts B stehen unter ihren Überschriften (`Standard (EUR)` bei x=273, `DAkkS-Kalibrierung` bei x=409 — dieselben Werte wie in Abschnitt A).

`scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` sauber.

Der Beispieldatensatz lässt die ISO-Spalte bewusst leer: der Grundpreis **ist** der ISO-Preis, gepflegt wird nur die Abweichung. Genau der Fall, für den es die Spalten gibt.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DEXrT8apqxevUD5RWjs7L)_