### PR TITLE
fix(dakks): Ergebnistabelle zeigt Sollwert und Messwert auch ohne Parameter

### DIFF
--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -109,6 +109,54 @@ python3 scripts/dcc330_writer.py \
 > `dcc330_writer.py` ist der PTB-3.3.0-Nachfolger des einfacheren
 > `dcc_xml_writer.py` (calhelp-Format).
 
+## Ergebnistabelle: welche Felder wo landen
+
+Die Messwertspalten hängen an zwei gleichwertigen Spaltenpaaren des Contracts,
+und die Layout-Variante entscheidet nur noch, welches sie **zuerst** liest:
+
+| Spalte des Scheins | primär | Rückfall |
+|--------------------|--------|----------|
+| Sollwert (Varianten `1`, `2`, `3`, `4`) | `results[].fixq` (+`_p`/`_u`) | `sys_actual` |
+| Sollwert (Varianten `21`, `22`) | `results[].sys_actual` (+`_p`/`_u`) | `fixq` |
+| Messwert (Varianten `1`, `2`, `3`, `4`) | `results[].varq` | `uut_ind` |
+| Messwert (Varianten `21`, `22`) | `results[].uut_ind` | `varq` |
+| Messbedingungen | `results[].test_desc` | – |
+| % rel. Abweichung | `results[].rel_err` | – |
+
+`sys_actual`/`uut_ind` füllt die calServer-Messwertaufnahme nur für numerische
+Prüfschritte mit gesetztem `tol_ref`; MET/CAL-Importe liefern beide Paare. Ohne
+den Rückfall blieb die Ergebnistabelle deshalb bei ungesetztem
+`MeasurementDetails` leer, obwohl die Zeilen die Werte trugen. **Sind beide
+Paare gefüllt, druckt jede Variante unverändert das Paar, das sie schon immer
+gedruckt hat.**
+
+`test_desc` ist die Bezeichnung des Prüfschritts aus der Prozedur — sprechende
+Messbedingungen entstehen dort, nicht im Bericht.
+
+## Prozedur und Umgebungsbedingungen: gepflegt wird an der Quelle
+
+Vier Abschnitte des Scheins kommen aus der **Prozedur**, nicht aus Parametern.
+Damit der Datensatz sie überhaupt trägt, muss die Berichtsvariable
+`procedure_field` auf das Kalibrierfeld zeigen, das den Prozedurnamen führt
+(V1-Original: `C2320`). Ohne sie bleibt der `procedure`-Block leer und der
+Schein fällt auf seine Textbausteine zurück:
+
+| Abschnitt | Feld der Prozedur | Fallback-Parameter |
+|-----------|-------------------|--------------------|
+| Kalibrierverfahren | `procedure.description` | `Calibration_procedure_1` |
+| Verfahrensanweisung | `procedure.calibration_method` | `Calibration_document` |
+| Messbedingungen | `procedure.measurement_conditions` | „im permanenten Labor" |
+| Geltungsbereich | `procedure.scope` | `calibration_item` → `standards` → `Calibration_procedure_2` |
+
+**Umgebungsbedingungen** kommen aus einer **Ressource**: `environmental_conditions`
+benennt sie, gelesen wird ihr Feld „Umgebungsbedingungen"
+(`resource.environment_resources`) → `environment.working_hours`. Das Format ist
+ein Text mit `|` als Trenner — links die Temperatur, rechts die Feuchte, jeweils
+mit Einheit, z. B. `21,0 ... 23,0 °C|40 ... 60 %`. Jede Hälfte fällt für sich auf
+den an der Kalibrierung erfassten Wert zurück (`calibration.custom_fields.C2311`
+bzw. `C2312`), wenn sie leer bleibt. So steht der Klimabereich des Labors einmal
+an der Ressource statt in jedem Bericht erneut.
+
 ## Konformitätsspalte: welche Werte die Vorlage liest
 
 Die Spalte „Konformität" hängt an **einem** Feld: `results[].pass_fail`.

--- a/DAKKS-JSON-SAMPLE/parameters.json
+++ b/DAKKS-JSON-SAMPLE/parameters.json
@@ -268,8 +268,8 @@
         "en": "Results table layout"
       },
       "description": {
-        "de": "Wählt die Spaltenvariante des Ergebnis-Subreports (1, 2, 21, 22, 3, 4 — wie V1 MET/CAL).",
-        "en": "Selects the column variant of the results subreport (1, 2, 21, 22, 3, 4 — as in V1 MET/CAL)."
+        "de": "Wählt die Spaltenvariante des Ergebnis-Subreports (1, 2, 21, 22, 3, 4 — wie V1 MET/CAL). Tipp: Die Spalte „Messbedingungen“ ist `test_desc` — die Bezeichnung des Prüfschritts aus der Prozedur. Wer sie sprechend haben will („Kanal 1, Anzeigeabweichung bei 15 °C“), pflegt sie in der Prozedur, nicht im Bericht. Sollwert und Messwert füllen sich aus dem Spaltenpaar, das die Zeile trägt: `fixq`/`varq` oder `sys_actual`/`uut_ind`; ist das eigene Paar leer, greift die Variante auf das andere zurück. Die Wahl der Variante entscheidet damit über das Layout, nicht mehr darüber, ob überhaupt Zahlen erscheinen.",
+        "en": "Selects the column variant of the results subreport (1, 2, 21, 22, 3, 4 — as in V1 MET/CAL). Tip: the \"measuring condition\" column is `test_desc`, the test step's label from the procedure. Maintain it there, not in the report. Nominal and measured value come from whichever column pair the row carries — `fixq`/`varq` or `sys_actual`/`uut_ind`; if its own pair is empty the variant falls back to the other one. The variant therefore decides the layout, no longer whether any numbers show up at all."
       },
       "role": "variable",
       "group": "Ergebnistabelle",
@@ -472,8 +472,8 @@
         "en": "Section \"calibration procedure\""
       },
       "description": {
-        "de": "„N“ blendet den Abschnitt „Kalibrierverfahren“ aus.",
-        "en": "\"N\" hides the \"calibration procedure\" section."
+        "de": "Abschnitt „Kalibrierverfahren“. Tipp: Gedruckt wird die Beschreibung der Prozedur; `Calibration_procedure_1` ist nur der Fallback, wenn die Prozedur nichts liefert.",
+        "en": "Section \"calibration procedure\". Tip: what gets printed is the procedure's description; `Calibration_procedure_1` is only the fallback for when the procedure has nothing."
       },
       "role": "variable",
       "group": "Abschnitte",
@@ -504,8 +504,8 @@
         "en": "Section \"procedural document\""
       },
       "description": {
-        "de": "„N“ blendet den Abschnitt „Verfahrensanweisung“ aus.",
-        "en": "\"N\" hides the \"procedural document\" section."
+        "de": "Abschnitt „Verfahrensanweisung / QMS-Dokument“. Tipp: Gedruckt wird die Kalibriermethode der Prozedur; `Calibration_document` ist nur der Fallback.",
+        "en": "Section \"procedure document / QMS document\". Tip: what gets printed is the procedure's calibration method; `Calibration_document` is only the fallback."
       },
       "role": "variable",
       "group": "Abschnitte",
@@ -536,8 +536,8 @@
         "en": "Section \"measurement conditions\""
       },
       "description": {
-        "de": "„N“ blendet den Abschnitt „Messbedingungen“ aus.",
-        "en": "\"N\" hides the \"measurement conditions\" section."
+        "de": "„N“ blendet den Abschnitt „Messbedingungen“ aus. Tipp: Der Text kommt aus dem Feld „Messbedingungen“ der Prozedur. Damit der Bericht die Prozedur überhaupt findet, muss die Berichtsvariable `procedure_field` auf das Kalibrierfeld zeigen, das den Prozedurnamen trägt (V1: `C2320`). Ohne Prozedur druckt der Schein „im permanenten Labor“.",
+        "en": "\"N\" hides the \"measurement conditions\" section. Tip: the text comes from the procedure's \"measurement conditions\" field. For the report to find the procedure at all, the `procedure_field` report variable must point at the calibration field holding the procedure name (V1: `C2320`). Without a procedure the certificate prints \"in the permanent laboratory\"."
       },
       "role": "variable",
       "group": "Abschnitte",
@@ -600,8 +600,8 @@
         "en": "Section \"environmental conditions\""
       },
       "description": {
-        "de": "„N“ blendet den Abschnitt „Umgebungsbedingungen“ aus.",
-        "en": "\"N\" hides the \"environmental conditions\" section."
+        "de": "„N“ blendet den Abschnitt „Umgebungsbedingungen“ aus. Tipp: Temperatur und Feuchte kommen aus der Ressource, die `environmental_conditions` benennt. Ist dort nichts hinterlegt, fällt der Schein je Zeile auf die an der Kalibrierung erfassten Werte zurück (`C2311` °C, `C2312` %).",
+        "en": "\"N\" hides the \"environmental conditions\" section. Tip: temperature and humidity come from the resource named by `environmental_conditions`. With nothing stored there, each line falls back to the values recorded on the calibration itself (`C2311` °C, `C2312` %)."
       },
       "role": "variable",
       "group": "Abschnitte",
@@ -866,8 +866,8 @@
         "en": "Environmental-conditions resource"
       },
       "description": {
-        "de": "Name der calServer-Ressource, deren Klimabereich („Temp|Feuchte“) gedruckt wird (kleingeschriebener V1-Parametername; speist auch environment.working_hours im Datensatz).",
-        "en": "Name of the calServer resource whose climate range (\"temp|humidity\") is printed (lowercase V1 parameter name; also feeds environment.working_hours in the dataset)."
+        "de": "Name der calServer-Ressource, deren Klimabereich („Temp|Feuchte“) gedruckt wird (kleingeschriebener V1-Parametername; speist auch environment.working_hours im Datensatz). Tipp: Gelesen wird das Feld „Umgebungsbedingungen“ der Ressource, ein Text mit `|` als Trenner — links die Temperatur, rechts die Feuchte, jeweils mit Einheit, z. B. `21,0 ... 23,0 °C|40 ... 60 %`. Jede Hälfte fällt für sich auf den an der Kalibrierung erfassten Wert zurück, wenn sie leer bleibt. So steht der Klimabereich des Labors einmal an der Ressource und nicht in jedem Bericht erneut.",
+        "en": "Name of the calServer resource whose climate range (\"temp|humidity\") is printed (lowercase V1 parameter name; also feeds environment.working_hours in the dataset). Tip: what is read is the resource's \"environmental conditions\" field, a text using `|` as the separator — temperature on the left, humidity on the right, each with its unit, e.g. `21.0 ... 23.0 °C|40 ... 60 %`. Each half falls back on its own to the value recorded on the calibration when left empty. That way the lab's climate range lives on the resource once instead of in every report."
       },
       "role": "variable",
       "group": "Abschnitte",
@@ -1075,8 +1075,8 @@
         "en": "Calibration-procedure fallback"
       },
       "description": {
-        "de": "Fallback-Text, wenn der Datensatz keine Verfahrensbeschreibung liefert. Leer lassen für den zweisprachigen V1-Standardtext.",
-        "en": "Overrides the built-in bilingual V1 default text; leave empty to keep it."
+        "de": "Fallback-Text, wenn der Datensatz keine Verfahrensbeschreibung liefert. Leer lassen für den zweisprachigen V1-Standardtext. Tipp: Der bessere Ort ist das Feld „Beschreibung“ der Prozedur — es gilt je Prüfmittel, dieser Parameter je Bericht.",
+        "en": "Fallback text when the dataset carries no procedure description. Leave empty to keep the bilingual V1 default. Tip: the better place is the procedure's \"description\" field — it applies per instrument, this parameter per report."
       },
       "role": "variable",
       "group": "Textbausteine",
@@ -1090,8 +1090,8 @@
         "en": "Procedural-document fallback"
       },
       "description": {
-        "de": "Fallback-Text, wenn der Datensatz keine Verfahrensanweisung liefert. Leer lassen für den zweisprachigen V1-Standardtext.",
-        "en": "Overrides the built-in bilingual V1 default text; leave empty to keep it."
+        "de": "Fallback für die Verfahrensanweisung, wenn der Datensatz keine liefert. Tipp: Der bessere Ort ist das Feld „Kalibriermethode“ der Prozedur.",
+        "en": "Fallback for the procedure document when the dataset carries none. Tip: the better place is the procedure's \"calibration method\" field."
       },
       "role": "variable",
       "group": "Textbausteine",
@@ -1105,8 +1105,8 @@
         "en": "Work-instruction fallback"
       },
       "description": {
-        "de": "Fallback-Text für die Arbeitsanweisungs-Kaskade. Leer lassen für den zweisprachigen V1-Standardtext.",
-        "en": "Overrides the built-in bilingual V1 default text; leave empty to keep it."
+        "de": "Fallback für den Geltungsbereich, wenn weder Prozedur-Scope, Kalibriergegenstand noch Normale gefüllt sind. Tipp: Der bessere Ort ist das Feld „Geltungsbereich“ der Prozedur.",
+        "en": "Fallback for the scope when neither the procedure scope, the calibration item nor the standards are filled. Tip: the better place is the procedure's \"scope\" field."
       },
       "role": "variable",
       "group": "Textbausteine",

--- a/DAKKS-JSON-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/Results.jrxml
@@ -133,15 +133,72 @@
     || !$P{ModernResultsHeader}.toString().trim().equalsIgnoreCase("N")
 )]]></variableExpression>
 	</variable>
+	<!--
+	    Sollwert und Messwert stehen je nach Erfassungsweg in einem von zwei
+	    Spaltenpaaren: `fixq`/`varq` (Sollwert des Prüfschritts und Ablesung)
+	    oder `sys_actual`/`uut_ind` (Wert des Normals und Anzeige des
+	    Prüflings). MET/CAL liefert beide Paare; die V2-Messwertaufnahme füllt
+	    `sys_actual`/`uut_ind` nur für numerische Schritte mit gesetztem
+	    `tol_ref` und lässt sie sonst leer.
+
+	    Jede Layout-Variante band bisher genau ein Paar. Stand der Wert im
+	    anderen, blieb die Spalte leer, obwohl die Zeile ihn trug — genau der
+	    Fall, in dem der Schein ohne gesetzten Parameter `MeasurementDetails`
+	    eine leere Ergebnistabelle druckte. Die folgenden Variablen greifen auf
+	    die Schwesterspalte zurück, wenn die eigene leer ist; Präfix und
+	    Einheit folgen dabei der Spalte, aus der der Wert stammt. Sind beide
+	    Paare gefüllt — der MET/CAL-Fall —, druckt jede Variante unverändert
+	    das Paar, das sie schon immer gedruckt hat.
+	-->
+	<variable name="FixqValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+      ? $F{fixq}
+      : ($F{sys_actual} == null ? "" : $F{sys_actual})]]></variableExpression>
+	</variable>
+	<variable name="FixqPrefix" class="java.lang.String">
+		<variableExpression><![CDATA[($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+      ? ($F{fixq_p} == null ? "" : $F{fixq_p})
+      : ($F{sys_actual_p} == null ? "" : $F{sys_actual_p})]]></variableExpression>
+	</variable>
+	<variable name="FixqUnit" class="java.lang.String">
+		<variableExpression><![CDATA[($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+      ? ($F{fixq_u} == null ? "" : $F{fixq_u})
+      : ($F{sys_actual_u} == null ? "" : $F{sys_actual_u})]]></variableExpression>
+	</variable>
+	<variable name="SysActualValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{sys_actual} != null && !$F{sys_actual}.trim().isEmpty())
+      ? $F{sys_actual}
+      : ($F{fixq} == null ? "" : $F{fixq})]]></variableExpression>
+	</variable>
+	<variable name="SysActualPrefix" class="java.lang.String">
+		<variableExpression><![CDATA[($F{sys_actual} != null && !$F{sys_actual}.trim().isEmpty())
+      ? ($F{sys_actual_p} == null ? "" : $F{sys_actual_p})
+      : ($F{fixq_p} == null ? "" : $F{fixq_p})]]></variableExpression>
+	</variable>
+	<variable name="SysActualUnit" class="java.lang.String">
+		<variableExpression><![CDATA[($F{sys_actual} != null && !$F{sys_actual}.trim().isEmpty())
+      ? ($F{sys_actual_u} == null ? "" : $F{sys_actual_u})
+      : ($F{fixq_u} == null ? "" : $F{fixq_u})]]></variableExpression>
+	</variable>
+	<variable name="VarqValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{varq} != null && !$F{varq}.trim().isEmpty())
+      ? $F{varq}
+      : ($F{uut_ind} == null ? "" : $F{uut_ind})]]></variableExpression>
+	</variable>
+	<variable name="UutIndValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{uut_ind} != null && !$F{uut_ind}.trim().isEmpty())
+      ? $F{uut_ind}
+      : ($F{varq} == null ? "" : $F{varq})]]></variableExpression>
+	</variable>
 	<variable name="NominalValue" class="java.lang.String">
-		<variableExpression><![CDATA[$F{fixq}==null || $F{fixq}.trim().isEmpty()
+		<variableExpression><![CDATA[$V{FixqValue}==null || $V{FixqValue}.trim().isEmpty()
       ? ""
-      : $F{fixq}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
+      : $V{FixqValue}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
 	</variable>
 	<variable name="MeasuredValue" class="java.lang.String">
-		<variableExpression><![CDATA[$F{varq}==null || $F{varq}.trim().isEmpty()
+		<variableExpression><![CDATA[$V{VarqValue}==null || $V{VarqValue}.trim().isEmpty()
       ? ""
-      : $F{varq}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
+      : $V{VarqValue}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
 	</variable>
 	<variable name="PosLimit" class="java.lang.String">
 		<variableExpression><![CDATA[($F{upper_limit} == null || $F{upper_limit}.trim().isEmpty()
@@ -189,10 +246,10 @@
  ? ""
  : (
      (
-       $F{fixq} != null
-       && !$F{fixq}.trim().isEmpty()
-       && $F{fixq}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", ".").matches("[+-]?\\d+(\\.\\d+)?([eE][+-]?\\d+)?")
-       && Math.abs(Double.parseDouble($F{fixq}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", "."))) < 1e-9
+       $V{FixqValue} != null
+       && !$V{FixqValue}.trim().isEmpty()
+       && $V{FixqValue}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", ".").matches("[+-]?\\d+(\\.\\d+)?([eE][+-]?\\d+)?")
+       && Math.abs(Double.parseDouble($V{FixqValue}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", "."))) < 1e-9
      )
      ? "--"
      : (
@@ -2449,6 +2506,17 @@
               : ""]]></textFieldExpression>
 				</textField>
 				<textField isBlankWhenNull="true">
+					<reportElement x="70" y="0" width="54" height="14" uuid="3a0f6c21-7d54-4b8e-9a2f-6c1b0e4d8f37"/>
+					<textElement textAlignment="Right" verticalAlignment="Bottom">
+						<font fontName="DejaVu Sans" size="8"/>
+					</textElement>
+					<textFieldExpression><![CDATA[(
+              $V{FixqValue} == null || $V{FixqValue}.trim().isEmpty()
+            ? ""
+            : $V{FixqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+            )]]></textFieldExpression>
+				</textField>
+				<textField isBlankWhenNull="true">
 					<reportElement x="124" y="0" width="54" height="14" uuid="8fac207f-71ce-479d-aedf-4db886a10327"/>
 					<textElement textAlignment="Right" verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
@@ -2465,9 +2533,9 @@
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{varq} == null || $F{varq}.trim().isEmpty()
+              $V{VarqValue} == null || $V{VarqValue}.trim().isEmpty()
             ? ""
-            : $F{varq}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+            : $V{VarqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
 				</textField>
 				<textField isBlankWhenNull="true">
@@ -2541,21 +2609,21 @@
 					</textElement>
                                         <textFieldExpression><![CDATA[(
               (
-                $F{fixq} == null || $F{fixq}.trim().isEmpty()
+                $V{FixqValue} == null || $V{FixqValue}.trim().isEmpty()
                   ? ""
-                  : $F{fixq}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
+                  : $V{FixqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
               )
-            + ($F{fixq_p} == null || $F{fixq_p}.trim().isEmpty() ? "" : " " + $F{fixq_p}.trim())
+            + ($V{FixqPrefix} == null || $V{FixqPrefix}.trim().isEmpty() ? "" : " " + $V{FixqPrefix}.trim())
             + (
                 (
-                  $F{fixq} != null
-                    && !$F{fixq}.trim().isEmpty()
-                    && $F{fixq}.trim().matches(".*\\p{L}.*")
+                  $V{FixqValue} != null
+                    && !$V{FixqValue}.trim().isEmpty()
+                    && $V{FixqValue}.trim().matches(".*\\p{L}.*")
                 )
-                || $F{fixq_u} == null
-                || $F{fixq_u}.trim().isEmpty()
+                || $V{FixqUnit} == null
+                || $V{FixqUnit}.trim().isEmpty()
                   ? ""
-                  : " " + $F{fixq_u}.trim()
+                  : " " + $V{FixqUnit}.trim()
               )
             ).trim().replaceAll("(?i)ohm","Ω")]]></textFieldExpression>
 				</textField>
@@ -2590,9 +2658,9 @@
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{varq} == null || $F{varq}.trim().isEmpty()
+              $V{VarqValue} == null || $V{VarqValue}.trim().isEmpty()
             ? ""
-            : $F{varq}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+            : $V{VarqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
 				</textField>
 				<textField isBlankWhenNull="true">
@@ -2692,21 +2760,21 @@
 					</textElement>
                                         <textFieldExpression><![CDATA[(
               (
-                $F{sys_actual} == null || $F{sys_actual}.trim().isEmpty()
+                $V{SysActualValue} == null || $V{SysActualValue}.trim().isEmpty()
                   ? ""
-                  : $F{sys_actual}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
+                  : $V{SysActualValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
               )
-            + ($F{sys_actual_p} == null || $F{sys_actual_p}.trim().isEmpty() ? "" : " " + $F{sys_actual_p}.trim())
+            + ($V{SysActualPrefix} == null || $V{SysActualPrefix}.trim().isEmpty() ? "" : " " + $V{SysActualPrefix}.trim())
             + (
                 (
-                  $F{sys_actual} != null
-                    && !$F{sys_actual}.trim().isEmpty()
-                    && $F{sys_actual}.trim().matches(".*\\p{L}.*")
+                  $V{SysActualValue} != null
+                    && !$V{SysActualValue}.trim().isEmpty()
+                    && $V{SysActualValue}.trim().matches(".*\\p{L}.*")
                 )
-                || $F{sys_actual_u} == null
-                || $F{sys_actual_u}.trim().isEmpty()
+                || $V{SysActualUnit} == null
+                || $V{SysActualUnit}.trim().isEmpty()
                   ? ""
-                  : " " + $F{sys_actual_u}.trim()
+                  : " " + $V{SysActualUnit}.trim()
               )
             ).trim().replaceAll("(?i)ohm","Ω")]]></textFieldExpression>
 				</textField>
@@ -2741,9 +2809,9 @@
                                                 <font fontName="DejaVu Sans" size="8"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{uut_ind} == null || $F{uut_ind}.trim().isEmpty()
+              $V{UutIndValue} == null || $V{UutIndValue}.trim().isEmpty()
                 ? ""
-                : $F{uut_ind}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+                : $V{UutIndValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
                                 </textField>
                                 <textField isBlankWhenNull="true">
@@ -2843,21 +2911,21 @@
 					</textElement>
                                         <textFieldExpression><![CDATA[(
               (
-                $F{sys_actual} == null || $F{sys_actual}.trim().isEmpty()
+                $V{SysActualValue} == null || $V{SysActualValue}.trim().isEmpty()
                   ? ""
-                  : $F{sys_actual}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
+                  : $V{SysActualValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
               )
-            + ($F{sys_actual_p} == null || $F{sys_actual_p}.trim().isEmpty() ? "" : " " + $F{sys_actual_p}.trim())
+            + ($V{SysActualPrefix} == null || $V{SysActualPrefix}.trim().isEmpty() ? "" : " " + $V{SysActualPrefix}.trim())
             + (
                 (
-                  $F{sys_actual} != null
-                    && !$F{sys_actual}.trim().isEmpty()
-                    && $F{sys_actual}.trim().matches(".*\\p{L}.*")
+                  $V{SysActualValue} != null
+                    && !$V{SysActualValue}.trim().isEmpty()
+                    && $V{SysActualValue}.trim().matches(".*\\p{L}.*")
                 )
-                || $F{sys_actual_u} == null
-                || $F{sys_actual_u}.trim().isEmpty()
+                || $V{SysActualUnit} == null
+                || $V{SysActualUnit}.trim().isEmpty()
                   ? ""
-                  : " " + $F{sys_actual_u}.trim()
+                  : " " + $V{SysActualUnit}.trim()
               )
             ).trim().replaceAll("(?i)ohm","Ω")]]></textFieldExpression>
 				</textField>
@@ -2867,9 +2935,9 @@
                                                 <font fontName="DejaVu Sans" size="8"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{uut_ind} == null || $F{uut_ind}.trim().isEmpty()
+              $V{UutIndValue} == null || $V{UutIndValue}.trim().isEmpty()
                 ? ""
-                : $F{uut_ind}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+                : $V{UutIndValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
                                 </textField>
 				<textField>

--- a/DAKKS-SAMPLE/README.md
+++ b/DAKKS-SAMPLE/README.md
@@ -127,16 +127,31 @@ für optionale Parameter.
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
 | `Cert_field` | ➖ | `""` | Quelle der Zertifikats­nummer und des Kalibrier­kennzeichens. Erlaubte Werte: `C2396`, `C2395`, `C2364` oder `C2356`; andere Werte fallen auf `C2356` zurück. Wird zugleich an den Subreport `Standard` durchgereicht. |
-| `MeasurementDetails` | ➖ | `1` | Wählt eines der vier Messwert-Layouts im Subreport `Results` (`1` Basis­darstellung, `2` formatierte Eingaben, `3` autoformatierte Anzeige, `4` ISO-konforme Unsicherheit). Leere oder nicht-numerische Eingaben werden als `1` behandelt. |
+| `MeasurementDetails` | ➖ | `1` | Wählt eines der Messwert-Layouts im Subreport `Results` (`1` Basis­darstellung, `2`/`22` formatierte Eingaben, `21` Kurzform ohne Spezifikations­spalten, `3` autoformatierte Anzeige, `4` ISO-konforme Unsicherheit). Leere oder nicht-numerische Eingaben werden als `1` behandelt. **Die Variante entscheidet über das Layout, nicht darüber, ob Zahlen erscheinen** – Sollwert und Messwert greifen auf das jeweils andere Spaltenpaar zurück (siehe Abschnitt 5.2). |
 | `ModernResultsHeader` | ➖ | `Y` | Tabellenkopf-Stil im `Results`-Unterbericht. Standard ist der moderne Kopf ohne umlaufende Rahmen (gilt auch für leere oder unbekannte Werte); nur ein explizites `N` schaltet auf den klassischen Kopf mit Rahmen zurück. Beide Stile sind je `MeasurementDetails`-Variante an den Datenspalten ausgerichtet. |
 | `ExpUncType` | ➖ | `""` | Freitext für ergänzende Hinweise zur erweiterten Messunsicherheit (z. B. `k=2`-Anmerkungen). |
-| `environmental_conditions` | ➖ | `""` | Optionaler Freitext für Umgebungs­temperatur und relative Luft­feuchte im Format `Text_Temperatur \| Text_Feuchte`. Ersetzt die Werte aus `C2311`/`C2312`, wenn angegeben. Ist ein Ressourcen­name übergeben, werden Temperatur und Feuchte aus `resource.environment_resources` derselben Zeile übernommen. |
+| `environmental_conditions` | ➖ | `""` | Name der Ressource, deren Klimabereich gedruckt wird. Der Bericht joint `resource.name = $P{environmental_conditions}` und liest deren Feld „Umgebungs­bedingungen“ (`environment_resources`) – ein Text mit `\|` als Trenner, links die Temperatur, rechts die Feuchte, jeweils mit Einheit, z. B. `21,0 ... 23,0 °C\|40 ... 60 %`. **Jede Hälfte fällt für sich zurück:** bleibt sie leer, druckt der Schein den an der Kalibrierung erfassten Wert (`C2311` + ` °C` bzw. `C2312` + ` %`). So steht der Klimabereich des Labors einmal an der Ressource statt in jedem Bericht erneut. |
 
 ### 4.5 Normative Textbausteine {#params-textblocks}
 
 Alle Textbaustein-Parameter sind optional. Sie sind im JRXML mit DAkkS-konformen
 Standard­formulierungen (de/en gemäß `Sprache`) vorbelegt; durch Übergabe eines
 eigenen Werts wird der Standard überschrieben.
+
+**Die Prozedur schlägt den Parameter.** Die drei `Calibration_*`-Bausteine sind
+reine Fallbacks: Liefert die zur Kalibrierung gehörende Prozedur einen Text,
+gewinnt sie. Gepflegt gehören diese Angaben deshalb an die Prozedur – sie gelten
+dort je Prüfmittel, der Parameter dagegen je Bericht. Welches Kalibrierfeld den
+Prozedurnamen trägt, entscheidet der Join `procedures.procedure_name = c.C2320`
+(V2: die Berichtsvariable `procedure_field`); ohne treffende Prozedur bleiben
+alle vier Prozedur-Abschnitte bei ihren Fallbacks.
+
+| Abschnitt | Feld der Prozedur | Fallback |
+| --- | --- | --- |
+| Kalibrier­verfahren | `procedure_description` | `Calibration_procedure_1` → „Kalibrierverfahren nicht angegeben“ |
+| Verfahrens­anweisung | `calibration_method` | `Calibration_document` → „Verfahrensanweisung nicht angegeben“ |
+| Messbedingungen | `measurement_conditions` | „im permanenten Labor“ |
+| Geltungs­bereich | `scope` | `calibration_item` → `standards` → `Calibration_procedure_2` → „--“ |
 
 | Parameter | Pflicht | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
@@ -151,9 +166,9 @@ eigenen Werts wird der Standard überschrieben.
 | `Conformity_description_2` | ➖ | sprachabhängig | Mehrzeilige Kurzlegende zu den Konformitäts­symbolen (`?`, `!?`, `!`, `*`). |
 | `Conformity_description_3` | ➖ | sprachabhängig | Abschluss­hinweis zur Konformitäts­aussage. |
 | `Additional_information` | ➖ | sprachabhängig | Zusatzhinweise, u. a. zur internationalen DAkkS-Anerkennung. |
-| `Calibration_procedure_1` | ➖ | sprachabhängig | Erster Textbaustein zum angewendeten Kalibrier­verfahren. |
-| `Calibration_procedure_2` | ➖ | sprachabhängig | Zweiter Textbaustein zum Kalibrier­verfahren (z. B. Verweis auf Norm). |
-| `Calibration_document` | ➖ | sprachabhängig | Verweis auf Verfahrens­anweisung bzw. QMS-Dokument. |
+| `Calibration_procedure_1` | ➖ | sprachabhängig | Fallback für das angewendete Kalibrier­verfahren. Der bessere Ort ist das Feld „Beschreibung“ der Prozedur. |
+| `Calibration_procedure_2` | ➖ | sprachabhängig | Fallback für den Geltungs­bereich, wenn weder Prozedur-Scope noch Kalibrier­gegenstand noch Normale gefüllt sind. Der bessere Ort ist das Feld „Geltungsbereich“ der Prozedur. |
+| `Calibration_document` | ➖ | sprachabhängig | Fallback für die Verfahrens­anweisung bzw. das QMS-Dokument. Der bessere Ort ist das Feld „Kalibriermethode“ der Prozedur. |
 
 ### 4.6 Abschnittsumschalter (`ShowGroup1*`) {#params-showgroup}
 
@@ -167,11 +182,11 @@ und können auf `Y` (anzeigen) oder `N` (ausblenden) gesetzt werden. Die Werte
 | `ShowGroup1IncomingDate` | ➖ | `Y` | Abschnitt „Datum der Anlieferung / Incoming Date“. |
 | `ShowGroup1Condition` | ➖ | `Y` | Abschnitt „Zustand bei Eingang/Ausgang“. |
 | `ShowGroup1Spacer` | ➖ | `Y` | Optionaler Abstand vor dem Verfahren. |
-| `ShowGroup1Procedure` | ➖ | `Y` | Abschnitt „Kalibrierverfahren“. |
-| `ShowGroup1ProcedureDocument` | ➖ | `Y` | Abschnitt „Verfahrens­anweisung / QMS-Dokument“. |
-| `ShowGroup1MeasurementConditions` | ➖ | `Y` | Abschnitt „Messbedingungen“. |
+| `ShowGroup1Procedure` | ➖ | `Y` | Abschnitt „Kalibrierverfahren“ (Text aus der Prozedur, siehe 4.5). |
+| `ShowGroup1ProcedureDocument` | ➖ | `Y` | Abschnitt „Verfahrens­anweisung / QMS-Dokument“ (Kalibriermethode der Prozedur, siehe 4.5). |
+| `ShowGroup1MeasurementConditions` | ➖ | `Y` | Abschnitt „Messbedingungen“ (Feld „Messbedingungen“ der Prozedur, siehe 4.5). |
 | `ShowGroup1CalibrationPlace` | ➖ | `Y` | Abschnitt „Ort der Kalibrierung“. |
-| `ShowGroup1EnvironmentalConditions` | ➖ | `Y` | Abschnitt „Umgebungsbedingungen“. |
+| `ShowGroup1EnvironmentalConditions` | ➖ | `Y` | Abschnitt „Umgebungsbedingungen“ (Ressource aus `environmental_conditions`, siehe 4.4). |
 | `ShowGroup1StandardsTraceability` | ➖ | `Y` | Abschnitt „Verwendete Normale / Rückführung“. |
 | `ShowGroup1ResultsIntro` | ➖ | `Y` | Einleitung zu den Mess­ergebnissen. |
 | `ShowGroup1MeasurementUncertainty` | ➖ | `Y` | Abschnitt „MESSUNSICHERHEITEN / UNCERTAINTY OF MEASUREMENTS“. |
@@ -213,8 +228,27 @@ sowie optional `P_Image_Path`. `Cert_field` wird zusätzlich an
   und Status­symbol ausgegeben.
 * **SQL-Grundlage:** Liest direkt aus `$P!{PrefixTable}results` und reduziert
   alle Felder per `COALESCE(...)` auf Strings. Filter: `WHERE ctag = $P{P_CTAG}`.
+* **Woher Sollwert und Messwert kommen:** Beide stehen je nach Erfassungsweg in
+  einem von zwei Spaltenpaaren — `fixq`/`varq` (Sollwert des Prüfschritts und
+  Ablesung) oder `sys_actual`/`uut_ind` (Wert des Normals und Anzeige des
+  Prüflings). MET/CAL liefert beide Paare; die calServer-Messwertaufnahme füllt
+  `sys_actual`/`uut_ind` nur für numerische Schritte mit gesetztem `tol_ref`.
+  Jede Layout-Variante band früher genau ein Paar und druckte eine leere Spalte,
+  wenn der Wert im anderen stand — sichtbar als Ergebnistabelle ohne Zahlen bei
+  ungesetztem `MeasurementDetails`. Heute greifen die Variablen `FixqValue` /
+  `SysActualValue` / `VarqValue` / `UutIndValue` auf die Schwesterspalte zurück,
+  wenn die eigene leer ist; Präfix und Einheit folgen der Spalte, aus der der
+  Wert stammt. **Sind beide Paare gefüllt, druckt jede Variante unverändert das
+  Paar, das sie schon immer gedruckt hat.**
+* **Messbedingungen (`test_desc`):** Die erste Spalte trägt die Bezeichnung des
+  Prüfschritts aus der Prozedur. Wer sie sprechend haben will („Kanal 1,
+  Anzeigeabweichung bei 15 °C“), pflegt sie in der Prozedur — der Bericht
+  formatiert sie nur.
 * **Besonderheiten:**
   * `NominalValue` und `MeasuredValue` kombinieren Wert, Prüfschritt und Einheit.
+  * Variante `1` druckt den Sollwert in der Spalte `Sollwert / True Value`, die
+    ihr Tabellenkopf seit jeher ausweist; bis dahin war die Spalte in beiden
+    Kopfstilen ohne Datenzelle und damit immer leer.
   * `ToleranceRange` entscheidet automatisch zwischen ±-Anzeige und
     Min/Max-Spalten.
   * `RoundedTolErr` rundet auf eine Nachkommastelle und hängt `%` an.

--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -107,15 +107,72 @@
     || !$P{ModernResultsHeader}.toString().trim().equalsIgnoreCase("N")
 )]]></variableExpression>
 	</variable>
+	<!--
+	    Sollwert und Messwert stehen je nach Erfassungsweg in einem von zwei
+	    Spaltenpaaren: `fixq`/`varq` (Sollwert des Prüfschritts und Ablesung)
+	    oder `sys_actual`/`uut_ind` (Wert des Normals und Anzeige des
+	    Prüflings). MET/CAL liefert beide Paare; die V2-Messwertaufnahme füllt
+	    `sys_actual`/`uut_ind` nur für numerische Schritte mit gesetztem
+	    `tol_ref` und lässt sie sonst leer.
+
+	    Jede Layout-Variante band bisher genau ein Paar. Stand der Wert im
+	    anderen, blieb die Spalte leer, obwohl die Zeile ihn trug — genau der
+	    Fall, in dem der Schein ohne gesetzten Parameter `MeasurementDetails`
+	    eine leere Ergebnistabelle druckte. Die folgenden Variablen greifen auf
+	    die Schwesterspalte zurück, wenn die eigene leer ist; Präfix und
+	    Einheit folgen dabei der Spalte, aus der der Wert stammt. Sind beide
+	    Paare gefüllt — der MET/CAL-Fall —, druckt jede Variante unverändert
+	    das Paar, das sie schon immer gedruckt hat.
+	-->
+	<variable name="FixqValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+      ? $F{fixq}
+      : ($F{sys_actual} == null ? "" : $F{sys_actual})]]></variableExpression>
+	</variable>
+	<variable name="FixqPrefix" class="java.lang.String">
+		<variableExpression><![CDATA[($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+      ? ($F{fixq_p} == null ? "" : $F{fixq_p})
+      : ($F{sys_actual_p} == null ? "" : $F{sys_actual_p})]]></variableExpression>
+	</variable>
+	<variable name="FixqUnit" class="java.lang.String">
+		<variableExpression><![CDATA[($F{fixq} != null && !$F{fixq}.trim().isEmpty())
+      ? ($F{fixq_u} == null ? "" : $F{fixq_u})
+      : ($F{sys_actual_u} == null ? "" : $F{sys_actual_u})]]></variableExpression>
+	</variable>
+	<variable name="SysActualValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{sys_actual} != null && !$F{sys_actual}.trim().isEmpty())
+      ? $F{sys_actual}
+      : ($F{fixq} == null ? "" : $F{fixq})]]></variableExpression>
+	</variable>
+	<variable name="SysActualPrefix" class="java.lang.String">
+		<variableExpression><![CDATA[($F{sys_actual} != null && !$F{sys_actual}.trim().isEmpty())
+      ? ($F{sys_actual_p} == null ? "" : $F{sys_actual_p})
+      : ($F{fixq_p} == null ? "" : $F{fixq_p})]]></variableExpression>
+	</variable>
+	<variable name="SysActualUnit" class="java.lang.String">
+		<variableExpression><![CDATA[($F{sys_actual} != null && !$F{sys_actual}.trim().isEmpty())
+      ? ($F{sys_actual_u} == null ? "" : $F{sys_actual_u})
+      : ($F{fixq_u} == null ? "" : $F{fixq_u})]]></variableExpression>
+	</variable>
+	<variable name="VarqValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{varq} != null && !$F{varq}.trim().isEmpty())
+      ? $F{varq}
+      : ($F{uut_ind} == null ? "" : $F{uut_ind})]]></variableExpression>
+	</variable>
+	<variable name="UutIndValue" class="java.lang.String">
+		<variableExpression><![CDATA[($F{uut_ind} != null && !$F{uut_ind}.trim().isEmpty())
+      ? $F{uut_ind}
+      : ($F{varq} == null ? "" : $F{varq})]]></variableExpression>
+	</variable>
 	<variable name="NominalValue" class="java.lang.String">
-		<variableExpression><![CDATA[$F{fixq}==null || $F{fixq}.trim().isEmpty()
+		<variableExpression><![CDATA[$V{FixqValue}==null || $V{FixqValue}.trim().isEmpty()
       ? ""
-      : $F{fixq}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
+      : $V{FixqValue}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
 	</variable>
 	<variable name="MeasuredValue" class="java.lang.String">
-		<variableExpression><![CDATA[$F{varq}==null || $F{varq}.trim().isEmpty()
+		<variableExpression><![CDATA[$V{VarqValue}==null || $V{VarqValue}.trim().isEmpty()
       ? ""
-      : $F{varq}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
+      : $V{VarqValue}.trim().replaceAll("(?i)ohm","Ω")]]></variableExpression>
 	</variable>
 	<variable name="PosLimit" class="java.lang.String">
 		<variableExpression><![CDATA[($F{upper_limit} == null || $F{upper_limit}.trim().isEmpty()
@@ -163,10 +220,10 @@
  ? ""
  : (
      (
-       $F{fixq} != null
-       && !$F{fixq}.trim().isEmpty()
-       && $F{fixq}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", ".").matches("[+-]?\\d+(\\.\\d+)?([eE][+-]?\\d+)?")
-       && Math.abs(Double.parseDouble($F{fixq}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", "."))) < 1e-9
+       $V{FixqValue} != null
+       && !$V{FixqValue}.trim().isEmpty()
+       && $V{FixqValue}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", ".").matches("[+-]?\\d+(\\.\\d+)?([eE][+-]?\\d+)?")
+       && Math.abs(Double.parseDouble($V{FixqValue}.replaceAll("[^0-9\\.,\\-+eE]", "").replace(",", "."))) < 1e-9
      )
      ? "--"
      : (
@@ -2423,6 +2480,17 @@
               : ""]]></textFieldExpression>
 				</textField>
 				<textField isBlankWhenNull="true">
+					<reportElement x="70" y="0" width="54" height="14" uuid="3a0f6c21-7d54-4b8e-9a2f-6c1b0e4d8f37"/>
+					<textElement textAlignment="Right" verticalAlignment="Bottom">
+						<font fontName="DejaVu Sans" size="8"/>
+					</textElement>
+					<textFieldExpression><![CDATA[(
+              $V{FixqValue} == null || $V{FixqValue}.trim().isEmpty()
+            ? ""
+            : $V{FixqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+            )]]></textFieldExpression>
+				</textField>
+				<textField isBlankWhenNull="true">
 					<reportElement x="124" y="0" width="54" height="14" uuid="8fac207f-71ce-479d-aedf-4db886a10327"/>
 					<textElement textAlignment="Right" verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
@@ -2439,9 +2507,9 @@
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{varq} == null || $F{varq}.trim().isEmpty()
+              $V{VarqValue} == null || $V{VarqValue}.trim().isEmpty()
             ? ""
-            : $F{varq}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+            : $V{VarqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
 				</textField>
 				<textField isBlankWhenNull="true">
@@ -2515,21 +2583,21 @@
 					</textElement>
                                         <textFieldExpression><![CDATA[(
               (
-                $F{fixq} == null || $F{fixq}.trim().isEmpty()
+                $V{FixqValue} == null || $V{FixqValue}.trim().isEmpty()
                   ? ""
-                  : $F{fixq}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
+                  : $V{FixqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
               )
-            + ($F{fixq_p} == null || $F{fixq_p}.trim().isEmpty() ? "" : " " + $F{fixq_p}.trim())
+            + ($V{FixqPrefix} == null || $V{FixqPrefix}.trim().isEmpty() ? "" : " " + $V{FixqPrefix}.trim())
             + (
                 (
-                  $F{fixq} != null
-                    && !$F{fixq}.trim().isEmpty()
-                    && $F{fixq}.trim().matches(".*\\p{L}.*")
+                  $V{FixqValue} != null
+                    && !$V{FixqValue}.trim().isEmpty()
+                    && $V{FixqValue}.trim().matches(".*\\p{L}.*")
                 )
-                || $F{fixq_u} == null
-                || $F{fixq_u}.trim().isEmpty()
+                || $V{FixqUnit} == null
+                || $V{FixqUnit}.trim().isEmpty()
                   ? ""
-                  : " " + $F{fixq_u}.trim()
+                  : " " + $V{FixqUnit}.trim()
               )
             ).trim().replaceAll("(?i)ohm","Ω")]]></textFieldExpression>
 				</textField>
@@ -2564,9 +2632,9 @@
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{varq} == null || $F{varq}.trim().isEmpty()
+              $V{VarqValue} == null || $V{VarqValue}.trim().isEmpty()
             ? ""
-            : $F{varq}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+            : $V{VarqValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
 				</textField>
 				<textField isBlankWhenNull="true">
@@ -2666,21 +2734,21 @@
 					</textElement>
                                         <textFieldExpression><![CDATA[(
               (
-                $F{sys_actual} == null || $F{sys_actual}.trim().isEmpty()
+                $V{SysActualValue} == null || $V{SysActualValue}.trim().isEmpty()
                   ? ""
-                  : $F{sys_actual}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
+                  : $V{SysActualValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
               )
-            + ($F{sys_actual_p} == null || $F{sys_actual_p}.trim().isEmpty() ? "" : " " + $F{sys_actual_p}.trim())
+            + ($V{SysActualPrefix} == null || $V{SysActualPrefix}.trim().isEmpty() ? "" : " " + $V{SysActualPrefix}.trim())
             + (
                 (
-                  $F{sys_actual} != null
-                    && !$F{sys_actual}.trim().isEmpty()
-                    && $F{sys_actual}.trim().matches(".*\\p{L}.*")
+                  $V{SysActualValue} != null
+                    && !$V{SysActualValue}.trim().isEmpty()
+                    && $V{SysActualValue}.trim().matches(".*\\p{L}.*")
                 )
-                || $F{sys_actual_u} == null
-                || $F{sys_actual_u}.trim().isEmpty()
+                || $V{SysActualUnit} == null
+                || $V{SysActualUnit}.trim().isEmpty()
                   ? ""
-                  : " " + $F{sys_actual_u}.trim()
+                  : " " + $V{SysActualUnit}.trim()
               )
             ).trim().replaceAll("(?i)ohm","Ω")]]></textFieldExpression>
 				</textField>
@@ -2715,9 +2783,9 @@
                                                 <font fontName="DejaVu Sans" size="8"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{uut_ind} == null || $F{uut_ind}.trim().isEmpty()
+              $V{UutIndValue} == null || $V{UutIndValue}.trim().isEmpty()
                 ? ""
-                : $F{uut_ind}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+                : $V{UutIndValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
                                 </textField>
                                 <textField isBlankWhenNull="true">
@@ -2817,21 +2885,21 @@
 					</textElement>
                                         <textFieldExpression><![CDATA[(
               (
-                $F{sys_actual} == null || $F{sys_actual}.trim().isEmpty()
+                $V{SysActualValue} == null || $V{SysActualValue}.trim().isEmpty()
                   ? ""
-                  : $F{sys_actual}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
+                  : $V{SysActualValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".")
               )
-            + ($F{sys_actual_p} == null || $F{sys_actual_p}.trim().isEmpty() ? "" : " " + $F{sys_actual_p}.trim())
+            + ($V{SysActualPrefix} == null || $V{SysActualPrefix}.trim().isEmpty() ? "" : " " + $V{SysActualPrefix}.trim())
             + (
                 (
-                  $F{sys_actual} != null
-                    && !$F{sys_actual}.trim().isEmpty()
-                    && $F{sys_actual}.trim().matches(".*\\p{L}.*")
+                  $V{SysActualValue} != null
+                    && !$V{SysActualValue}.trim().isEmpty()
+                    && $V{SysActualValue}.trim().matches(".*\\p{L}.*")
                 )
-                || $F{sys_actual_u} == null
-                || $F{sys_actual_u}.trim().isEmpty()
+                || $V{SysActualUnit} == null
+                || $V{SysActualUnit}.trim().isEmpty()
                   ? ""
-                  : " " + $F{sys_actual_u}.trim()
+                  : " " + $V{SysActualUnit}.trim()
               )
             ).trim().replaceAll("(?i)ohm","Ω")]]></textFieldExpression>
 				</textField>
@@ -2841,9 +2909,9 @@
                                                 <font fontName="DejaVu Sans" size="8"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[(
-              $F{uut_ind} == null || $F{uut_ind}.trim().isEmpty()
+              $V{UutIndValue} == null || $V{UutIndValue}.trim().isEmpty()
                 ? ""
-                : $F{uut_ind}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
+                : $V{UutIndValue}.trim().replaceAll("(?<=\\d),(?=\\d)", ".").replaceAll("(?i)ohm","Ω")
             )]]></textFieldExpression>
                                 </textField>
 				<textField>


### PR DESCRIPTION
## Problem

Auf einem in calServer erfassten DAkkS-Schein blieb die Ergebnistabelle in der Standardauslieferung leer: Messbedingung und Messunsicherheit standen da, Sollwert und Messwert nicht. Der Ausdruck sah aus wie ein Bericht ohne Daten, obwohl die `results`-Zeilen die Werte trugen.

Zwei unabhängige Ursachen im `Results`-Subreport:

**1. Zwei gleichwertige Spaltenpaare, je Variante nur eines gebunden.**
Sollwert und Messwert stehen je nach Erfassungsweg in `fixq`/`varq` (Sollwert des Prüfschritts und Ablesung) oder in `sys_actual`/`uut_ind` (Wert des Normals und Anzeige des Prüflings). MET/CAL liefert beide Paare; die calServer-Messwertaufnahme (`ResultCalculator`) füllt `sys_actual`/`uut_ind` nur für numerische Schritte mit gesetztem `tol_ref`. Jede `MeasurementDetails`-Variante band genau ein Paar — stand der Wert im anderen, druckte sie eine leere Zelle. Für die Varianten `21`/`22` traf das jede Zeile ohne `tol_ref`.

**2. Variante `1` versprach eine Spalte, die es nicht gab.**
Ihr Tabellenkopf weist seit jeher „Sollwert / True Value" bei `x=70` aus, in beiden Kopfstilen. Im Detailband stand an dieser Stelle kein Textfeld. Die Spalte war nicht manchmal leer, sondern immer.

## Lösung

**Rückfall auf die Schwesterspalte, kein Tausch.** Vier neue Variablen (`FixqValue`/`SysActualValue`/`VarqValue`/`UutIndValue`) lesen die jeweils andere Spalte, wenn die eigene leer ist; Präfix und Einheit folgen der Spalte, aus der der Wert stammt. Sind beide Paare gefüllt — der MET/CAL-Fall —, druckt jede Variante unverändert das Paar, das sie schon immer gedruckt hat. `MeasurementDetails` entscheidet damit wieder über das Layout und nicht mehr darüber, ob überhaupt Zahlen erscheinen.

Bewusst *nicht* im Report-Contract vereinheitlicht: `fixq` und `sys_actual` sind nicht dasselbe Feld, und genau diese Unterscheidung ist der Grund, warum es die Varianten `2`/`22` und `21` gibt.

**Variante `1` bekommt die Zelle, die ihr Kopf ausweist.** Kein neuer Kopf, keine verschobene Geometrie — das Textfeld sitzt in der Lücke, die seit jeher frei stand.

## Hinweise in den Parametern

Dazu Tipps, wo die beschreibenden Felder gepflegt gehören (`parameters.json` + beide READMEs):

- **Messbedingungen-Spalte** ist `test_desc`, die Bezeichnung des Prüfschritts aus der Prozedur — sprechende Messbedingungen entstehen dort, nicht im Bericht.
- **Verfahren, Verfahrensanweisung, Messbedingungen, Geltungsbereich** kommen aus der Prozedur; die `Calibration_*`-Bausteine sind nur Fallbacks. Damit der Bericht die Prozedur findet, muss `procedure_field` auf das Kalibrierfeld mit dem Prozedurnamen zeigen (V1: `C2320`).
- **Temperatur und Feuchte** kommen aus dem Feld „Umgebungsbedingungen" der Ressource, die `environmental_conditions` benennt — ein Text mit `|` als Trenner, jede Hälfte mit eigenem Rückfall auf die an der Kalibrierung erfassten Werte (`C2311`/`C2312`).

## Verifikation

Der Subreport wurde mit JasperReports 6.20.6 über vier Datensätze gerendert, jeweils vor und nach der Änderung:

| Datensatz | Variante 21 vorher | Variante 21 nachher |
|---|---|---|
| nur `fixq`/`varq` (V2-Erfassung ohne `tol_ref`) | Sollwert leer, Messwert leer | `10.00000 V` / `10.00004` |
| ausgeliefertes Sample | Sollwert leer, Messwert `10.00004` | `10.00000 V` / `10.00004` |
| nur `sys_actual`/`uut_ind` | unverändert korrekt | unverändert korrekt |

Regressionslauf mit **beiden** Paaren gefüllt (paarweise verschiedene Werte): Varianten `2`, `21`, `22`, `3`, `4` byte-identisch zu vorher; Variante `1` unterscheidet sich genau um die neue Sollwert-Spalte.

Repo-Checks: `check_jasper_version.sh`, `check_parameters_manifest.py`, `build_dakks_json_clone.py --check`, `build_pruefplan_manifest.py --check`, `build_wiki_manifest.py --check`, `build_config_manifest.py --check`, `build_ticket_config_3d.py --check` — alle grün.

## Hinweise für Reviewer

- `DAKKS-JSON-SAMPLE` ist mechanisch aus `DAKKS-SAMPLE` neu abgeleitet (`scripts/build_dakks_json_clone.py --write`), die Parität bleibt geprüft. Nur `subreports/Results.jrxml` hat sich geändert; Haupt- und `Standard`-Report sind byte-identisch geblieben.
- Sichtbare Änderung an einem Dokument, das Kunden schon in der Hand hatten: Nachdrucke zeigen jetzt Zahlen, wo bisher eine leere Zelle stand. Wer das nicht will, druckt nicht neu.
- Zugehörige Backend-Änderung (`rel_err` wird erstmals berechnet) und die Entscheidungsdokumentation stehen in `calhelp/calServer-yii`, gleicher Branch-Name.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zKi6hWcAzvPFwNwHQtXVH)_