### PR TITLE
Auftragsbeleg: Fensterbrief nach DIN 5008 Form B, in jeder Variante

### DIFF
--- a/DELIVERY-JSON-SAMPLE/README.md
+++ b/DELIVERY-JSON-SAMPLE/README.md
@@ -9,7 +9,7 @@ v1.0) statt aus SQL — DB-agnostisch, keine V1-Codespalten.
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/delivery-json-sample.jrxml` | Hauptbericht: Briefkopf mit **Lieferadresse** (Meta-Box Liefernummer/Datum/Kunde/Kontakt), Positionstabelle (Pos/Beschreibung/Menge), Empfangs-Unterschriftszeile |
+| `main_reports/delivery-json-sample.jrxml` | Hauptbericht: **Fensterbrief nach DIN 5008 Form B** — Anschriftfeld mit der **Lieferadresse** und Rücksendeangabe, Informationsblock rechts (Liefernummer/Datum/Kunden-Nr./Kontakt), Betreffzeile bei 98,4 mm, Falz- und Lochmarken, Positionstabelle (Pos/Beschreibung/Menge), Empfangs-Unterschriftszeile |
 | `subreports/positions-delivery.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` — nur Pos/Beschreibung/Menge |
 | `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `order-document` v1.0, `document.status = "Lieferung"`) |
 | `main_reports/delivery-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
@@ -20,6 +20,20 @@ Gleicher Contract wie `ORDER-JSON-SAMPLE`; der Lieferschein liest nur `document`
 die serverseitig aufgelöste `delivery`-Adressrolle (Fallback → Bestell-Kunde) und
 `positions[]` (ohne Preis-/Steuerfelder). Dataset-Builder: Laravel
 `OrderDocumentDataBuilder`.
+
+## DIN-Form
+
+Gleiche Geometrie wie der vollständige Auftragsbeleg (`ORDER-JSON-SAMPLE`):
+Fensterbrief nach DIN 5008 Form B, Anschriftfeld 20 mm von links und 45 mm von
+oben (85 × 45 mm), Informationsblock ab 125 mm, Betreffzeile bei 98,4 mm,
+Falz- und Lochmarken bei 105 / 148,5 / 210 mm — abschaltbar über die
+Berichtsvariable `show_fold_marks` (Parameter `Show_fold_marks`, Default `1`).
+
+Im Anschriftfeld steht die **Lieferadresse** samt Ansprechpartner; die
+Landzeile druckt nur bei einem Land abweichend vom Absenderland. Die
+Rücksendeangabe kommt aus `supplier.sender_line` bzw. der Absenderanschrift,
+also aus den `company_*`-Berichtsvariablen — dieselben, die Auftragsbeleg,
+Leihschein und Versandschein nutzen.
 
 ## ⚠️ Leeres Blatt = fehlende Datenquelle
 

--- a/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
+++ b/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
@@ -7,18 +7,31 @@
   source — NO SQL. Positions via subDataSource("positions"). The delivery address
   block is resolved server-side (delivery role → falls back to the ordering
   customer). All labels are staticText. See main_reports/sample-data.json.
+
+  Geometrie wie beim Auftragsbeleg (ORDER-JSON-SAMPLE): Fensterbrief nach
+  DIN 5008 Form B, Anschriftfeld 20 mm von links, 45 mm von oben, 85 x 45 mm
+  (im Titelband x=40, y=116, 241 x 128 pt), Informationsblock ab 125 mm,
+  Betreffzeile bei 98,4 mm, Falz- und Lochmarken im Hintergrundband
+  (abschaltbar ueber Show_fold_marks). Der Absender kommt aus dem
+  supplier-Block des Datensatzes, also aus den company_*-Berichtsvariablen.
 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="d7ddf600-0310-4d70-9f60-000000000310">
 	<property name="com.jaspersoft.studio.data.defadapter" value="delivery-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Value" fontSize="9"/>
+	<style name="Address" fontSize="10"/>
+	<style name="SenderLine" fontSize="6"/>
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
 	<parameter name="Company_footer" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Show_fold_marks" class="java.lang.String">
+		<parameterDescription><![CDATA[Falz- und Lochmarken am linken Rand drucken (105 mm, 148,5 mm, 210 mm). "0" = aus, z. B. bei vorgedrucktem Briefpapier, das sie schon trägt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<field name="doc_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
 	<field name="doc_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
@@ -30,32 +43,99 @@
 	<field name="del_city" class="java.lang.String"><fieldDescription><![CDATA[delivery.city]]></fieldDescription></field>
 	<field name="del_contact" class="java.lang.String"><fieldDescription><![CDATA[delivery.contact.name]]></fieldDescription></field>
 	<field name="cust_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
+	<field name="del_country" class="java.lang.String"><fieldDescription><![CDATA[delivery.country]]></fieldDescription></field>
+	<field name="cust_contact" class="java.lang.String"><fieldDescription><![CDATA[customer.contact.name]]></fieldDescription></field>
+	<field name="sup_sender_line" class="java.lang.String"><fieldDescription><![CDATA[supplier.sender_line]]></fieldDescription></field>
+	<field name="sup_name" class="java.lang.String"><fieldDescription><![CDATA[supplier.name]]></fieldDescription></field>
+	<field name="sup_street" class="java.lang.String"><fieldDescription><![CDATA[supplier.street]]></fieldDescription></field>
+	<field name="sup_zip" class="java.lang.String"><fieldDescription><![CDATA[supplier.zip]]></fieldDescription></field>
+	<field name="sup_city" class="java.lang.String"><fieldDescription><![CDATA[supplier.city]]></fieldDescription></field>
+	<field name="sup_country" class="java.lang.String"><fieldDescription><![CDATA[supplier.country]]></fieldDescription></field>
+	<!--
+	  Falz- und Lochmarken bei 105 mm / 148,5 mm / 210 mm ab Seitenoberkante.
+	  Sie gehören auf jede Seite, deshalb ins Hintergrundband.
+	-->
+	<background>
+		<band height="818">
+			<line>
+				<reportElement x="0" y="286" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="409" width="14" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="583" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+		</band>
+	</background>
 	<title>
-		<band height="184">
-			<staticText><reportElement x="0" y="0" width="330" height="9"/><textElement><font size="6"/></textElement><text><![CDATA[calServer V2 · Musterfirma · Musterstraße 1 · 12345 Musterstadt]]></text></staticText>
-			<textField><reportElement x="0" y="18" width="300" height="14"/><textElement><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{del_name}]]></textFieldExpression></textField>
-			<textField><reportElement x="0" y="32" width="300" height="12"/><textFieldExpression><![CDATA[$F{del_street}]]></textFieldExpression></textField>
-			<textField><reportElement x="0" y="44" width="300" height="12"/><textFieldExpression><![CDATA[($F{del_zip} == null ? "" : $F{del_zip}) + " " + ($F{del_city} == null ? "" : $F{del_city})]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="18" width="80" height="12"/><text><![CDATA[Liefernummer]]></text></staticText>
-			<textField><reportElement style="Value" x="460" y="18" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="32" width="80" height="12"/><text><![CDATA[Datum]]></text></staticText>
-			<textField><reportElement style="Value" x="460" y="32" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="46" width="80" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
-			<textField><reportElement style="Value" x="460" y="46" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="60" width="80" height="12"/><text><![CDATA[Kontakt]]></text></staticText>
-			<textField><reportElement style="Value" x="460" y="60" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{del_contact}]]></textFieldExpression></textField>
-			<textField><reportElement x="0" y="120" width="561" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA["Lieferschein " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight"><reportElement style="Value" x="0" y="144" width="561" height="14"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
-			<line><reportElement x="0" y="164" width="561" height="1"/></line>
-			<staticText><reportElement style="Label" x="0" y="168" width="40" height="14"/><text><![CDATA[Pos]]></text></staticText>
-			<staticText><reportElement style="Label" x="40" y="168" width="431" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
-			<staticText><reportElement style="Label" x="471" y="168" width="90" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+		<band height="332">
+			<!-- Anschriftfeld (DIN 676 Form B): der Frame IST das Feld, 85 x 45 mm an 20/45 mm. -->
+			<frame>
+				<reportElement x="40" y="116" width="241" height="128"/>
+				<textField isBlankWhenNull="true">
+					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
+					<textFieldExpression><![CDATA[($F{sup_sender_line} != null && !$F{sup_sender_line}.trim().isEmpty())
+	? $F{sup_sender_line}
+	: (
+		($F{sup_name} == null ? "" : $F{sup_name})
+		+ (($F{sup_street} == null || $F{sup_street}.trim().isEmpty()) ? "" : " · " + $F{sup_street})
+		+ ((($F{sup_zip} == null || $F{sup_zip}.trim().isEmpty()) && ($F{sup_city} == null || $F{sup_city}.trim().isEmpty()))
+			? ""
+			: " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city}))
+	).trim()]]></textFieldExpression>
+				</textField>
+				<!--
+				  Ein Textfeld mit \n-Zeilen: Fehlt der Ansprechpartner oder die
+				  Straße, rückt der Rest auf. Landzeile nur bei abweichendem Land.
+				-->
+				<textField isBlankWhenNull="true">
+					<reportElement style="Address" x="0" y="50" width="241" height="78"/>
+					<textElement><paragraph lineSpacing="Fixed" lineSpacingSize="12.5"/></textElement>
+					<textFieldExpression><![CDATA[(($F{del_name} == null || $F{del_name}.trim().isEmpty()) ? "" : $F{del_name} + "\n")
++ (($F{del_contact} == null || $F{del_contact}.trim().isEmpty()) ? "" : $F{del_contact} + "\n")
++ (($F{del_street} == null || $F{del_street}.trim().isEmpty()) ? "" : $F{del_street} + "\n")
++ (($F{del_zip} == null ? "" : $F{del_zip}) + " " + ($F{del_city} == null ? "" : $F{del_city})).trim()
++ (($F{del_country} == null || $F{del_country}.trim().isEmpty()
+		|| ($F{sup_country} != null && $F{del_country}.trim().equalsIgnoreCase($F{sup_country}.trim())))
+	? ""
+	: "\n" + $F{del_country})]]></textFieldExpression>
+				</textField>
+			</frame>
+			<!-- Informationsblock rechts (DIN 5008: ab 125 mm), auf Höhe des Anschriftfelds -->
+			<frame>
+				<reportElement x="337" y="116" width="224" height="65"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Liefernummer]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Datum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="26" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="39" width="104" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{del_contact} == null || !$F{del_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="39" width="120" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{del_contact} == null || !$F{del_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
+			</frame>
+			<!-- Betreffzeile (DIN 5008: 98,4 mm ab Seitenoberkante) -->
+			<textField><reportElement x="12" y="267" width="549" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA["Lieferschein " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="12" y="288" width="549" height="13" isRemoveLineWhenBlank="true"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
+			<line><reportElement positionType="Float" x="12" y="310" width="549" height="1"/></line>
+			<staticText><reportElement style="Label" positionType="Float" x="12" y="314" width="40" height="14"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="52" y="314" width="419" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="471" y="314" width="90" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
 		</band>
 	</title>
 	<detail>
 		<band height="30">
 			<subreport>
-				<reportElement positionType="Float" x="0" y="0" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="12" y="0" width="549" height="14" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/positions-delivery.jasper"]]></subreportExpression>
 			</subreport>
@@ -63,10 +143,10 @@
 	</detail>
 	<pageFooter>
 		<band height="58">
-			<staticText><reportElement positionType="Float" x="0" y="16" width="561" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Ware vollständig und unbeschädigt erhalten:]]></text></staticText>
-			<line><reportElement positionType="Float" x="0" y="30" width="240" height="1"/></line>
-			<staticText><reportElement positionType="Float" x="0" y="32" width="240" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement positionType="Float" x="0" y="46" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<staticText><reportElement positionType="Float" x="12" y="16" width="549" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Ware vollständig und unbeschädigt erhalten:]]></text></staticText>
+			<line><reportElement positionType="Float" x="12" y="30" width="240" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="12" y="32" width="240" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement positionType="Float" x="12" y="46" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/DELIVERY-JSON-SAMPLE/main_reports/sample-data.json
+++ b/DELIVERY-JSON-SAMPLE/main_reports/sample-data.json
@@ -17,13 +17,26 @@
       "W4109": "2026-07-20"
     }
   },
+  "supplier": {
+    "name": "calServer Musterfirma GmbH",
+    "sender_line": "calServer Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt",
+    "street": "Musterstraße 1",
+    "zip": "12345",
+    "city": "Musterstadt",
+    "country": "DE"
+  },
   "customer": {
     "name": "Muster GmbH",
     "customer_number": "K-1001",
     "street": "Musterstraße 1",
     "zip": "54321",
     "city": "Beispielstadt",
-    "country": "DE"
+    "country": "DE",
+    "contact": {
+      "name": "Hans Muster",
+      "email": "einkauf@muster.example",
+      "phone": "+49 30 1234501"
+    }
   },
   "delivery": {
     "name": "Muster GmbH",

--- a/DELIVERY-JSON-SAMPLE/parameters.json
+++ b/DELIVERY-JSON-SAMPLE/parameters.json
@@ -20,6 +20,24 @@
       "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
     },
     {
+      "name": "Show_fold_marks",
+      "label": {
+        "de": "Falz- und Lochmarken",
+        "en": "Fold and punch marks"
+      },
+      "description": {
+        "de": "Druckt die Falzmarken bei 105 mm und 210 mm sowie die Lochmarke bei 148,5 mm an den linken Blattrand. Auf \"0\" setzen, wenn auf vorgedrucktem Briefpapier gedruckt wird, das die Marken bereits trägt.",
+        "en": "Prints the fold marks at 105 mm and 210 mm plus the punch mark at 148.5 mm on the left edge of the sheet. Set to \"0\" when printing on pre-printed stationery that already carries them."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Layout",
+      "default": "1",
+      "example": "1"
+    },
+    {
       "name": "Reportpath",
       "label": {
         "de": "Bundle-Wurzelpfad",

--- a/DELIVERY-JSON-SAMPLE/subreports/positions-delivery.jrxml
+++ b/DELIVERY-JSON-SAMPLE/subreports/positions-delivery.jrxml
@@ -5,7 +5,7 @@
   "positions" array via subDataSource("positions"). Delivery-note variant — only
   position, description and quantity, no prices/tax. No $V{} variables.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0311-4d71-9f61-000000000311">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0311-4d71-9f61-000000000311">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<field name="pos_number" class="java.lang.Integer"><fieldDescription><![CDATA[pos_number]]></fieldDescription></field>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
@@ -14,9 +14,9 @@
 	<detail>
 		<band height="15">
 			<textField><reportElement x="0" y="0" width="40" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight"><reportElement x="40" y="0" width="431" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##"><reportElement x="471" y="0" width="60" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
-			<textField><reportElement x="533" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="40" y="0" width="419" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##"><reportElement x="459" y="0" width="60" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField><reportElement x="521" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -18,7 +18,7 @@ andere den Auftraggeber. Das Template verzweigt nur noch auf `document.type`.
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/order-json-sample.jrxml` | Hauptbericht: Absenderzeile + Briefkopf (`recipient` je Dokumenttyp, Meta-Box Belegnummer/Datum/Kunde/Kontakt/Lieferbedingung/-kosten), abweichende Liefer-/Rechnungsadresse als Info-Block, typabhängiger Betreff, Positionstabelle + Statistik + Zusatzfelder, Rechnungs-/Lieferschein-Spezifika, Fußzeile mit Firmen-/Steuer-/Bankangaben. Alle Labels als `staticText` |
+| `main_reports/order-json-sample.jrxml` | Hauptbericht: **Fensterbrief nach DIN 5008 Form B** — Anschriftfeld mit Rücksendeangabe (`recipient` je Dokumenttyp), Informationsblock rechts (Belegnummer/Datum/Kunden-Nr./Kontakt/Lieferbedingung/-kosten), Betreffzeile bei 98,4 mm, Falz- und Lochmarken; darunter abweichende Liefer-/Rechnungsadresse als Info-Block, Positionstabelle + Statistik + Zusatzfelder, Rechnungs-/Lieferschein-Spezifika, Fußzeile mit Firmen-/Steuer-/Bankangaben. Alle Labels als `staticText` |
 | `subreports/positions.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` (Pos/Beschreibung/Menge/Einzelpreis/Rabatt/Betrag/MwSt). Gruppe `sourceOrder` je Quellauftrag — Kopfzeile nur bei einer Sammelrechnung (s.u.) |
 | `subreports/positions-delivery.jrxml` | Positionen **ohne Preise** für Lieferscheine (Pos/Beschreibung/Menge/Einheit); wird bei `document.type = delivery_note` automatisch gewählt. Dieselbe Gruppierung |
 | `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz — § 14 UStG-Aufschlüsselung) |
@@ -27,6 +27,36 @@ andere den Auftraggeber. Das Template verzweigt nur noch auf `document.type`.
 | `main_reports/sample-data-collective.json` | Beispiel-Datensatz **Sammelrechnung**: Positionen aus zwei Aufträgen, `collective.is_collective = true` |
 | `main_reports/order-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 | `main_reports/order-json-sample-collective_adapter.xml` | Data-Adapter für die Vorschau des Sammelfalls (im Studio umschalten) |
+
+## DIN-Form: ein Fensterbrief, in **jeder** Variante
+
+Der Beleg ist ein **Fensterbrief nach DIN 5008 Form B** — dieselbe Geometrie
+wie beim Leihschein (`LOCATION-JSON-SAMPLE`) und beim Versandschein
+(`FREE-DELIVERY-JSON-SAMPLE`):
+
+| Element | Position | Im Template |
+|---|---|---|
+| Anschriftfeld | 20 mm von links, 45 mm von oben, 85 × 45 mm | Rahmen `x=40 y=116 241×128` im Titelband |
+| Rücksendeangabe | Zusatz-/Vermerkzone, 12 mm ab Feldoberkante | `y=34` im Anschriftfeld-Rahmen |
+| Anschrift | Beginn der Anschriftzone, 17,7 mm ab Feldoberkante | `y=50`, ein Textfeld mit `\n`-Zeilen |
+| Informationsblock | ab 125 mm, auf Höhe des Anschriftfelds | Rahmen `x=337 y=116` |
+| Betreffzeile | 98,4 mm ab Seitenoberkante | `y=267` |
+| Falz-/Lochmarken | 105 / 148,5 / 210 mm am linken Rand | Hintergrundband, abschaltbar über `Show_fold_marks` |
+
+Damit zeigt ein DIN-lang-Fensterumschlag nach DIN 680 genau die Anschrift des
+Empfängers — und zwar bei **allen** Belegtypen: Angebot, Auftragsbestätigung,
+Lieferschein, Rechnung und dem neutralen Beleg teilen sich diesen Kopf, nur die
+Blöcke darunter unterscheiden sich. Wer auf **Form A** umstellt (Anschriftfeld
+ab 27 mm), ändert eine Zahl: `y=116` wird `y=64`.
+
+Die Anschrift ist **ein** Textfeld mit `\n`-Zeilen, kein Stapel Einzelfelder:
+Fehlt der Ansprechpartner oder die Straße, rückt der Rest auf, statt eine Lücke
+im Fenster zu lassen. Die Landzeile druckt nur, wenn `recipient.country` vom
+Absenderland (`supplier.country`, aus `company_country`) abweicht — „DE" unter
+einer deutschen Inlandsanschrift wäre schlicht falsch.
+
+Der Textblock beginnt bei `x=12` (10,2 mm) statt am Rand, damit die Falzmarken
+nicht in die Positionsspalte laufen; die Tabelle ist entsprechend 549 pt breit.
 
 ## Contract `order-document` (v1.8)
 
@@ -205,6 +235,7 @@ von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
 | Parameter | Rolle | Wirkung |
 |-----------|-------|---------|
 | `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Auftragsbeleg). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
+| `Show_fold_marks` | variable (type) | Falz- und Lochmarken am linken Blattrand (105 / 148,5 / 210 mm). Default `1`; auf `0` setzen, wenn vorgedrucktes Briefpapier sie schon trägt (Berichtsvariable `show_fold_marks`). |
 
 Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
 und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
@@ -8,6 +8,16 @@
   (invoice -> invoice role, delivery_note -> delivery role, else ordering
   customer), so this template never guesses which address to print.
 
+  Geometrie: Fensterbrief nach DIN 5008 Form B, wie Leihschein
+  (LOCATION-JSON-SAMPLE) und Versandschein (FREE-DELIVERY-JSON-SAMPLE).
+  Anschriftfeld 20 mm von links, 45 mm von oben, 85 x 45 mm (im Titelband
+  x=40, y=116, 241 x 128 pt), Informationsblock ab 125 mm, Betreffzeile bei
+  98,4 mm, Falz- und Lochmarken im Hintergrundband (abschaltbar ueber
+  Show_fold_marks). Ein DIN-lang-Umschlag nach DIN 680 zeigt damit genau die
+  Anschrift des Empfaengers, und zwar in JEDER Variante: Angebot,
+  Auftragsbestaetigung, Lieferschein, Rechnung und der neutrale Beleg teilen
+  sich diesen Kopf. Wer auf Form A umstellt, aendert eine Zahl: y=116 wird 64.
+
   Per-type behavior (standards-oriented):
   - heading = document.type_label (Angebot / Auftragsbestätigung / Lieferschein /
     Rechnung), fallback = status title;
@@ -39,12 +49,18 @@
 	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Value" fontSize="9"/>
 	<style name="Money" fontSize="9"/>
+	<style name="Address" fontSize="10"/>
+	<style name="SenderLine" fontSize="6"/>
 	<parameter name="Reportpath" class="java.lang.String">
 		<parameterDescription><![CDATA[Bundle-Wurzel für die Auflösung der Subreports (/subreports/*.jasper).]]></parameterDescription>
 	</parameter>
 	<parameter name="Company_footer" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Show_fold_marks" class="java.lang.String">
+		<parameterDescription><![CDATA[Falz- und Lochmarken am linken Rand drucken (105 mm, 148,5 mm, 210 mm). "0" = aus, z. B. bei vorgedrucktem Briefpapier, das sie schon trägt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<field name="doc_number" class="java.lang.String"><fieldDescription><![CDATA[document.number]]></fieldDescription></field>
 	<field name="doc_date" class="java.lang.String"><fieldDescription><![CDATA[document.date]]></fieldDescription></field>
@@ -66,6 +82,8 @@
 	<field name="rcpt_zip" class="java.lang.String"><fieldDescription><![CDATA[recipient.zip]]></fieldDescription></field>
 	<field name="rcpt_city" class="java.lang.String"><fieldDescription><![CDATA[recipient.city]]></fieldDescription></field>
 	<field name="rcpt_number" class="java.lang.String"><fieldDescription><![CDATA[recipient.customer_number]]></fieldDescription></field>
+	<field name="rcpt_contact" class="java.lang.String"><fieldDescription><![CDATA[recipient.contact.name]]></fieldDescription></field>
+	<field name="rcpt_country" class="java.lang.String"><fieldDescription><![CDATA[recipient.country]]></fieldDescription></field>
 	<field name="cust_contact" class="java.lang.String"><fieldDescription><![CDATA[customer.contact.name]]></fieldDescription></field>
 	<field name="cust_number" class="java.lang.String"><fieldDescription><![CDATA[customer.customer_number]]></fieldDescription></field>
 	<field name="net_total" class="java.lang.Double"><fieldDescription><![CDATA[statistics.net_total]]></fieldDescription></field>
@@ -91,6 +109,7 @@
 	<field name="sup_street" class="java.lang.String"><fieldDescription><![CDATA[supplier.street]]></fieldDescription></field>
 	<field name="sup_zip" class="java.lang.String"><fieldDescription><![CDATA[supplier.zip]]></fieldDescription></field>
 	<field name="sup_city" class="java.lang.String"><fieldDescription><![CDATA[supplier.city]]></fieldDescription></field>
+	<field name="sup_country" class="java.lang.String"><fieldDescription><![CDATA[supplier.country]]></fieldDescription></field>
 	<field name="sup_tax_number" class="java.lang.String"><fieldDescription><![CDATA[supplier.tax_number]]></fieldDescription></field>
 	<field name="sup_vat_id" class="java.lang.String"><fieldDescription><![CDATA[supplier.vat_id]]></fieldDescription></field>
 	<field name="sup_register" class="java.lang.String"><fieldDescription><![CDATA[supplier.commercial_register]]></fieldDescription></field>
@@ -98,72 +117,153 @@
 	<field name="sup_iban" class="java.lang.String"><fieldDescription><![CDATA[supplier.iban]]></fieldDescription></field>
 	<field name="sup_bic" class="java.lang.String"><fieldDescription><![CDATA[supplier.bic]]></fieldDescription></field>
 	<field name="sup_payment_terms" class="java.lang.String"><fieldDescription><![CDATA[supplier.payment_terms]]></fieldDescription></field>
+	<!--
+	  Falz- und Lochmarken. Sie gehören auf JEDE Seite (gefalzt wird der ganze
+	  Stapel), deshalb ins Hintergrundband. Die Marken sitzen am linken Rand bei
+	  105 mm / 148,5 mm / 210 mm ab Seitenoberkante; die Lochmarke ist länger.
+	-->
+	<background>
+		<band height="818">
+			<line>
+				<reportElement x="0" y="286" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="409" width="14" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="0" y="583" width="8" height="1">
+					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
+				</reportElement>
+				<graphicElement><pen lineWidth="0.5"/></graphicElement>
+			</line>
+		</band>
+	</background>
 	<title>
-		<band height="200">
-			<!-- Sender line: supplier.sender_line, else composed from the supplier address -->
-			<textField isBlankWhenNull="true"><reportElement x="0" y="0" width="330" height="9"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[$F{sup_sender_line} != null ? $F{sup_sender_line} : (($F{sup_name} == null ? "" : $F{sup_name}) + ($F{sup_street} == null ? "" : " · " + $F{sup_street}) + (($F{sup_zip} == null && $F{sup_city} == null) ? "" : " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city})))]]></textFieldExpression></textField>
-			<!-- Recipient address block: server-resolved per document type (invoice/delivery/customer role) -->
-			<textField isBlankWhenNull="true"><reportElement x="0" y="18" width="300" height="14"/><textElement><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{rcpt_name}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="0" y="32" width="300" height="12"/><textFieldExpression><![CDATA[$F{rcpt_street}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="0" y="44" width="300" height="12"/><textFieldExpression><![CDATA[($F{rcpt_zip} == null ? "" : $F{rcpt_zip}) + " " + ($F{rcpt_city} == null ? "" : $F{rcpt_city})]]></textFieldExpression></textField>
-			<!-- Meta box (right) -->
-			<staticText><reportElement style="Label" x="380" y="18" width="80" height="12"/><text><![CDATA[Belegnummer]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="460" y="18" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="32" width="80" height="12"/><text><![CDATA[Datum]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="460" y="32" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="46" width="80" height="12"><printWhenExpression><![CDATA[$F{rcpt_number} != null]]></printWhenExpression></reportElement><text><![CDATA[Kunden-Nr.]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="460" y="46" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rcpt_number}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="60" width="80" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="460" y="60" width="101" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="74" width="80" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><text><![CDATA[Lieferung]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement style="Value" x="460" y="74" width="101" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_condition}]]></textFieldExpression></textField>
-			<staticText><reportElement style="Label" x="380" y="88" width="80" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><text><![CDATA[Lieferkosten]]></text></staticText>
-			<textField pattern="#,##0.00 €"><reportElement style="Value" x="460" y="88" width="101" height="12"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_costs}]]></textFieldExpression></textField>
-			<!-- Lieferadresse (Info-Block: nur wenn abweichend und nicht schon Briefkopf-Empfänger) -->
+		<band height="390">
+			<!--
+			  Anschriftfeld (DIN 676 Form B). Der Frame IST das Feld: 85 × 45 mm
+			  an 20/45 mm, damit die Anschrift im Fenster eines DIN-lang-Umschlags
+			  nach DIN 680 steht. Innen liegt die Rücksendeangabe in der Zusatz- und
+			  Vermerkzone (12 mm ab Feldoberkante), die Anschrift am Beginn der
+			  Anschriftzone (17,7 mm = 50 pt ab Feldoberkante). Wer auf Form A
+			  umstellt (Anschriftfeld ab 27 mm), ändert eine Zahl: y=116 wird y=64.
+			-->
 			<frame>
-				<reportElement x="0" y="64" width="175" height="52"><printWhenExpression><![CDATA[$F{del_number} != null && !$F{del_number}.equals($F{cust_number}) && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement x="40" y="116" width="241" height="128"/>
+				<!-- Rücksendeangabe: supplier.sender_line, sonst aus der Absenderanschrift gesetzt -->
+				<textField isBlankWhenNull="true">
+					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
+					<textFieldExpression><![CDATA[($F{sup_sender_line} != null && !$F{sup_sender_line}.trim().isEmpty())
+	? $F{sup_sender_line}
+	: (
+		($F{sup_name} == null ? "" : $F{sup_name})
+		+ (($F{sup_street} == null || $F{sup_street}.trim().isEmpty()) ? "" : " · " + $F{sup_street})
+		+ ((($F{sup_zip} == null || $F{sup_zip}.trim().isEmpty()) && ($F{sup_city} == null || $F{sup_city}.trim().isEmpty()))
+			? ""
+			: " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city}))
+	).trim()]]></textFieldExpression>
+				</textField>
+				<!--
+				  Die Anschrift ist EIN Textfeld mit \n-Zeilen, kein Stapel
+				  Einzelfelder: Fehlt der Ansprechpartner oder die Straße, rückt der
+				  Rest auf, statt eine Lücke im Fenster zu lassen. Keine Leerzeile vor
+				  dem Ort — die kannte DIN 5008 bis 1996, seit der Fassung 2020 ist die
+				  Anschrift durchgehend. Die Landzeile druckt nur bei abweichendem Land
+				  (supplier.country); "DE" unter einer deutschen Inlandsanschrift wäre
+				  schlicht falsch. Empfänger ist der serverseitig je Belegtyp
+				  aufgelöste `recipient` — Rechnung an die Rechnungsadresse,
+				  Lieferschein an die Lieferadresse, sonst an den Auftraggeber.
+				-->
+				<textField isBlankWhenNull="true">
+					<reportElement style="Address" x="0" y="50" width="241" height="78"/>
+					<textElement><paragraph lineSpacing="Fixed" lineSpacingSize="12.5"/></textElement>
+					<textFieldExpression><![CDATA[(($F{rcpt_name} == null || $F{rcpt_name}.trim().isEmpty()) ? "" : $F{rcpt_name} + "\n")
++ (($F{rcpt_contact} == null || $F{rcpt_contact}.trim().isEmpty()) ? "" : $F{rcpt_contact} + "\n")
++ (($F{rcpt_street} == null || $F{rcpt_street}.trim().isEmpty()) ? "" : $F{rcpt_street} + "\n")
++ (($F{rcpt_zip} == null ? "" : $F{rcpt_zip}) + " " + ($F{rcpt_city} == null ? "" : $F{rcpt_city})).trim()
++ (($F{rcpt_country} == null || $F{rcpt_country}.trim().isEmpty()
+		|| ($F{sup_country} != null && $F{rcpt_country}.trim().equalsIgnoreCase($F{sup_country}.trim())))
+	? ""
+	: "\n" + $F{rcpt_country})]]></textFieldExpression>
+				</textField>
+			</frame>
+			<!--
+			  Informationsblock rechts (DIN 5008: ab 125 mm, also außerhalb des
+			  Fensters, das bei 105 mm endet), auf Höhe des Anschriftfelds. Der
+			  Kontakt druckt nur, wenn er nicht ohnehin schon als z.-Hd.-Zeile in
+			  der Anschrift steht — zweimal derselbe Name ist keine Information.
+			-->
+			<frame>
+				<reportElement x="337" y="116" width="224" height="91"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Belegnummer]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Datum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{rcpt_number} != null]]></printWhenExpression></reportElement><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="26" width="120" height="12" isRemoveLineWhenBlank="true"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rcpt_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" positionType="Float" x="0" y="39" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{rcpt_contact} == null || !$F{rcpt_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="104" y="39" width="120" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{rcpt_contact} == null || !$F{rcpt_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" positionType="Float" x="0" y="52" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><text><![CDATA[Lieferung]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="104" y="52" width="120" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_condition}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" positionType="Float" x="0" y="65" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><text><![CDATA[Lieferkosten]]></text></staticText>
+				<textField pattern="#,##0.00 €"><reportElement style="Value" positionType="Float" x="104" y="65" width="120" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_costs}]]></textFieldExpression></textField>
+			</frame>
+			<!-- Betreffzeile (DIN 5008: 98,4 mm ab Seitenoberkante), Belegtyp je Status -->
+			<textField><reportElement x="12" y="267" width="549" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "Beleg" : $F{doc_status})) + " " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
+			<!-- Anschreiben aus dem Auftrag. Kollabiert, wenn keins gepflegt ist. -->
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="12" y="288" width="549" height="13" isRemoveLineWhenBlank="true"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
+			<!--
+			  Abweichende Liefer-/Rechnungsadresse. Sie stehen UNTER der
+			  Betreffzeile, nicht im Kopf: Im Fensterbereich ist nur Platz für eine
+			  Anschrift, und das ist die des Empfängers. Beide Rahmen kollabieren
+			  gemeinsam, wenn keiner druckt.
+			-->
+			<frame>
+				<reportElement positionType="Float" x="12" y="308" width="175" height="52" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{del_number} != null && !$F{del_number}.equals($F{cust_number}) && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<staticText><reportElement style="Label" x="0" y="0" width="175" height="11"/><text><![CDATA[Lieferadresse]]></text></staticText>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="12" width="175" height="12"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{del_name}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="24" width="175" height="12"/><textFieldExpression><![CDATA[$F{del_street}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="36" width="175" height="12"/><textFieldExpression><![CDATA[($F{del_zip} == null ? "" : $F{del_zip}) + " " + ($F{del_city} == null ? "" : $F{del_city})]]></textFieldExpression></textField>
 			</frame>
-			<!-- Rechnungsadresse (Info-Block: nur wenn abweichend und nicht schon Briefkopf-Empfänger) -->
 			<frame>
-				<reportElement x="185" y="64" width="175" height="52"><printWhenExpression><![CDATA[$F{inv_number} != null && !$F{inv_number}.equals($F{cust_number}) && !"invoice".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement positionType="Float" x="197" y="308" width="175" height="52" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{inv_number} != null && !$F{inv_number}.equals($F{cust_number}) && !"invoice".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<staticText><reportElement style="Label" x="0" y="0" width="175" height="11"/><text><![CDATA[Rechnungsadresse]]></text></staticText>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="12" width="175" height="12"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{inv_name}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="24" width="175" height="12"/><textFieldExpression><![CDATA[$F{inv_street}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="36" width="175" height="12"/><textFieldExpression><![CDATA[($F{inv_zip} == null ? "" : $F{inv_zip}) + " " + ($F{inv_city} == null ? "" : $F{inv_city})]]></textFieldExpression></textField>
 			</frame>
-			<!-- Subject: standards-compliant document heading per status -->
-			<textField><reportElement x="0" y="120" width="561" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "Beleg" : $F{doc_status})) + " " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="144" width="561" height="14"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
 			<!-- Positions table header (full, priced document types) -->
-			<line><reportElement x="0" y="176" width="561" height="1"/></line>
+			<line><reportElement positionType="Float" x="12" y="368" width="549" height="1"/></line>
 			<frame>
-				<reportElement x="0" y="180" width="561" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement positionType="Float" x="12" y="372" width="549" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<staticText><reportElement style="Label" x="0" y="0" width="28" height="14"/><text><![CDATA[Pos]]></text></staticText>
-				<staticText><reportElement style="Label" x="28" y="0" width="240" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
-				<staticText><reportElement style="Label" x="268" y="0" width="60" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
-				<staticText><reportElement style="Label" x="328" y="0" width="70" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Einzelpreis]]></text></staticText>
-				<staticText><reportElement style="Label" x="398" y="0" width="45" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Rabatt]]></text></staticText>
-				<staticText><reportElement style="Label" x="443" y="0" width="78" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Betrag]]></text></staticText>
-				<staticText><reportElement style="Label" x="521" y="0" width="40" height="14"/><textElement textAlignment="Right"/><text><![CDATA[MwSt]]></text></staticText>
+				<staticText><reportElement style="Label" x="28" y="0" width="228" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+				<staticText><reportElement style="Label" x="256" y="0" width="60" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+				<staticText><reportElement style="Label" x="316" y="0" width="70" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Einzelpreis]]></text></staticText>
+				<staticText><reportElement style="Label" x="386" y="0" width="45" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Rabatt]]></text></staticText>
+				<staticText><reportElement style="Label" x="431" y="0" width="78" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Betrag]]></text></staticText>
+				<staticText><reportElement style="Label" x="509" y="0" width="40" height="14"/><textElement textAlignment="Right"/><text><![CDATA[MwSt]]></text></staticText>
 			</frame>
 			<!-- Positions table header (delivery note: no prices) -->
 			<frame>
-				<reportElement x="0" y="180" width="561" height="14"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement positionType="Float" x="12" y="372" width="549" height="14"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<staticText><reportElement style="Label" x="0" y="0" width="28" height="14"/><text><![CDATA[Pos]]></text></staticText>
-				<staticText><reportElement style="Label" x="28" y="0" width="372" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
-				<staticText><reportElement style="Label" x="400" y="0" width="80" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
-				<staticText><reportElement style="Label" x="490" y="0" width="71" height="14"/><text><![CDATA[Einheit]]></text></staticText>
+				<staticText><reportElement style="Label" x="28" y="0" width="360" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+				<staticText><reportElement style="Label" x="388" y="0" width="80" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+				<staticText><reportElement style="Label" x="478" y="0" width="71" height="14"/><text><![CDATA[Einheit]]></text></staticText>
 			</frame>
 		</band>
 	</title>
 	<detail>
 		<band height="230">
 			<subreport>
-				<reportElement positionType="Float" x="0" y="0" width="561" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="12" y="0" width="549" height="14" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Is_collective"><subreportParameterExpression><![CDATA[$F{collective_is}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + ("delivery_note".equals($F{doc_type}) ? "/subreports/positions-delivery.jasper" : "/subreports/positions.jasper")]]></subreportExpression>
@@ -185,33 +285,33 @@
 			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="470" y="88" width="91" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{gross_total}]]></textFieldExpression></textField>
 			<!-- Weitere Angaben: Zusatzfelder (W41xx) generisch aus custom_fields_list (Contract 1.1) -->
 			<subreport>
-				<reportElement positionType="Float" x="0" y="30" width="320" height="12" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="12" y="30" width="320" height="12" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("document.custom_fields_list")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/custom-fields.jasper"]]></subreportExpression>
 			</subreport>
 			<!-- Status-specific description text (booking_offer/order/billing/delivery_report_description) -->
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="0" y="120" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{doc_description}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="12" y="120" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{doc_description}]]></textFieldExpression></textField>
 			<!-- Invoice only: § 14 Abs. 4 Nr. 6 UStG — Leistungsdatum + Zahlungsbedingungen -->
-			<staticText><reportElement positionType="Float" x="0" y="136" width="561" height="12"><printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Soweit nicht anders angegeben, entspricht das Liefer-/Leistungsdatum dem Rechnungsdatum.]]></text></staticText>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="0" y="150" width="561" height="12"><printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="8" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{sup_payment_terms}]]></textFieldExpression></textField>
+			<staticText><reportElement positionType="Float" x="12" y="136" width="549" height="12"><printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Soweit nicht anders angegeben, entspricht das Liefer-/Leistungsdatum dem Rechnungsdatum.]]></text></staticText>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="12" y="150" width="549" height="12"><printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="8" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{sup_payment_terms}]]></textFieldExpression></textField>
 			<!-- Delivery note only: receipt confirmation -->
-			<staticText><reportElement positionType="Float" x="0" y="150" width="561" height="12"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="8" isBold="true"/></textElement><text><![CDATA[Empfang der aufgeführten Positionen bestätigt:]]></text></staticText>
-			<line><reportElement positionType="Float" x="0" y="196" width="150" height="1"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
-			<staticText><reportElement positionType="Float" x="0" y="199" width="150" height="10"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Datum]]></text></staticText>
-			<line><reportElement positionType="Float" x="200" y="196" width="220" height="1"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
-			<staticText><reportElement positionType="Float" x="200" y="199" width="220" height="10"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Name, Unterschrift Empfänger]]></text></staticText>
+			<staticText><reportElement positionType="Float" x="12" y="150" width="549" height="12"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="8" isBold="true"/></textElement><text><![CDATA[Empfang der aufgeführten Positionen bestätigt:]]></text></staticText>
+			<line><reportElement positionType="Float" x="12" y="196" width="150" height="1"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
+			<staticText><reportElement positionType="Float" x="12" y="199" width="150" height="10"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Datum]]></text></staticText>
+			<line><reportElement positionType="Float" x="212" y="196" width="220" height="1"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
+			<staticText><reportElement positionType="Float" x="212" y="199" width="220" height="10"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Name, Unterschrift Empfänger]]></text></staticText>
 		</band>
 	</detail>
 	<pageFooter>
 		<band height="52">
-			<line><reportElement x="0" y="0" width="561" height="1"/></line>
-			<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "" : $F{doc_status})) + (($F{doc_number} == null) ? "" : (" · " + $F{doc_number}))]]></textFieldExpression></textField>
+			<line><reportElement x="12" y="0" width="549" height="1"/></line>
+			<textField isBlankWhenNull="true"><reportElement x="12" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "" : $F{doc_status})) + (($F{doc_number} == null) ? "" : (" · " + $F{doc_number}))]]></textFieldExpression></textField>
 			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
-			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
 			<!-- Supplier identity (§ 14 UStG: vollständige Anschrift + Steuernummer/USt-IdNr. des Ausstellers) -->
-			<textField isBlankWhenNull="true"><reportElement x="0" y="17" width="561" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_name} == null ? "" : $F{sup_name}) + ($F{sup_street} == null ? "" : " · " + $F{sup_street}) + (($F{sup_zip} == null && $F{sup_city} == null) ? "" : " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city})) + ($F{sup_vat_id} == null ? "" : " · USt-IdNr. " + $F{sup_vat_id}) + ($F{sup_tax_number} == null ? "" : " · Steuernummer " + $F{sup_tax_number}) + ($F{sup_register} == null ? "" : " · " + $F{sup_register}))]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="0" y="27" width="561" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_bank_name} == null ? "" : $F{sup_bank_name}) + ($F{sup_iban} == null ? "" : " · IBAN " + $F{sup_iban}) + ($F{sup_bic} == null ? "" : " · BIC " + $F{sup_bic}))]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="0" y="38" width="561" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="12" y="17" width="549" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_name} == null ? "" : $F{sup_name}) + ($F{sup_street} == null ? "" : " · " + $F{sup_street}) + (($F{sup_zip} == null && $F{sup_city} == null) ? "" : " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city})) + ($F{sup_vat_id} == null ? "" : " · USt-IdNr. " + $F{sup_vat_id}) + ($F{sup_tax_number} == null ? "" : " · Steuernummer " + $F{sup_tax_number}) + ($F{sup_register} == null ? "" : " · " + $F{sup_register}))]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="12" y="27" width="549" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_bank_name} == null ? "" : $F{sup_bank_name}) + ($F{sup_iban} == null ? "" : " · IBAN " + $F{sup_iban}) + ($F{sup_bic} == null ? "" : " · BIC " + $F{sup_bic}))]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="12" y="38" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/parameters.json
+++ b/ORDER-JSON-SAMPLE/parameters.json
@@ -20,6 +20,24 @@
       "example": "Musterfirma GmbH · Musterstraße 1 · 12345 Musterstadt · info@musterfirma.de"
     },
     {
+      "name": "Show_fold_marks",
+      "label": {
+        "de": "Falz- und Lochmarken",
+        "en": "Fold and punch marks"
+      },
+      "description": {
+        "de": "Druckt die Falzmarken bei 105 mm und 210 mm sowie die Lochmarke bei 148,5 mm an den linken Blattrand. Auf \"0\" setzen, wenn auf vorgedrucktem Briefpapier gedruckt wird, das die Marken bereits trägt.",
+        "en": "Prints the fold marks at 105 mm and 210 mm plus the punch mark at 148.5 mm on the left edge of the sheet. Set to \"0\" when printing on pre-printed stationery that already carries them."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Layout",
+      "default": "1",
+      "example": "1"
+    },
+    {
       "name": "Reportpath",
       "label": {
         "de": "Bundle-Wurzelpfad",

--- a/ORDER-JSON-SAMPLE/subreports/positions-delivery.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions-delivery.jrxml
@@ -12,7 +12,7 @@
   einen Sammel-Lieferschein ist das noch wichtiger als fuer die Rechnung — wer
   die Ware annimmt, muss sehen, welche Zeilen zu welchem Auftrag gehoeren.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0304-4d64-9f54-000000000304">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0304-4d64-9f54-000000000304">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Is_collective" class="java.lang.Boolean">
 		<parameterDescription><![CDATA[true = der Beleg fasst mehrere Auftraege zusammen; nur dann druckt die Gruppenkopfzeile je Quellauftrag. Wird vom Hauptbericht aus collective.is_collective gesetzt.]]></parameterDescription>
@@ -29,18 +29,18 @@
 		<groupHeader>
 			<band height="20">
 				<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{Is_collective})]]></printWhenExpression>
-				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="280" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
-				<textField isBlankWhenNull="true"><reportElement x="280" y="4" width="281" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
-				<line><reportElement x="0" y="18" width="561" height="1"/></line>
+				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="274" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement x="274" y="4" width="275" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
+				<line><reportElement x="0" y="18" width="549" height="1"/></line>
 			</band>
 		</groupHeader>
 	</group>
 	<detail>
 		<band height="15">
 			<textField isBlankWhenNull="true"><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="28" y="0" width="372" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##" isBlankWhenNull="true"><reportElement x="400" y="0" width="80" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="490" y="0" width="71" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="28" y="0" width="360" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##" isBlankWhenNull="true"><reportElement x="388" y="0" width="80" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="478" y="0" width="71" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/subreports/positions.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions.jrxml
@@ -23,7 +23,7 @@
   eindeutige Zeilenbezeichner `line_id` (EN 16931 BT-126) wird nicht gedruckt; er
   ist fuer die E-Rechnung da, nicht fuer das Papier.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions" pageWidth="561" pageHeight="842" columnWidth="561" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0301-4d61-9f51-000000000301">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0301-4d61-9f51-000000000301">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Is_collective" class="java.lang.Boolean">
 		<parameterDescription><![CDATA[true = der Beleg fasst mehrere Auftraege zusammen; nur dann druckt die Gruppenkopfzeile je Quellauftrag. Wird vom Hauptbericht aus collective.is_collective gesetzt.]]></parameterDescription>
@@ -49,27 +49,27 @@
 		<groupHeader>
 			<band height="20">
 				<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{Is_collective})]]></printWhenExpression>
-				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="280" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="274" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
 				<!-- Der Warenempfaenger des Quellauftrags: V1 beschriftet seine
 				     Gruppen genau damit ("Lieferung: …"), und das ist der Fall,
 				     fuer den es die Sammelrechnung gibt — ein Rechnungsempfaenger,
 				     mehrere Warenempfaenger. Fehlt er (Contract < 1.7 oder kein
 				     abweichender Lieferkunde), bleibt die Zeile leer. -->
-				<textField isBlankWhenNull="true"><reportElement x="280" y="4" width="281" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
-				<line><reportElement x="0" y="18" width="561" height="1"/></line>
+				<textField isBlankWhenNull="true"><reportElement x="274" y="4" width="275" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
+				<line><reportElement x="0" y="18" width="549" height="1"/></line>
 			</band>
 		</groupHeader>
 	</group>
 	<detail>
 		<band height="15">
 			<textField><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="28" y="0" width="240" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##"><reportElement x="268" y="0" width="32" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="306" y="0" width="22" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.00 €"><reportElement x="328" y="0" width="70" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{price}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##' %'"><reportElement x="398" y="0" width="45" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.00 €"><reportElement x="443" y="0" width="78" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{line_net}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##' %'"><reportElement x="521" y="0" width="40" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tax}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="28" y="0" width="228" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##"><reportElement x="256" y="0" width="32" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="294" y="0" width="22" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="316" y="0" width="70" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{price}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##' %'"><reportElement x="386" y="0" width="45" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="431" y="0" width="78" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{line_net}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##' %'"><reportElement x="509" y="0" width="40" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tax}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>


### PR DESCRIPTION
## Warum

Von den drei Versandpapieren hielt nur der Auftragsbeleg die DIN-Form nicht. Gemessen am Referenz-Bundle stand die Empfängeranschrift bei **6,0 mm von links und 10,6 mm von oben**; im Sichtbereich eines DIN-lang-Umschlags (rund 45 bis 90 mm ab Oberkante) standen stattdessen die Überschrift und der Kopf der Positionstabelle. Das Papier war nur als Beilage brauchbar.

Das galt für **alle** Belegtypen: Angebot, Auftragsbestätigung, Lieferschein, Rechnung und der neutrale Beleg teilen sich ein Titelband, die `printWhenExpression`-Schalter trennen nur Preise, Summen und Unterschriftszeilen. Ein Kopf, fünf Varianten, kein Fenster.

| | vorher | jetzt | DIN 5008 Form B |
|---|---|---|---|
| Anschriftfeld | 6,0 / 10,6 mm | 20,1 / 45,2 mm, 85 × 45 mm | 20 / 45 mm, 85 × 45 mm |
| Rücksendeangabe | Seitenkopf, 6,0 / 4,2 mm | im Anschriftfeld, 57,1 mm | Zusatz-/Vermerkzone im Feld |
| Informationsblock | 140,1 mm, oben bei 10,6 mm | 124,9 mm, auf Höhe der Anschrift | ab 125 mm |
| Betreffzeile | 46,6 mm | 98,4 mm | 98,4 mm |
| Falz-/Lochmarken | keine | 105 / 148,5 / 210 mm, abschaltbar | vorgesehen |

## Was geändert wurde

`ORDER-JSON-SAMPLE` und `DELIVERY-JSON-SAMPLE` bekommen exakt die Geometrie von Leihschein (`LOCATION-JSON-SAMPLE`) und Versandschein (`FREE-DELIVERY-JSON-SAMPLE`) — nicht eine eigene Variante davon. Wer drei Papiere im eigenen Layout pflegt, verschiebt dreimal dieselben Koordinaten; der Umstieg auf Form A bleibt eine Zahl (`y=116` → `y=64`).

- Anschriftfeld als Rahmen `x=40 y=116 241×128`, Rücksendeangabe bei `y=34` daraus, Anschrift bei `y=50`
- Anschrift als **ein** Textfeld mit `\n`-Zeilen: Ansprechpartner als z.-Hd.-Zeile, keine Lücke bei fehlender Straße, Landzeile nur bei einem von `supplier.country` abweichenden Land
- Informationsblock `x=337 y=116`; die Zeile „Kontakt" entfällt, wenn der Name schon in der Anschrift steht, und eine entfallende Zeile schließt sich, statt eine Lücke zu lassen
- Betreffzeile bei `y=267`, abweichende Liefer-/Rechnungsadresse darunter statt im Kopf — im Fenster ist Platz für genau eine Anschrift
- Falz- und Lochmarken im Hintergrundband, abschaltbar über den neuen Parameter `Show_fold_marks` (Berichtsvariable `show_fold_marks`, Default `1`), auch im Parameter-Manifest

**Textblock rückt auf `x=12` ein, Tabelle wird 549 pt breit.** Der Beleg war randbündig gesetzt (561 pt Inhalt auf 210 mm Blatt), damit läge jede Falzmarke in der Positionsspalte — die Lochmarke bei 148,5 mm kreuzte sichtbar eine Positionsnummer. Derselbe Einzug wie bei den anderen beiden Fensterbriefen. Kostet 12 pt in der Spalte „Beschreibung" und verschiebt die Betragsspalten um 12 pt nach links; rechtsbündige Blöcke (Summen, Steuerzeilen, Seitenzählung) enden weiter bei 561 pt.

Nebenbei: „Seite 1 von1" in der Fußzeile bekommt sein Leerzeichen, und der Musterdatensatz des Lieferscheins einen `supplier`-Block statt des fest verdrahteten Musterabsenders.

## Kein Backend-Eingriff

Der Contract liefert alles: `recipient.contact.name` seit 1.2, `recipient.country` seit 1.8, `supplier.*` aus den `company_*`-Berichtsvariablen. `Show_fold_marks` erreicht die Vorlage über die vorhandene `ucfirst`-Auflösung im `ReportParameterBuilder` — dieselbe Variable, die Leihschein und Versandschein schon benutzen. Doku und ADR liegen im PR zu calServer-yii.

## Geprüft

- JasperReports **6.20.6** lokal gerendert, alle fünf Varianten (Angebot, Auftragsbestätigung, Lieferschein, Rechnung, Statusfallback) plus die schlanke Lieferschein-Fassung; Anschrift, Informationsblock, Betreff und Marken nachgemessen
- `scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` grün (die zwei Warnungen betreffen `DAKKS-JSON-SAMPLE` und sind Bestand)

## Grenzen, bewusst

- **Kein DIN-Schreibbereich** (24,1 / 8,1 mm). Sieben Betragsspalten passen nicht in 178 mm, ohne dass die Beschreibungsspalte unbrauchbar wird; Leihschein und Versandschein setzen denselben Kompromiss. DIN-relevant ist, was das Fenster zeigt.
- **Kein wiederholter Tabellenkopf auf Folgeseiten** — der steht im Titelband. War vorher so, bleibt ein eigener Punkt.
- Bestandslayouts sind nicht betroffen: Das Referenz-Bundle ist Vorlage, nicht Vorschrift. Wer es übernimmt, bekommt das neue Layout inklusive der schmaleren Beschreibungsspalte.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HPuT6RmXGPB5hda4d9pBTZ)_