### PR TITLE
Preisliste: Abschnitt B trägt keine Zeile ohne Bezeichnung (Contract 1.5)

### DIFF
--- a/PRICE-LIST-JSON-SAMPLE/README.md
+++ b/PRICE-LIST-JSON-SAMPLE/README.md
@@ -112,7 +112,7 @@ Laborlisten nennen die Währung ohnehin einmal oben. Die Abschnitte
 Zusatzleistungen und Standardartikel haben nur einen Betrag und behalten ihre
 Währungsangabe an der Zeile.
 
-## Contract `price-list` (v1.4)
+## Contract `price-list` (v1.5)
 
 Dataset-Builder: Laravel `PriceListReportDataBuilder`; derselbe Aufbau, den die
 Preislisten-Seite liest (`PriceListService`). Datensatz zum Vorlagenbau:
@@ -130,6 +130,22 @@ wenn der Mandant nur eine Sprache führt — dann ist `mode` immer `primary`.
 
 **Neu in 1.1** (additiv, 1.0-Vorlagen laufen unverändert weiter):
 `list.language` und `name_secondary` an jeder benannten Zeile.
+
+**Neu in 1.5** (additiv): `list.counts.services_unnamed` zählt die Zeilen der
+Leistungsachse, die **nicht** in `list.services` stehen, weil ihr
+Standardartikel fehlt oder keinen Namen trägt.
+
+Die Bezeichnung einer Zusatzleistung ist der Name des Standardartikels, auf den
+die Preiszeile zeigt. Ist der gelöscht, blieb bis 1.4 ein Betrag ohne
+Gegenstand: Abschnitt B druckte eine leere Zeile mit einer Zahl daneben, und auf
+einem Blatt, das man aus der Hand gibt, liest sich das wie ein Druckfehler.
+Solche Zeilen liefert der Datensatz nicht mehr aus — verkaufen ließen sie sich
+ohnehin nicht, es gibt keinen Artikel für die Auftragsposition.
+
+Weggelassen wird sichtbar, wie bei `complexities_truncated`: die Zahl steht im
+Datensatz, und die Preislisten-Seite weist darauf hin, damit die Zeile
+reparierbar bleibt statt spurlos zu fehlen. Auf dem Kundendokument hat sie
+nichts zu suchen, die mitgelieferte Vorlage druckt sie deshalb nicht.
 
 **Neu in 1.4** (additiv): das Betragsraster ist **rechtsbündig**. Vier feste
 Felder je Zeile (`slot_1` … `slot_4`, Kopf `list.slot_1_label` …

--- a/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
+++ b/PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "contract": "price-list",
-    "schema_version": "1.4",
+    "schema_version": "1.5",
     "generated_at": "2026-08-10T09:00:00+02:00",
     "locale": "de-DE"
   },
@@ -332,6 +332,7 @@
       "type_exceptions": 1,
       "other_type_prices": 0,
       "services": 2,
+      "services_unnamed": 0,
       "articles": 2
     }
   }

--- a/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
+++ b/PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml
@@ -18,6 +18,13 @@
   Achsenspalte und damit eine eigene Tabelle, und die gehoert in einen eigenen
   Schnitt statt beilaeufig hier hinein.
 
+  KEINE ZEILE OHNE BEZEICHNUNG (Contract 1.5): `name` ist hier immer gefüllt.
+  Die Bezeichnung ist der Name des Standardartikels, auf den die Preiszeile
+  zeigt; fehlt der Artikel, liefert der Datensatz-Builder die Zeile gar nicht
+  erst aus und zählt sie in `list.counts.services_unnamed`. Bis 1.4 stand sie
+  hier als leere Zeile mit einem Betrag daneben. Die Vorlage braucht dafür
+  keinen Fall: was nicht im Datensatz steht, druckt sie nicht.
+
   ZWEISPRACHIG (Contract 1.1): `name` trägt die angeforderte Sprache,
   `name_secondary` ist nur in der Fassung "beide" gefüllt und fällt sonst als
   Zeile weg. Aufgelöst wird das im Datensatz-Builder, nicht hier.


### PR DESCRIPTION
## Worum es geht

Abschnitt B der Preisliste („Zusatzleistungen") druckte Beträge ohne Bezeichnung: linke Spalte leer, daneben eine Zahl, ein Dutzend Zeilen untereinander. Auf einem Blatt, das ein Labor seinem Kunden übergibt, liest sich das wie ein Druckfehler.

Die Ursache liegt nicht in der Vorlage, sondern im Datensatz: Eine Zusatzleistung heißt so, wie der Standardartikel heißt, auf den die Preiszeile zeigt (`service_prices.service_id` → `standard_article.uID`). Fehlt der Artikel, hat die Zeile keinen Namen, und `$F{name}` ist leer.

Behoben wird das im Backend (calServer-yii, Contract `price-list` 1.5): Solche Zeilen liefert der Datensatz-Builder nicht mehr aus und zählt sie stattdessen in `list.counts.services_unnamed`.

## Was hier drin ist

- `PRICE-LIST-JSON-SAMPLE/README.md` — Contract-Abschnitt auf **v1.5**, mit dem neuen Zähler und der Begründung, warum eine Zeile fehlen kann.
- `PRICE-LIST-JSON-SAMPLE/main_reports/sample-data.json` — `schema_version` 1.5, `counts.services_unnamed`.
- `PRICE-LIST-JSON-SAMPLE/subreports/price-list-services.jrxml` — Kommentarkopf hält fest, dass `name` in Abschnitt B belegt ist und warum die Vorlage dafür keinen Fall braucht.

## Was hier nicht drin ist

Kein Layout- und kein Feldwechsel. Die Vorlage bleibt Punkt für Punkt dieselbe — was nicht im Datensatz steht, druckt sie nicht. Der Zähler ist additiv; eine Vorlage aus der Zeit vor 1.5 läuft unverändert weiter.

## Geprüft

Beide geänderten Dateien parsen (`sample-data.json` als JSON, das JRXML als XML). Der Rendering-Pfad ändert sich nicht, deshalb kein neuer Füll-Lauf.

Gegenstück im Backend: gleichnamiger Branch in `calhelp/calServer-yii`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs8tp3az5XVFWrHEZe1RDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs8tp3az5XVFWrHEZe1RDZ)_