### PR TITLE
Preisliste: Betragsraster rechtsbündig, Führungslinie optional

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/README.md
+++ b/PRICE-LIST-JSON-SAMPLE/README.md
@@ -3,7 +3,7 @@
 Die **Preisliste**, wie ein Labor sie seinem Kunden übergibt: Kategoriebaum mit
 den geltenden Kalibrierpreisen (Typausnahmen eingerückt), Zusatzleistungen mit
 Mengenstaffel, Standardartikel und die Konditions-Fußnoten. Gefüllt aus einem
-**JSON-Datensatz** (Contract `price-list` v1.3) statt aus SQL — DB-agnostisch,
+**JSON-Datensatz** (Contract `price-list` v1.4) statt aus SQL — DB-agnostisch,
 keine V1-Codespalten. **Zweisprachig**, wenn der Datensatz es ist, und
 **mehrspaltig**, wenn Kalibrierarten gepflegt sind.
 
@@ -31,7 +31,7 @@ ist ein Layout-Eingriff und gehört in die Vorlage.
 | `subreports/price-list-scales.jrxml` | Mengenstaffel einer Zeile (`scales`), als Kondition unter dem Betrag |
 | `subreports/price-list-articles.jrxml` | Standardartikel aus `list.articles` |
 | `subreports/price-list-surcharges.jrxml` | Konditions-Fußnoten aus `list.surcharges` |
-| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.3) |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `price-list` v1.4) |
 | `main_reports/price-list-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
 ## Zweisprachig, ohne Fallunterscheidung in der Vorlage
@@ -112,7 +112,7 @@ Laborlisten nennen die Währung ohnehin einmal oben. Die Abschnitte
 Zusatzleistungen und Standardartikel haben nur einen Betrag und behalten ihre
 Währungsangabe an der Zeile.
 
-## Contract `price-list` (v1.3)
+## Contract `price-list` (v1.4)
 
 Dataset-Builder: Laravel `PriceListReportDataBuilder`; derselbe Aufbau, den die
 Preislisten-Seite liest (`PriceListService`). Datensatz zum Vorlagenbau:
@@ -130,6 +130,28 @@ wenn der Mandant nur eine Sprache führt — dann ist `mode` immer `primary`.
 
 **Neu in 1.1** (additiv, 1.0-Vorlagen laufen unverändert weiter):
 `list.language` und `name_secondary` an jeder benannten Zeile.
+
+**Neu in 1.4** (additiv): das Betragsraster ist **rechtsbündig**. Vier feste
+Felder je Zeile (`slot_1` … `slot_4`, Kopf `list.slot_1_label` …
+`slot_4_label`), gefüllt wird von rechts: `list.amount_block_slot` sagt, in
+welchem Feld der Grundpreis steht, die Kalibrierarten folgen dahinter. Bei zwei
+gepflegten Kalibrierarten beginnt der Block also in Feld 2 und das Raster endet
+am rechten Rand statt mitten auf dem Blatt.
+
+Warum über die Zuweisung und nicht über die Geometrie: JRXML kann Felder zur
+Laufzeit nicht verschieben. Vorher standen die Felder links und der ungenutzte
+Rest blieb weiß — genau die Fläche, die im Kundendokument nach einem
+Druckfehler aussieht.
+
+`amount`, `amounts`, `amount_1` … `amount_3` und `complexity_N_label` bleiben
+unverändert stehen: eine 1.3-Vorlage druckt weiter wie bisher.
+
+Dazu der Vorlagenparameter **`Leader_style`** (`dots` / `none`, Vorgabe `dots`):
+eine gepunktete Führungslinie überbrückt die Lücke zwischen Kategoriebezeichnung
+und Betragsblock. Sie wird nur einmal je Zeile gezeichnet, in der Länge, die
+`amount_block_slot` vorgibt — bei einem Block ganz rechts über drei Felder, bei
+einem Block in Feld 2 über eines, und bei Feld 1 gar nicht (dort wäre sie ein
+Stummel).
 
 **Neu in 1.3** (additiv): dieselben Kalibrierart-Spalten in **Abschnitt B**
 (`services[]` und ihre `variants[]` tragen `amounts` sowie `amount_1` …
@@ -195,6 +217,7 @@ verbindlich.
 |-----------|-------|---------|
 | `List_title` | variable (type) | Überschrift des Dokuments; Vorgabe „Preisliste". |
 | `Company_footer` | variable (type) | Optionale Fußzeile auf jeder Seite. Leer lassen, wenn der Briefkopf schon eine mitbringt. |
+| `Leader_style` | variable (type) | Führungslinie zwischen Bezeichnung und Betragsblock: `dots` (Vorgabe) oder `none`. |
 | `Reportpath` | system | Bundle-Wurzel für die Subreport-Auflösung, von calServer gesetzt. |
 
 ## Geprüft
@@ -212,6 +235,15 @@ einsprachige Liste also keinen Millimeter. Der mitgelieferte
 `sample-data.json` steht bewusst auf `mode: both` und lässt zwei Zeilen
 unübersetzt (`Klimaschrank / Ofen`, `Express-Bearbeitung`), damit beide Fälle
 in der Vorschau sichtbar sind.
+
+Für 1.4 kamen zwei Gegenproben dazu, wieder Kompilat **und** Füllung. Mit zwei
+gepflegten Kalibrierarten steht der Spaltenkopf bei x = 341 / 409 / 477 statt
+wie vorher bei 273 / 341 / 409 — also 136 pt weiter rechts, am Blattrand statt
+in der Blattmitte. **Ohne** Kalibrierart landet der Grundpreis in Feld 4
+(`Betrag (EUR)` bei x = 477), nicht in Feld 1. Und die Führungslinie wird genau
+einmal je Zeile gezeichnet, in der zum Block passenden Länge (`w=68` bei Block
+in Feld 2, `w=204` bei Block in Feld 4); mit `Leader_style="none"` bleiben nur
+die beiden durchgehenden Trennlinien der Seite übrig.
 
 Für 1.2 kam ein dritter Lauf dazu, jeweils Kompilat **und** Füllung gegen
 JasperReports 6.20.6: derselbe Datensatz mit zwei Kalibrierart-Spalten, mit

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/price-list-json-sample.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
-  V2 Preisliste (customer-facing), Contract "price-list" v1.3. Gefüllt aus einem
+  V2 Preisliste (customer-facing), Contract "price-list" v1.4. Gefüllt aus einem
   JSON-Datensatz — kein SQL, keine V1-Codespalten.
 
   DER BRIEFKOPF STEHT NICHT IN DIESER VORLAGE. Er kommt je Mandant über das
@@ -70,6 +70,10 @@
 		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
+	<parameter name="Leader_style" class="java.lang.String">
+		<parameterDescription><![CDATA[Fuehrungslinie zwischen Bezeichnung und Betrag: "dots" (gepunktet, Vorgabe) oder "none".]]></parameterDescription>
+		<defaultValueExpression><![CDATA["dots"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="List_title" class="java.lang.String">
 		<parameterDescription><![CDATA[Überschrift des Dokuments. Leer = "Preisliste".]]></parameterDescription>
 		<defaultValueExpression><![CDATA["Preisliste"]]></defaultValueExpression>
@@ -90,6 +94,11 @@
 	<field name="complexity_3_label" class="java.lang.String"><fieldDescription><![CDATA[list.complexity_3_label]]></fieldDescription></field>
 	<field name="complexities_truncated" class="java.lang.Boolean"><fieldDescription><![CDATA[list.complexities_truncated]]></fieldDescription></field>
 	<field name="base_column_label" class="java.lang.String"><fieldDescription><![CDATA[list.base_column_label]]></fieldDescription></field>
+	<field name="slot_1_label" class="java.lang.String"><fieldDescription><![CDATA[list.slot_1_label]]></fieldDescription></field>
+	<field name="slot_2_label" class="java.lang.String"><fieldDescription><![CDATA[list.slot_2_label]]></fieldDescription></field>
+	<field name="slot_3_label" class="java.lang.String"><fieldDescription><![CDATA[list.slot_3_label]]></fieldDescription></field>
+	<field name="slot_4_label" class="java.lang.String"><fieldDescription><![CDATA[list.slot_4_label]]></fieldDescription></field>
+	<field name="amount_block_slot" class="java.lang.Integer"><fieldDescription><![CDATA[list.amount_block_slot]]></fieldDescription></field>
 	<!--
 		Die oberen 128 pt (≈ 45 mm) des Titelbandes bleiben leer: dort stempelt
 		das PDF-Overlay den Briefkopf des Mandanten. Der Freiraum ist bewusst
@@ -147,42 +156,47 @@
 				<text><![CDATA[Kalibrierpreise]]></text>
 			</staticText>
 			<!--
-				Vier Betragsspalten in einem Raster von 68 pt: Grundpreis, dann
-				bis zu drei Kalibrierarten. Eine Spalte ohne Namen wird nicht
-				gedruckt — dann steht rechts vom Grundpreis nichts, wie vor 1.2.
+				Vier Betragsfelder in einem Raster von 68 pt, von RECHTS belegt.
+				Welches Feld welche Spalte traegt, entscheidet der
+				Datensatz-Builder ueber `slot_N_label`: JRXML kann Spalten nicht
+				zur Laufzeit verschieben, also wandert die Zuweisung statt der
+				Geometrie. Ein leeres Feld liegt damit links neben der
+				Bezeichnung, wo es als Abstand liest, statt rechts als Luecke.
 			-->
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" x="256" y="0" width="64" height="22">
-					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0 && $F{slot_1_label} != null && !$F{slot_1_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[($F{base_column_label} == null || $F{base_column_label}.isEmpty() ? "Betrag" : $F{base_column_label}) + ($F{currency} == null || $F{currency}.isEmpty() ? "" : " (" + $F{currency} + ")")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_1_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" x="324" y="0" width="64" height="22">
-					<printWhenExpression><![CDATA[$F{complexity_1_label} != null && !$F{complexity_1_label}.isEmpty()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0 && $F{slot_2_label} != null && !$F{slot_2_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[$F{complexity_1_label}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_2_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" x="392" y="0" width="64" height="22">
-					<printWhenExpression><![CDATA[$F{complexity_2_label} != null && !$F{complexity_2_label}.isEmpty()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0 && $F{slot_3_label} != null && !$F{slot_3_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[$F{complexity_2_label}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_3_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" x="460" y="0" width="64" height="22">
-					<printWhenExpression><![CDATA[$F{complexity_3_label} != null && !$F{complexity_3_label}.isEmpty()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_categories} != null && $F{count_categories}.intValue() > 0 && $F{slot_4_label} != null && !$F{slot_4_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[$F{complexity_3_label}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_4_label}]]></textFieldExpression>
 			</textField>
 			<subreport>
 				<reportElement positionType="Float" x="0" y="24" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
+				<subreportParameter name="Leader_style"><subreportParameterExpression><![CDATA[$P{Leader_style}]]></subreportParameterExpression></subreportParameter>
+				<subreportParameter name="Block_slot"><subreportParameterExpression><![CDATA[$F{amount_block_slot} == null ? Integer.valueOf(4) : $F{amount_block_slot}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.calibration")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-categories.jasper"]]></subreportExpression>
 			</subreport>
@@ -197,36 +211,38 @@
 			     liest man eine DAkkS-Zahl unter einer ISO-Ueberschrift. -->
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" positionType="Float" x="256" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
-					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{slot_1_label} != null && !$F{slot_1_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[($F{base_column_label} == null || $F{base_column_label}.isEmpty() ? "Betrag" : $F{base_column_label}) + ($F{currency} == null || $F{currency}.isEmpty() ? "" : " (" + $F{currency} + ")")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_1_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" positionType="Float" x="324" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
-					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{complexity_1_label} != null && !$F{complexity_1_label}.isEmpty()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{slot_2_label} != null && !$F{slot_2_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[$F{complexity_1_label}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_2_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" positionType="Float" x="392" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
-					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{complexity_2_label} != null && !$F{complexity_2_label}.isEmpty()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{slot_3_label} != null && !$F{slot_3_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[$F{complexity_2_label}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_3_label}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" textAdjust="StretchHeight">
 				<reportElement style="Label" positionType="Float" x="460" y="26" width="64" height="18" isRemoveLineWhenBlank="true">
-					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{complexity_3_label} != null && !$F{complexity_3_label}.isEmpty()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$F{count_services} != null && $F{count_services}.intValue() > 0 && $F{slot_4_label} != null && !$F{slot_4_label}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Bottom"><font size="7"/></textElement>
-				<textFieldExpression><![CDATA[$F{complexity_3_label}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_4_label}]]></textFieldExpression>
 			</textField>
 			<subreport>
 				<reportElement positionType="Float" x="0" y="44" width="561" height="1" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Reportpath"><subreportParameterExpression><![CDATA[$P{Reportpath}]]></subreportParameterExpression></subreportParameter>
 				<subreportParameter name="Currency"><subreportParameterExpression><![CDATA[$F{currency} == null ? "" : $F{currency}]]></subreportParameterExpression></subreportParameter>
+				<subreportParameter name="Leader_style"><subreportParameterExpression><![CDATA[$P{Leader_style}]]></subreportParameterExpression></subreportParameter>
+				<subreportParameter name="Block_slot"><subreportParameterExpression><![CDATA[$F{amount_block_slot} == null ? Integer.valueOf(4) : $F{amount_block_slot}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("list.services")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/price-list-services.jasper"]]></subreportExpression>
 			</subreport>

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "price-list",
-    "schema_version": "1.3",
+    "schema_version": "1.4",
     "generated_at": "2026-08-10T09:00:00+02:00",
     "locale": "de-DE"
   },
@@ -35,6 +35,11 @@
     ],
     "complexities_truncated": false,
     "base_column_label": "Standard",
+    "amount_block_slot": 2,
+    "slot_1_label": "",
+    "slot_2_label": "Standard (EUR)",
+    "slot_3_label": "ISO-Kalibrierung",
+    "slot_4_label": "DAkkS-Kalibrierung",
     "complexity_1_label": "ISO-Kalibrierung",
     "complexity_2_label": "DAkkS-Kalibrierung",
     "complexity_3_label": "",
@@ -70,7 +75,11 @@
         "amounts": {},
         "amount_1": null,
         "amount_2": null,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": null,
+        "slot_3": null,
+        "slot_4": null
       },
       {
         "id": "pk-100-01",
@@ -98,7 +107,11 @@
             },
             "amount_1": null,
             "amount_2": 209.0,
-            "amount_3": null
+            "amount_3": null,
+            "slot_1": null,
+            "slot_2": 110.0,
+            "slot_3": null,
+            "slot_4": 209.0
           }
         ],
         "scales": [],
@@ -116,7 +129,11 @@
         },
         "amount_1": 75.74,
         "amount_2": 176.72,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": 84.15,
+        "slot_3": 75.74,
+        "slot_4": 176.72
       },
       {
         "id": "pk-100-02",
@@ -145,7 +162,11 @@
         },
         "amount_1": null,
         "amount_2": 212.42,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": 101.15,
+        "slot_3": null,
+        "slot_4": 212.42
       },
       {
         "id": "pk-200",
@@ -162,7 +183,11 @@
         "amounts": {},
         "amount_1": null,
         "amount_2": null,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": null,
+        "slot_3": null,
+        "slot_4": null
       },
       {
         "id": "pk-200-01",
@@ -185,7 +210,11 @@
         },
         "amount_1": null,
         "amount_2": 105.31,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": 50.15,
+        "slot_3": null,
+        "slot_4": 105.31
       },
       {
         "id": "pk-200-02",
@@ -212,7 +241,11 @@
         },
         "amount_1": null,
         "amount_2": 622.97,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": 296.65,
+        "slot_3": null,
+        "slot_4": 622.97
       }
     ],
     "other_type_prices": {
@@ -248,7 +281,11 @@
         },
         "amount_1": null,
         "amount_2": 42.5,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": 25.0,
+        "slot_3": null,
+        "slot_4": 42.5
       },
       {
         "id": "sv-2",
@@ -266,7 +303,11 @@
         },
         "amount_1": null,
         "amount_2": 102.0,
-        "amount_3": null
+        "amount_3": null,
+        "slot_1": null,
+        "slot_2": 60.0,
+        "slot_3": null,
+        "slot_4": 102.0
       }
     ],
     "articles": [

--- a/PRICE-LIST-JSON-SAMPLE/parameters.json
+++ b/PRICE-LIST-JSON-SAMPLE/parameters.json
@@ -37,6 +37,40 @@
       "example": "Musterlabor GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterlabor.de"
     },
     {
+      "name": "Leader_style",
+      "label": {
+        "de": "Führungslinie",
+        "en": "Leader line"
+      },
+      "description": {
+        "de": "Gepunktete Linie zwischen Kategoriebezeichnung und Betragsblock. Sie überbrückt die Lücke, die entsteht, wenn weniger Kalibrierarten gepflegt sind als das Raster Spalten hat — ohne sie wandert das Auge über weißen Grund. „dots\" zeichnet sie, „none\" lässt sie weg.",
+        "en": "Dotted line between the category label and the amount block. It bridges the gap that appears when fewer calibration types are maintained than the grid has columns. \"dots\" draws it, \"none\" leaves it out."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "select",
+      "options": [
+        {
+          "value": "dots",
+          "label": {
+            "de": "Gepunktet",
+            "en": "Dotted"
+          }
+        },
+        {
+          "value": "none",
+          "label": {
+            "de": "Ohne",
+            "en": "None"
+          }
+        }
+      ],
+      "required": false,
+      "default": "dots",
+      "group": "Layout",
+      "example": "dots"
+    },
+    {
       "name": "Reportpath",
       "label": {
         "de": "Bundle-Wurzelpfad",

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-categories.jrxml
@@ -34,6 +34,8 @@
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Reportpath" class="java.lang.String"/>
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<parameter name="Leader_style" class="java.lang.String"><defaultValueExpression><![CDATA["dots"]]></defaultValueExpression></parameter>
+	<parameter name="Block_slot" class="java.lang.Integer"><defaultValueExpression><![CDATA[Integer.valueOf(4)]]></defaultValueExpression></parameter>
 	<field name="number" class="java.lang.String"><fieldDescription><![CDATA[number]]></fieldDescription></field>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
 	<field name="name_secondary" class="java.lang.String"><fieldDescription><![CDATA[name_secondary]]></fieldDescription></field>
@@ -41,9 +43,10 @@
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
 	<field name="derived" class="java.lang.Boolean"><fieldDescription><![CDATA[derived]]></fieldDescription></field>
 	<field name="inherited_from_name" class="java.lang.String"><fieldDescription><![CDATA[inherited_from.name]]></fieldDescription></field>
-	<field name="amount_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_1]]></fieldDescription></field>
-	<field name="amount_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_2]]></fieldDescription></field>
-	<field name="amount_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_3]]></fieldDescription></field>
+	<field name="slot_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_1]]></fieldDescription></field>
+	<field name="slot_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_2]]></fieldDescription></field>
+	<field name="slot_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_3]]></fieldDescription></field>
+	<field name="slot_4" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_4]]></fieldDescription></field>
 	<detail>
 		<band height="25">
 			<textField isBlankWhenNull="true">
@@ -73,25 +76,52 @@
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
+			<!--
+				Fuehrungslinie: sie traegt das Auge ueber die Luecke zwischen
+				Bezeichnung und Betrag. Vier Fassungen, weil das erste belegte
+				Feld je nach Zahl der Kalibrierarten woanders beginnt und JRXML
+				die Breite eines Elements nicht zur Laufzeit rechnen kann —
+				gedruckt wird genau die, auf die `Block_slot` zeigt. Zeilen ohne
+				Betrag bekommen keine: eine Linie ins Leere ist keine Fuehrung.
+				Abschaltbar ueber den Parameter Leader_style.
+			-->
+			<line>
+				<reportElement x="252" y="8" width="68" height="1" forecolor="#B8B8B8">
+					<printWhenExpression><![CDATA["none".equals($P{Leader_style}) == false && $P{Block_slot} != null && $P{Block_slot}.intValue() == 2 && $F{slot_2} != null]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dotted" lineColor="#B8B8B8"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="252" y="8" width="136" height="1" forecolor="#B8B8B8">
+					<printWhenExpression><![CDATA["none".equals($P{Leader_style}) == false && $P{Block_slot} != null && $P{Block_slot}.intValue() == 3 && $F{slot_3} != null]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dotted" lineColor="#B8B8B8"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="252" y="8" width="204" height="1" forecolor="#B8B8B8">
+					<printWhenExpression><![CDATA["none".equals($P{Leader_style}) == false && $P{Block_slot} != null && $P{Block_slot}.intValue() == 4 && $F{slot_4} != null]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dotted" lineColor="#B8B8B8"/></graphicElement>
+			</line>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="256" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_1}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="324" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount_1}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_2}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="392" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount_2}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_3}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="460" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount_3}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_4}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement x="528" y="0" width="33" height="12"/>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-exceptions.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-exceptions.jrxml
@@ -22,9 +22,10 @@
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
 	<field name="type_label" class="java.lang.String"><fieldDescription><![CDATA[type_label]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
-	<field name="amount_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_1]]></fieldDescription></field>
-	<field name="amount_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_2]]></fieldDescription></field>
-	<field name="amount_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_3]]></fieldDescription></field>
+	<field name="slot_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_1]]></fieldDescription></field>
+	<field name="slot_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_2]]></fieldDescription></field>
+	<field name="slot_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_3]]></fieldDescription></field>
+	<field name="slot_4" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_4]]></fieldDescription></field>
 	<detail>
 		<band height="12">
 			<staticText>
@@ -40,22 +41,22 @@
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="256" y="0" width="64" height="11"/>
 				<textElement textAlignment="Right"><font size="8"/></textElement>
-				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_1}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="324" y="0" width="64" height="11"/>
 				<textElement textAlignment="Right"><font size="8"/></textElement>
-				<textFieldExpression><![CDATA[$F{amount_1}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_2}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="392" y="0" width="64" height="11"/>
 				<textElement textAlignment="Right"><font size="8"/></textElement>
-				<textFieldExpression><![CDATA[$F{amount_2}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_3}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="460" y="0" width="64" height="11"/>
 				<textElement textAlignment="Right"><font size="8"/></textElement>
-				<textFieldExpression><![CDATA[$F{amount_3}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_4}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
@@ -26,37 +26,67 @@
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Reportpath" class="java.lang.String"/>
 	<parameter name="Currency" class="java.lang.String"><defaultValueExpression><![CDATA[""]]></defaultValueExpression></parameter>
+	<parameter name="Leader_style" class="java.lang.String"><defaultValueExpression><![CDATA["dots"]]></defaultValueExpression></parameter>
+	<parameter name="Block_slot" class="java.lang.Integer"><defaultValueExpression><![CDATA[Integer.valueOf(4)]]></defaultValueExpression></parameter>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
 	<field name="name_secondary" class="java.lang.String"><fieldDescription><![CDATA[name_secondary]]></fieldDescription></field>
 	<field name="amount" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount]]></fieldDescription></field>
-	<field name="amount_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_1]]></fieldDescription></field>
-	<field name="amount_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_2]]></fieldDescription></field>
-	<field name="amount_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[amount_3]]></fieldDescription></field>
+	<field name="slot_1" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_1]]></fieldDescription></field>
+	<field name="slot_2" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_2]]></fieldDescription></field>
+	<field name="slot_3" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_3]]></fieldDescription></field>
+	<field name="slot_4" class="java.math.BigDecimal"><fieldDescription><![CDATA[slot_4]]></fieldDescription></field>
 	<detail>
 		<band height="25">
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="250" height="12"/>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
+			<!--
+				Fuehrungslinie: sie traegt das Auge ueber die Luecke zwischen
+				Bezeichnung und Betrag. Vier Fassungen, weil das erste belegte
+				Feld je nach Zahl der Kalibrierarten woanders beginnt und JRXML
+				die Breite eines Elements nicht zur Laufzeit rechnen kann —
+				gedruckt wird genau die, auf die `Block_slot` zeigt. Zeilen ohne
+				Betrag bekommen keine: eine Linie ins Leere ist keine Fuehrung.
+				Abschaltbar ueber den Parameter Leader_style.
+			-->
+			<line>
+				<reportElement x="252" y="8" width="68" height="1" forecolor="#B8B8B8">
+					<printWhenExpression><![CDATA["none".equals($P{Leader_style}) == false && $P{Block_slot} != null && $P{Block_slot}.intValue() == 2 && $F{slot_2} != null]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dotted" lineColor="#B8B8B8"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="252" y="8" width="136" height="1" forecolor="#B8B8B8">
+					<printWhenExpression><![CDATA["none".equals($P{Leader_style}) == false && $P{Block_slot} != null && $P{Block_slot}.intValue() == 3 && $F{slot_3} != null]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dotted" lineColor="#B8B8B8"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="252" y="8" width="204" height="1" forecolor="#B8B8B8">
+					<printWhenExpression><![CDATA["none".equals($P{Leader_style}) == false && $P{Block_slot} != null && $P{Block_slot}.intValue() == 4 && $F{slot_4} != null]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dotted" lineColor="#B8B8B8"/></graphicElement>
+			</line>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="256" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_1}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="324" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount_1}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_2}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="392" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount_2}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_3}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true" pattern="#,##0.00">
 				<reportElement x="460" y="0" width="64" height="12"/>
 				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[$F{amount_3}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{slot_4}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement positionType="Float" x="12" y="12" width="392" height="10" isRemoveLineWhenBlank="true"/>


### PR DESCRIPTION
## Warum

Bei zwei gepflegten Kalibrierarten blieb das vierte von vier festen Feldern leer, und der Betragsblock stand mitten auf dem Blatt. Daneben eine weiße Fläche, die in einem Kundendokument nach einem Druckfehler aussieht.

## Was

**Rechtsbündig über die Zuweisung, nicht über die Geometrie.** JRXML kann Felder zur Laufzeit nicht verschieben. Also bleiben vier feste Felder (`slot_1` … `slot_4`) stehen und werden von rechts gefüllt: `list.amount_block_slot` sagt, in welchem Feld der Grundpreis steht, die Kalibrierarten folgen dahinter.

**Contract `price-list` auf 1.4, additiv.** `amount`, `amounts`, `amount_1` … `amount_3` und `complexity_N_label` bleiben unverändert stehen — eine 1.3-Vorlage druckt weiter wie bisher.

**Neuer Parameter `Leader_style`** (`dots` / `none`, Vorgabe `dots`): eine dezente gepunktete Linie überbrückt die Lücke zwischen Kategoriebezeichnung und Betragsblock. Genau eine je Zeile, in der Länge, die `amount_block_slot` vorgibt. Bei einem Block in Feld 1 gar keine — dort wäre sie ein Stummel.

## Geprüft

Alle sieben JRXML übersetzen mit JasperReports 6.20.6, der Hauptbericht füllt gegen `sample-data.json` durch. Dazu drei Läufe, jeweils Kompilat **und** Füllung:

| Fall | Erwartung | Ergebnis |
|------|-----------|----------|
| Zwei Kalibrierarten | Spaltenkopf am rechten Rand | x = 341 / 409 / 477 statt vorher 273 / 341 / 409 (136 pt weiter rechts) |
| Ohne Kalibrierart | Grundpreis im letzten Feld | `Betrag (EUR)` bei x = 477, nicht in Feld 1 |
| `Leader_style="none"` | keine Führungslinien | nur die zwei durchgehenden Trennlinien der Seite bleiben |

Führungslinie genau einmal je Zeile, in passender Länge: `w=68` bei Block in Feld 2, `w=204` bei Block in Feld 4.

`scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` laufen sauber durch.

## Gegenstück

Backend-Seite in calhelp/calServer-yii (derselbe Branch): `PriceListReportDataBuilder` auf Schema 1.4.

## Nicht enthalten

`services[].variants` werden weiterhin nicht gedruckt — die brauchen eine eigene Achsenspalte und sind ein eigener Schnitt. Ebenso die Spaltenüberschriften auf Seite 2: der Bericht ist zweiseitig, die Köpfe stehen nur auf Seite 1, und wer umblättert, liest Zahlen ohne Kopf. Das wäre ein `pageHeader`-Umbau.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DEXrT8apqxevUD5RWjs7L)_