### PR TITLE
Fensterbriefe halten die Freizone von Briefpapier ein

### DIFF
--- a/DELIVERY-JSON-SAMPLE/README.md
+++ b/DELIVERY-JSON-SAMPLE/README.md
@@ -28,12 +28,38 @@ Fensterbrief nach DIN 5008 Form B, Anschriftfeld 20 mm von links und 45 mm von
 oben (85 × 45 mm), Informationsblock ab 125 mm, Betreffzeile bei 98,4 mm,
 Falz- und Lochmarken bei 105 / 148,5 / 210 mm — abschaltbar über die
 Berichtsvariable `show_fold_marks` (Parameter `Show_fold_marks`, Default `1`).
+Im Titelband liegt das Anschriftfeld bei `x=37 y=52 241×128`, der
+Informationsblock bei `x=297 y=66`, die Betreffzeile bei `y=203`; alle
+Bandkoordinaten liegen hinter `topMargin=76`, auf dem Blatt also bei `76 + y`.
+Für DIN 676 Form A (Anschriftfeld ab 27 mm) wird `y=52` zu `y=0`.
 
 Im Anschriftfeld steht die **Lieferadresse** samt Ansprechpartner; die
 Landzeile druckt nur bei einem Land abweichend vom Absenderland. Die
 Rücksendeangabe kommt aus `supplier.sender_line` bzw. der Absenderanschrift,
 also aus den `company_*`-Berichtsvariablen — dieselben, die Auftragsbeleg,
 Leihschein und Versandschein nutzen.
+
+### Freizone für vorgedrucktes Briefpapier
+
+calServer legt die Bogenvorlage unter den Beleg (Berichtseinstellung
+`use_template` = `pdf` oder `html`; Seite 1 der Vorlage auf Belegseite 1,
+Seite 2 auf jede Folgeseite). Damit nichts in Kopf, Fuß oder Seitenrand des
+Bogens läuft, hält der Beleg feste Grenzen ein:
+
+| Zone | Grenze | Woher |
+|---|---|---|
+| Satzspiegel links | 20 mm (57 pt) | `leftMargin=20` + Inhalt ab `x=37` |
+| Satzspiegel rechts | 195 mm (553 pt) | `rightMargin=42`, `columnWidth=533` |
+| Oberkante Folgeseiten | 26,8 mm (76 pt) | `topMargin=76` |
+| Oberkante Seite 1 | 45 mm (128 pt), Anschriftfeld | Titelband |
+| Unterkante Inhalt | 249 mm (706 pt) | `bottomMargin=136` |
+
+Die 20 mm links sind der Rand, den vorgedrucktes Briefpapier üblicherweise für
+seine Kopf- und Fußlinien benutzt — Tabelle und Trennlinien stehen damit bündig
+unter dem Bogen statt daneben. Trägt der Bogen die Falz- und Lochmarken schon
+selbst, schaltet `show_fold_marks = 0` die eigenen ab. Ein Bogen mit höherem
+Kopf oder Fuß braucht andere Ränder: das sind die vier Zahlen im
+`<jasperReport>`-Element, sonst nichts.
 
 ## ⚠️ Leeres Blatt = fehlende Datenquelle
 

--- a/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
+++ b/DELIVERY-JSON-SAMPLE/main_reports/delivery-json-sample.jrxml
@@ -10,12 +10,18 @@
 
   Geometrie wie beim Auftragsbeleg (ORDER-JSON-SAMPLE): Fensterbrief nach
   DIN 5008 Form B, Anschriftfeld 20 mm von links, 45 mm von oben, 85 x 45 mm
-  (im Titelband x=40, y=116, 241 x 128 pt), Informationsblock ab 125 mm,
+  (im Titelband x=37, y=52, 241 x 128 pt), Informationsblock ab 125 mm,
   Betreffzeile bei 98,4 mm, Falz- und Lochmarken im Hintergrundband
   (abschaltbar ueber Show_fold_marks). Der Absender kommt aus dem
   supplier-Block des Datensatzes, also aus den company_*-Berichtsvariablen.
+
+  Briefpapierfest: Die Seitenraender halten die Freizone eines vorgedruckten
+  Bogens frei, den calServer per ReportOverlayService unter den Beleg legt.
+  leftMargin=20 / rightMargin=42 / topMargin=76 / bottomMargin=136, Inhalt ab
+  x=37 (20 mm) bis 533 (195 mm), Folgeseiten ab 26,8 mm, Inhalt bis 249 mm.
+  Wer auf Form A umstellt, aendert eine Zahl: y=52 wird zu y=0.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="d7ddf600-0310-4d70-9f60-000000000310">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="533" leftMargin="20" rightMargin="42" topMargin="76" bottomMargin="136" uuid="d7ddf600-0310-4d70-9f60-000000000310">
 	<property name="com.jaspersoft.studio.data.defadapter" value="delivery-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
@@ -56,21 +62,21 @@
 	  Sie gehören auf jede Seite, deshalb ins Hintergrundband.
 	-->
 	<background>
-		<band height="818">
+		<band height="630">
 			<line>
-				<reportElement x="0" y="286" width="8" height="1">
+				<reportElement x="0" y="222" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="409" width="14" height="1">
+				<reportElement x="0" y="345" width="14" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="583" width="8" height="1">
+				<reportElement x="0" y="519" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
@@ -78,10 +84,10 @@
 		</band>
 	</background>
 	<title>
-		<band height="332">
+		<band height="268">
 			<!-- Anschriftfeld (DIN 676 Form B): der Frame IST das Feld, 85 x 45 mm an 20/45 mm. -->
 			<frame>
-				<reportElement x="40" y="116" width="241" height="128"/>
+				<reportElement x="37" y="52" width="241" height="128"/>
 				<textField isBlankWhenNull="true">
 					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
 					<textFieldExpression><![CDATA[($F{sup_sender_line} != null && !$F{sup_sender_line}.trim().isEmpty())
@@ -113,29 +119,29 @@
 			</frame>
 			<!-- Informationsblock rechts (DIN 5008: ab 125 mm), auf Höhe des Anschriftfelds -->
 			<frame>
-				<reportElement x="337" y="116" width="224" height="65"/>
-				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Liefernummer]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Datum]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="26" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="39" width="104" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{del_contact} == null || !$F{del_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="39" width="120" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{del_contact} == null || !$F{del_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
+				<reportElement x="297" y="66" width="236" height="65"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="95" height="12"/><text><![CDATA[Liefernummer]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="0" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="95" height="12"/><text><![CDATA[Datum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="13" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="95" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="26" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="39" width="95" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{del_contact} == null || !$F{del_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="39" width="141" height="12"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{del_contact} == null || !$F{del_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
 			</frame>
 			<!-- Betreffzeile (DIN 5008: 98,4 mm ab Seitenoberkante) -->
-			<textField><reportElement x="12" y="267" width="549" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA["Lieferschein " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="12" y="288" width="549" height="13" isRemoveLineWhenBlank="true"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
-			<line><reportElement positionType="Float" x="12" y="310" width="549" height="1"/></line>
-			<staticText><reportElement style="Label" positionType="Float" x="12" y="314" width="40" height="14"/><text><![CDATA[Pos]]></text></staticText>
-			<staticText><reportElement style="Label" positionType="Float" x="52" y="314" width="419" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
-			<staticText><reportElement style="Label" positionType="Float" x="471" y="314" width="90" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+			<textField><reportElement x="37" y="203" width="496" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA["Lieferschein " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="37" y="224" width="496" height="13" isRemoveLineWhenBlank="true"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
+			<line><reportElement positionType="Float" x="37" y="246" width="496" height="1"/></line>
+			<staticText><reportElement style="Label" positionType="Float" x="37" y="250" width="36" height="14"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="73" y="250" width="379" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="452" y="250" width="81" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
 		</band>
 	</title>
 	<detail>
 		<band height="30">
 			<subreport>
-				<reportElement positionType="Float" x="12" y="0" width="549" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="37" y="0" width="496" height="14" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/positions-delivery.jasper"]]></subreportExpression>
 			</subreport>
@@ -143,10 +149,10 @@
 	</detail>
 	<pageFooter>
 		<band height="58">
-			<staticText><reportElement positionType="Float" x="12" y="16" width="549" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Ware vollständig und unbeschädigt erhalten:]]></text></staticText>
-			<line><reportElement positionType="Float" x="12" y="30" width="240" height="1"/></line>
-			<staticText><reportElement positionType="Float" x="12" y="32" width="240" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift]]></text></staticText>
-			<textField isBlankWhenNull="true"><reportElement positionType="Float" x="12" y="46" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<staticText><reportElement positionType="Float" x="37" y="16" width="496" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Ware vollständig und unbeschädigt erhalten:]]></text></staticText>
+			<line><reportElement positionType="Float" x="37" y="30" width="217" height="1"/></line>
+			<staticText><reportElement positionType="Float" x="37" y="32" width="217" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum, Unterschrift]]></text></staticText>
+			<textField isBlankWhenNull="true"><reportElement positionType="Float" x="37" y="46" width="496" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/DELIVERY-JSON-SAMPLE/subreports/positions-delivery.jrxml
+++ b/DELIVERY-JSON-SAMPLE/subreports/positions-delivery.jrxml
@@ -5,7 +5,7 @@
   "positions" array via subDataSource("positions"). Delivery-note variant — only
   position, description and quantity, no prices/tax. No $V{} variables.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0311-4d71-9f61-000000000311">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="496" pageHeight="842" columnWidth="496" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0311-4d71-9f61-000000000311">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<field name="pos_number" class="java.lang.Integer"><fieldDescription><![CDATA[pos_number]]></fieldDescription></field>
 	<field name="name" class="java.lang.String"><fieldDescription><![CDATA[name]]></fieldDescription></field>
@@ -13,10 +13,10 @@
 	<field name="unit" class="java.lang.String"><fieldDescription><![CDATA[unit]]></fieldDescription></field>
 	<detail>
 		<band height="15">
-			<textField><reportElement x="0" y="0" width="40" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight"><reportElement x="40" y="0" width="419" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##"><reportElement x="459" y="0" width="60" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
-			<textField><reportElement x="521" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="0" width="36" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement x="36" y="0" width="379" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##"><reportElement x="415" y="0" width="54" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField><reportElement x="471" y="0" width="25" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/FREE-DELIVERY-JSON-SAMPLE/README.md
+++ b/FREE-DELIVERY-JSON-SAMPLE/README.md
@@ -58,9 +58,32 @@ Anschriftzone        untere 27,3 mm (Lieferanschrift)
 Betreffzeile         98,4 mm von oben
 ```
 
-Umgerechnet (1 mm = 2,8346 pt, Seitenränder links 17 pt / oben 12 pt) liegt das
-Anschriftfeld im Titelband bei `x=40, y=116, 241 × 128 pt` — **ein** Frame. Für
-DIN 676 Form A (kurzer Briefkopf) wird `y=116` zu `y=64`, sonst nichts.
+Umgerechnet (1 mm = 2,8346 pt, Seitenränder links 20 pt / oben 76 pt) liegt das
+Anschriftfeld im Titelband bei `x=37, y=52, 241 × 128 pt` — **ein** Frame; der
+Informationsblock steht bei `x=297, y=66`, die Betreffzeile bei `y=203`. Für
+DIN 676 Form A (kurzer Briefkopf) wird `y=52` zu `y=0`, sonst nichts.
+
+### Freizone für vorgedrucktes Briefpapier
+
+calServer legt die Bogenvorlage unter den Beleg (Berichtseinstellung
+`use_template` = `pdf` oder `html`; Seite 1 der Vorlage auf Belegseite 1,
+Seite 2 auf jede Folgeseite). Damit nichts in Kopf, Fuß oder Seitenrand des
+Bogens läuft, hält der Beleg feste Grenzen ein:
+
+| Zone | Grenze | Woher |
+|---|---|---|
+| Satzspiegel links | 20 mm (57 pt) | `leftMargin=20` + Inhalt ab `x=37` |
+| Satzspiegel rechts | 195 mm (553 pt) | `rightMargin=42`, `columnWidth=533` |
+| Oberkante Folgeseiten | 26,8 mm (76 pt) | `topMargin=76` |
+| Oberkante Seite 1 | 45 mm (128 pt), Anschriftfeld | Titelband |
+| Unterkante Inhalt | 249 mm (706 pt) | `bottomMargin=136` |
+
+Die 20 mm links sind der Rand, den vorgedrucktes Briefpapier üblicherweise für
+seine Kopf- und Fußlinien benutzt — Tabelle und Trennlinien stehen damit bündig
+unter dem Bogen statt daneben. Trägt der Bogen die Falz- und Lochmarken schon
+selbst, schaltet `show_fold_marks = 0` die eigenen ab. Ein Bogen mit höherem
+Kopf oder Fuß braucht andere Ränder: das sind die vier Zahlen im
+`<jasperReport>`-Element, sonst nichts.
 
 ## ⚠️ Leeres Blatt = fehlende Datenquelle
 

--- a/FREE-DELIVERY-JSON-SAMPLE/main_reports/free-delivery-json-sample.jrxml
+++ b/FREE-DELIVERY-JSON-SAMPLE/main_reports/free-delivery-json-sample.jrxml
@@ -11,9 +11,16 @@
 
   Geometrie wie beim Leihschein (LOCATION-JSON-SAMPLE): Fensterbrief nach
   DIN 5008 Form B, Anschriftfeld 20 mm von links, 45 mm von oben, 85 × 45 mm
-  (im Titelband x=40, y=116, 241 × 128 pt), Betreffzeile bei 98,4 mm. Ein
+  (im Titelband x=37, y=52, 241 × 128 pt), Betreffzeile bei 98,4 mm. Ein
   DIN-lang-Umschlag nach DIN 680 zeigt damit genau die Anschrift. Wer auf
-  Form A umstellt, ändert eine Zahl: y=116 wird zu y=64.
+  Form A umstellt, ändert eine Zahl: y=52 wird zu y=0.
+
+  Briefpapierfest: Die Seitenraender halten die Freizone eines vorgedruckten
+  Bogens frei, den calServer per ReportOverlayService unter den Beleg legt.
+  leftMargin=20 / rightMargin=42 / topMargin=76 / bottomMargin=136, Inhalt ab
+  x=37 (20 mm) bis 533 (195 mm), Folgeseiten ab 26,8 mm, Inhalt bis 249 mm.
+  Ein Bogen mit hoeherem Kopf oder Fuss braucht andere Raender — das sind diese
+  vier Zahlen, sonst nichts.
 
   Bewusst dieselbe Sprache wie der Leihschein: `devices[]` trägt exakt
   dieselben Schlüssel, deshalb ist der Unterbericht derselbe. Wer beide
@@ -24,7 +31,7 @@
   nutzen. Ohne gepflegte Variablen bleibt die Rücksendeangabe leer und der
   Umschlag trägt sie selbst. Siehe main_reports/sample-data.json.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="free-delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="c4aab700-0700-4e80-af70-000000000700">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="free-delivery-json-sample" pageWidth="595" pageHeight="842" columnWidth="533" leftMargin="20" rightMargin="42" topMargin="76" bottomMargin="136" uuid="c4aab700-0700-4e80-af70-000000000700">
 	<property name="com.jaspersoft.studio.data.defadapter" value="free-delivery-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
@@ -104,21 +111,21 @@
 	  Stapel), deshalb ins Hintergrundband.
 	-->
 	<background>
-		<band height="818">
+		<band height="630">
 			<line>
-				<reportElement x="0" y="286" width="8" height="1">
+				<reportElement x="0" y="222" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="409" width="14" height="1">
+				<reportElement x="0" y="345" width="14" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="583" width="8" height="1">
+				<reportElement x="0" y="519" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
@@ -126,10 +133,10 @@
 		</band>
 	</background>
 	<title>
-		<band height="364">
+		<band height="300">
 			<!-- Anschriftfeld (DIN 676 Form B): der Frame IST das Feld. -->
 			<frame>
-				<reportElement x="40" y="116" width="241" height="128"/>
+				<reportElement x="37" y="52" width="241" height="128"/>
 				<textField isBlankWhenNull="true">
 					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
 					<textFieldExpression><![CDATA[($P{Company_sender_line} != null && !$P{Company_sender_line}.trim().isEmpty())
@@ -170,30 +177,30 @@
 			  wahrscheinlichste Handlung.
 			-->
 			<frame>
-				<reportElement x="337" y="116" width="224" height="91"/>
-				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Lieferschein-Nr.]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Datum]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_date}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="26" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_customer_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="39" width="104" height="12"/><text><![CDATA[Ansprechpartner]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="39" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_name}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="52" width="104" height="12"/><text><![CDATA[Telefon]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="52" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_phone}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="65" width="104" height="12"/><text><![CDATA[E-Mail]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="65" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_email}]]></textFieldExpression></textField>
+				<reportElement x="297" y="66" width="236" height="91"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="95" height="12"/><text><![CDATA[Lieferschein-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="0" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="95" height="12"/><text><![CDATA[Datum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="13" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_date}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="95" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="26" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{document_customer_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="39" width="95" height="12"/><text><![CDATA[Ansprechpartner]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="39" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_name}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="52" width="95" height="12"/><text><![CDATA[Telefon]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="52" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_phone}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="65" width="95" height="12"/><text><![CDATA[E-Mail]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="65" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{sender_email}]]></textFieldExpression></textField>
 				<staticText>
-					<reportElement style="Label" x="0" y="78" width="104" height="12">
+					<reportElement style="Label" x="0" y="78" width="95" height="12">
 						<printWhenExpression><![CDATA[$F{tracking_number} != null && !$F{tracking_number}.trim().isEmpty()]]></printWhenExpression>
 					</reportElement>
 					<text><![CDATA[Sendungsnummer]]></text>
 				</staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="78" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tracking_number}]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="78" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tracking_number}]]></textFieldExpression></textField>
 			</frame>
 			<!-- Dokumenttitel (DIN 5008: Betreffzeile bei 98,4 mm ab Oberkante) -->
 			<textField>
-				<reportElement x="12" y="267" width="549" height="18"/>
+				<reportElement x="37" y="203" width="496" height="18"/>
 				<textElement><font size="13" isBold="true"/></textElement>
 				<textFieldExpression><![CDATA[$P{Document_title}]]></textFieldExpression>
 			</textField>
@@ -203,16 +210,16 @@
 			  Überschrift sieht aus wie ein Fehler im Druck.
 			-->
 			<textField isBlankWhenNull="true">
-				<reportElement style="Value" x="12" y="286" width="549" height="13" isRemoveLineWhenBlank="true"/>
+				<reportElement style="Value" x="37" y="222" width="496" height="13" isRemoveLineWhenBlank="true"/>
 				<textFieldExpression><![CDATA[$F{document_subject}]]></textFieldExpression>
 			</textField>
-			<staticText><reportElement style="SectionTitle" x="12" y="310" width="270" height="14"/><text><![CDATA[Empfänger]]></text></staticText>
+			<staticText><reportElement style="SectionTitle" x="37" y="246" width="244" height="14"/><text><![CDATA[Empfänger]]></text></staticText>
 			<textField>
-				<reportElement style="Value" x="12" y="326" width="270" height="13"/>
+				<reportElement style="Value" x="37" y="262" width="244" height="13"/>
 				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{document_customer_number} == null || $F{document_customer_number}.isEmpty()) ? "" : ("  (" + $F{document_customer_number} + ")"))]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement style="Small" x="12" y="339" width="270" height="12"/>
+				<reportElement style="Small" x="37" y="275" width="244" height="12"/>
 				<textFieldExpression><![CDATA[(($F{customer_street} == null ? "" : $F{customer_street} + ", ")
 	+ ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})).trim()]]></textFieldExpression>
 			</textField>
@@ -222,13 +229,13 @@
 			  die E-Mail des Lieferkontakts für die Rückfrage zur Sendung.
 			-->
 			<staticText>
-				<reportElement style="SectionTitle" x="291" y="310" width="270" height="14">
+				<reportElement style="SectionTitle" x="289" y="246" width="244" height="14">
 					<printWhenExpression><![CDATA[$F{delivery_email} != null && !$F{delivery_email}.trim().isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<text><![CDATA[Rückfragen zur Sendung]]></text>
 			</staticText>
 			<textField isBlankWhenNull="true">
-				<reportElement style="Value" x="291" y="326" width="270" height="13"/>
+				<reportElement style="Value" x="289" y="262" width="244" height="13"/>
 				<textFieldExpression><![CDATA[$F{delivery_email}]]></textFieldExpression>
 			</textField>
 		</band>
@@ -238,15 +245,15 @@
 			<!-- Hinweis zur Sendung. Kollabiert vollständig, wenn keiner gepflegt
 			     ist — alles darunter schwimmt (positionType Float). -->
 			<frame>
-				<reportElement x="12" y="0" width="549" height="30" isRemoveLineWhenBlank="true">
+				<reportElement x="37" y="0" width="496" height="30" isRemoveLineWhenBlank="true">
 					<printWhenExpression><![CDATA[$F{shipping_note} != null && !$F{shipping_note}.trim().isEmpty()]]></printWhenExpression>
 				</reportElement>
-				<staticText><reportElement style="Label" x="0" y="0" width="549" height="12"/><text><![CDATA[Hinweis zur Sendung]]></text></staticText>
-				<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="13" width="549" height="13"/><textFieldExpression><![CDATA[$F{shipping_note}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="0" width="496" height="12"/><text><![CDATA[Hinweis zur Sendung]]></text></staticText>
+				<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="13" width="496" height="13"/><textFieldExpression><![CDATA[$F{shipping_note}]]></textFieldExpression></textField>
 			</frame>
-			<staticText><reportElement style="SectionTitle" positionType="Float" x="12" y="36" width="300" height="14"/><text><![CDATA[Sendungsinhalt]]></text></staticText>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="37" y="36" width="271" height="14"/><text><![CDATA[Sendungsinhalt]]></text></staticText>
 			<textField>
-				<reportElement style="Small" positionType="Float" x="300" y="37" width="261" height="13"/>
+				<reportElement style="Small" positionType="Float" x="297" y="37" width="236" height="13"/>
 				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[($F{item_count} == null ? "" : ($F{item_count} + ($F{item_count}.intValue() == 1 ? " Position" : " Positionen")))]]></textFieldExpression>
 			</textField>
@@ -256,7 +263,7 @@
 			  dieselben Schlüssel.
 			-->
 			<subreport>
-				<reportElement positionType="Float" x="12" y="54" width="549" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="37" y="54" width="496" height="14" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("devices")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/devices.jasper"]]></subreportExpression>
 			</subreport>
@@ -266,23 +273,23 @@
 			  Quittung — nur verlangt das Papier sie nicht von jemandem, der
 			  nicht da ist.
 			-->
-			<line><reportElement positionType="Float" x="12" y="80" width="549" height="1"/></line>
+			<line><reportElement positionType="Float" x="37" y="80" width="496" height="1"/></line>
 			<rectangle>
-				<reportElement positionType="Float" x="12" y="88" width="9" height="9"/>
+				<reportElement positionType="Float" x="37" y="88" width="8" height="9"/>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</rectangle>
-			<staticText><reportElement style="Small" positionType="Float" x="26" y="87" width="280" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
-			<staticText><reportElement style="Label" positionType="Float" x="341" y="87" width="40" height="12"/><text><![CDATA[Datum]]></text></staticText>
-			<line><reportElement positionType="Float" x="381" y="98" width="180" height="1"/></line>
+			<staticText><reportElement style="Small" positionType="Float" x="50" y="87" width="253" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="334" y="87" width="36" height="12"/><text><![CDATA[Datum]]></text></staticText>
+			<line><reportElement positionType="Float" x="370" y="98" width="163" height="1"/></line>
 		</band>
 	</detail>
 	<pageFooter>
 		<band height="36">
-			<line><reportElement x="12" y="0" width="549" height="1"/></line>
-			<textField><reportElement x="12" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Document_title} + " · calServer V2"]]></textFieldExpression></textField>
-			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
-			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="12" y="18" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<line><reportElement x="37" y="0" width="496" height="1"/></line>
+			<textField><reportElement x="37" y="4" width="361" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Document_title} + " · calServer V2"]]></textFieldExpression></textField>
+			<textField><reportElement x="406" y="4" width="99" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="505" y="4" width="28" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="37" y="18" width="496" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/FREE-DELIVERY-JSON-SAMPLE/subreports/devices.jrxml
+++ b/FREE-DELIVERY-JSON-SAMPLE/subreports/devices.jrxml
@@ -20,7 +20,7 @@
   Die Reihenfolge ist die, in der der Anwender die Geräte eingesammelt hat —
   der Server sortiert sie nicht um.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="496" pageHeight="842" columnWidth="496" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Small" fontSize="8"/>
@@ -32,13 +32,13 @@
 	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
 	<columnHeader>
 		<band height="16">
-			<staticText><reportElement style="Label" x="12" y="0" width="22" height="13"/><text><![CDATA[Pos]]></text></staticText>
-			<staticText><reportElement style="Label" x="34" y="0" width="88" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
-			<staticText><reportElement style="Label" x="122" y="0" width="94" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
-			<staticText><reportElement style="Label" x="216" y="0" width="128" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
-			<staticText><reportElement style="Label" x="344" y="0" width="140" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
-			<staticText><reportElement style="Label" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><text><![CDATA[Nächste Kal.]]></text></staticText>
-			<line><reportElement x="0" y="14" width="549" height="1"/></line>
+			<staticText><reportElement style="Label" x="11" y="0" width="20" height="13"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" x="31" y="0" width="79" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="110" y="0" width="85" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="195" y="0" width="116" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<staticText><reportElement style="Label" x="311" y="0" width="126" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" x="437" y="0" width="59" height="13"/><textElement textAlignment="Right"/><text><![CDATA[Nächste Kal.]]></text></staticText>
+			<line><reportElement x="0" y="14" width="496" height="1"/></line>
 		</band>
 	</columnHeader>
 	<!--
@@ -52,17 +52,17 @@
 		<band height="16" splitType="Prevent">
 			<!-- Ankreuzfeld zum Abhaken der Position beim Packen bzw. Auspacken. -->
 			<rectangle>
-				<reportElement x="0" y="1" width="9" height="9"/>
+				<reportElement x="0" y="1" width="8" height="9"/>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</rectangle>
-			<textField><reportElement style="Small" x="12" y="0" width="22" height="13"/><textFieldExpression><![CDATA[String.valueOf($V{REPORT_COUNT})]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="34" y="0" width="88" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="122" y="0" width="94" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
-			<textField><reportElement style="Small" x="216" y="0" width="128" height="13"/><textFieldExpression><![CDATA[(($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})).trim()]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="344" y="0" width="140" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="11" y="0" width="20" height="13"/><textFieldExpression><![CDATA[String.valueOf($V{REPORT_COUNT})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="31" y="0" width="79" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="110" y="0" width="85" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="195" y="0" width="116" height="13"/><textFieldExpression><![CDATA[(($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})).trim()]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="311" y="0" width="126" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="437" y="0" width="59" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
 			<!-- Zeilentrenner: eine Abhakliste braucht die Führung fürs Auge. -->
-			<line><reportElement positionType="Float" x="0" y="14" width="549" height="1"/><graphicElement><pen lineWidth="0.25" lineColor="#BBBBBB"/></graphicElement></line>
+			<line><reportElement positionType="Float" x="0" y="14" width="496" height="1"/><graphicElement><pen lineWidth="0.25" lineColor="#BBBBBB"/></graphicElement></line>
 		</band>
 	</detail>
 </jasperReport>

--- a/LOCATION-JSON-SAMPLE/README.md
+++ b/LOCATION-JSON-SAMPLE/README.md
@@ -31,22 +31,47 @@ derselben Zeile genauso hochgeladen.
 
 | Element | Lage (ab Blattkante) | Im Titelband (pt) |
 |---------|----------------------|-------------------|
-| Anschriftfeld (Frame) | 20 mm links, 45 mm oben, 85 × 45 mm | `x=40 y=116 w=241 h=128` |
+| Anschriftfeld (Frame) | 20 mm links, 45 mm oben, 85 × 45 mm | `x=37 y=52 w=241 h=128` |
 | Rücksendeangabe | Zusatz-/Vermerkzone, 12 mm ab Feldoberkante | Frame-intern `y=34` |
 | Lieferanschrift | Anschriftzone, 17,7 mm ab Feldoberkante | Frame-intern `y=50` |
-| Betreffzeile | 98,4 mm oben | `y=267` |
+| Betreffzeile | 98,4 mm oben | `y=203` |
 | Falz-/Lochmarken | linker Rand bei 105 / 148,5 / 210 mm | Hintergrundband |
 
 Das passt in einen DIN-lang-Fensterumschlag nach DIN 680 (Fenster 20 mm von
 links, 15 mm von unten) bei Falzung auf 105 mm und 210 mm.
 
-**Form A statt Form B?** Wer einen kurzen Briefkopf hat und das Anschriftfeld
-schon ab 27 mm setzen will, ändert **eine** Zahl: `y="116"` am Frame
-`Anschriftfeld` wird zu `y="64"`. Deshalb steckt der ganze Block in einem Frame.
+Alle Bandkoordinaten liegen hinter `topMargin=76`: Bandzeile `y` steht auf dem
+Blatt bei `76 + y` Punkt.
 
-**Der linke 12-pt-Streifen ist frei.** Dort liegen die Falz- und Lochmarken; der
-Textkörper beginnt bei `x=12` (rund 10 mm ab Blattkante). Wer Elemente ergänzt,
+**Form A statt Form B?** Wer einen kurzen Briefkopf hat und das Anschriftfeld
+schon ab 27 mm setzen will, ändert **eine** Zahl: `y="52"` am Frame
+`Anschriftfeld` wird zu `y="0"`. Deshalb steckt der ganze Block in einem Frame.
+
+**Der linke 37-pt-Streifen ist frei.** Dort liegen die Falz- und Lochmarken; der
+Textkörper beginnt bei `x=37` (20 mm ab Blattkante). Wer Elemente ergänzt,
 setzt sie nicht auf `x=0`, sonst läuft die Lochmarke bei 148,5 mm hindurch.
+
+### Freizone für vorgedrucktes Briefpapier
+
+calServer legt die Bogenvorlage unter den Beleg (Berichtseinstellung
+`use_template` = `pdf` oder `html`; Seite 1 der Vorlage auf Belegseite 1,
+Seite 2 auf jede Folgeseite). Damit nichts in Kopf, Fuß oder Seitenrand des
+Bogens läuft, hält der Beleg feste Grenzen ein:
+
+| Zone | Grenze | Woher |
+|---|---|---|
+| Satzspiegel links | 20 mm (57 pt) | `leftMargin=20` + Inhalt ab `x=37` |
+| Satzspiegel rechts | 195 mm (553 pt) | `rightMargin=42`, `columnWidth=533` |
+| Oberkante Folgeseiten | 26,8 mm (76 pt) | `topMargin=76` |
+| Oberkante Seite 1 | 45 mm (128 pt), Anschriftfeld | Titelband |
+| Unterkante Inhalt | 249 mm (706 pt) | `bottomMargin=136` |
+
+Die 20 mm links sind der Rand, den vorgedrucktes Briefpapier üblicherweise für
+seine Kopf- und Fußlinien benutzt — Tabelle und Trennlinien stehen damit bündig
+unter dem Bogen statt daneben. Trägt der Bogen die Falz- und Lochmarken schon
+selbst, schaltet `show_fold_marks = 0` die eigenen ab. Ein Bogen mit höherem
+Kopf oder Fuß braucht andere Ränder: das sind die vier Zahlen im
+`<jasperReport>`-Element, sonst nichts.
 
 ## Aufbau
 

--- a/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
+++ b/LOCATION-JSON-SAMPLE/main_reports/location-json-sample.jrxml
@@ -19,10 +19,17 @@
     Anschriftzone        untere 27,3 mm (hier: die Lieferanschrift)
     Betreffzeile    98,4 mm von oben
 
-  Umgerechnet (1 mm = 2,8346 pt, Seitenränder links 17 pt / oben 12 pt) liegt das
-  Feld im Titelband bei x=40, y=116, 241 × 128 pt. Es steckt in EINEM Frame:
+  Umgerechnet (1 mm = 2,8346 pt, Seitenränder links 20 pt / oben 76 pt) liegt das
+  Feld im Titelband bei x=37, y=52, 241 × 128 pt. Es steckt in EINEM Frame:
   Wer auf Form A umstellen muss (Anschriftfeld ab 27 mm, kurzer Briefkopf),
-  ändert genau eine Zahl — y=116 wird zu y=64.
+  ändert genau eine Zahl — y=52 wird zu y=0.
+
+  Briefpapierfest: Die Seitenraender halten die Freizone eines vorgedruckten
+  Bogens frei, den calServer per ReportOverlayService unter den Beleg legt.
+  leftMargin=20 / rightMargin=42 / topMargin=76 / bottomMargin=136, Inhalt ab
+  x=37 (20 mm) bis 533 (195 mm), Folgeseiten ab 26,8 mm, Inhalt bis 249 mm.
+  Ein Bogen mit hoeherem Kopf oder Fuss braucht andere Raender — das sind diese
+  vier Zahlen, sonst nichts.
 
   Was NICHT drauf steht: die Standortfelder location_1..5. Auf einer Leihe sind
   das interne Platzierungsangaben, und eines davon ist auf vielen Anlagen als
@@ -37,7 +44,7 @@
   selbst. Alle Beschriftungen sind staticText (kein report-level $V{} → kein
   null-im-Titel-Risiko). Siehe main_reports/sample-data.json.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="location-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="e8eef700-0500-4e80-af70-000000000500">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="location-json-sample" pageWidth="595" pageHeight="842" columnWidth="533" leftMargin="20" rightMargin="42" topMargin="76" bottomMargin="136" uuid="e8eef700-0500-4e80-af70-000000000500">
 	<property name="com.jaspersoft.studio.data.defadapter" value="location-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
@@ -115,21 +122,21 @@
 	  105 mm / 148,5 mm / 210 mm ab Seitenoberkante; die Lochmarke ist länger.
 	-->
 	<background>
-		<band height="818">
+		<band height="630">
 			<line>
-				<reportElement x="0" y="286" width="8" height="1">
+				<reportElement x="0" y="222" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="409" width="14" height="1">
+				<reportElement x="0" y="345" width="14" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="583" width="8" height="1">
+				<reportElement x="0" y="519" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
@@ -137,7 +144,7 @@
 		</band>
 	</background>
 	<title>
-		<band height="364">
+		<band height="300">
 			<!--
 			  Anschriftfeld (DIN 676 Form B). Der Frame IST das Feld: 85 × 45 mm
 			  an 20/45 mm. Innen liegt die Rücksendeangabe in der Zusatz- und
@@ -145,7 +152,7 @@
 			  der Anschriftzone (17,7 mm = 50 pt ab Feldoberkante).
 			-->
 			<frame>
-				<reportElement x="40" y="116" width="241" height="128"/>
+				<reportElement x="37" y="52" width="241" height="128"/>
 				<textField isBlankWhenNull="true">
 					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
 					<textFieldExpression><![CDATA[($P{Company_sender_line} != null && !$P{Company_sender_line}.trim().isEmpty())
@@ -187,45 +194,45 @@
 			  und unter welcher Nummer die Sendung läuft.
 			-->
 			<frame>
-				<reportElement x="337" y="116" width="224" height="91"/>
-				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{customer_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Ansprechpartner]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{delivery_contact_name} != null && !$F{delivery_contact_name}.trim().isEmpty()) ? $F{delivery_contact_name} : $F{contact_name}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12"/><text><![CDATA[Telefon]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="26" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{delivery_contact_phone} != null && !$F{delivery_contact_phone}.trim().isEmpty()) ? $F{delivery_contact_phone} : $F{contact_phone}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="39" width="104" height="12"/><text><![CDATA[Versanddatum]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="39" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{location_date} == null ? "" : $F{location_date}) + (($F{location_time} == null || $F{location_time}.isEmpty()) ? "" : " " + $F{location_time})]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="52" width="104" height="12"/><text><![CDATA[Rückgabe bis]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="52" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rental_end}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="65" width="104" height="12"/><text><![CDATA[Verleih-Status]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="65" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{location_status}]]></textFieldExpression></textField>
+				<reportElement x="297" y="66" width="236" height="91"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="95" height="12"/><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="0" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{customer_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="95" height="12"/><text><![CDATA[Ansprechpartner]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="13" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{delivery_contact_name} != null && !$F{delivery_contact_name}.trim().isEmpty()) ? $F{delivery_contact_name} : $F{contact_name}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="95" height="12"/><text><![CDATA[Telefon]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="26" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{delivery_contact_phone} != null && !$F{delivery_contact_phone}.trim().isEmpty()) ? $F{delivery_contact_phone} : $F{contact_phone}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="39" width="95" height="12"/><text><![CDATA[Versanddatum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="39" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[($F{location_date} == null ? "" : $F{location_date}) + (($F{location_time} == null || $F{location_time}.isEmpty()) ? "" : " " + $F{location_time})]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="52" width="95" height="12"/><text><![CDATA[Rückgabe bis]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="52" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rental_end}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="65" width="95" height="12"/><text><![CDATA[Verleih-Status]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="65" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{location_status}]]></textFieldExpression></textField>
 				<staticText>
-					<reportElement style="Label" x="0" y="78" width="104" height="12">
+					<reportElement style="Label" x="0" y="78" width="95" height="12">
 						<printWhenExpression><![CDATA[$F{tracking_number} != null && !$F{tracking_number}.trim().isEmpty()]]></printWhenExpression>
 					</reportElement>
 					<text><![CDATA[Sendungsnummer]]></text>
 				</staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Small" x="104" y="78" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tracking_number}]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement style="Small" x="95" y="78" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tracking_number}]]></textFieldExpression></textField>
 			</frame>
 			<!-- Betreffzeile (DIN 5008: 98,4 mm ab Seitenoberkante) -->
 			<staticText>
-				<reportElement x="12" y="267" width="549" height="18"/>
+				<reportElement x="37" y="203" width="496" height="18"/>
 				<textElement><font size="13" isBold="true"/></textElement>
 				<text><![CDATA[Leihschein / Versandschein]]></text>
 			</staticText>
-			<staticText><reportElement style="SectionTitle" x="12" y="296" width="270" height="14"/><text><![CDATA[Entleiher]]></text></staticText>
+			<staticText><reportElement style="SectionTitle" x="37" y="232" width="244" height="14"/><text><![CDATA[Entleiher]]></text></staticText>
 			<textField>
-				<reportElement style="Value" x="12" y="312" width="270" height="13"/>
+				<reportElement style="Value" x="37" y="248" width="244" height="13"/>
 				<textFieldExpression><![CDATA[($F{customer_name} == null ? "" : $F{customer_name}) + (($F{customer_number} == null || $F{customer_number}.isEmpty()) ? "" : ("  (" + $F{customer_number} + ")"))]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement style="Small" x="12" y="325" width="270" height="12"/>
+				<reportElement style="Small" x="37" y="261" width="244" height="12"/>
 				<textFieldExpression><![CDATA[(($F{customer_street} == null ? "" : $F{customer_street} + ", ")
 	+ ($F{customer_zip} == null ? "" : $F{customer_zip}) + " " + ($F{customer_city} == null ? "" : $F{customer_city})).trim()]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement style="Small" x="12" y="337" width="270" height="12"/>
+				<reportElement style="Small" x="37" y="273" width="244" height="12"/>
 				<textFieldExpression><![CDATA[(($F{contact_name} == null ? "" : $F{contact_name})
 	+ (($F{contact_email} == null || $F{contact_email}.isEmpty()) ? "" : "  ·  " + $F{contact_email})
 	+ (($F{contact_phone} == null || $F{contact_phone}.isEmpty()) ? "" : "  ·  " + $F{contact_phone})).trim()]]></textFieldExpression>
@@ -238,13 +245,13 @@
 			  scheitert (Telefon und Name führt der Informationsblock oben).
 			-->
 			<staticText>
-				<reportElement style="SectionTitle" x="291" y="296" width="270" height="14">
+				<reportElement style="SectionTitle" x="289" y="232" width="244" height="14">
 					<printWhenExpression><![CDATA[$F{delivery_contact_email} != null && !$F{delivery_contact_email}.trim().isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<text><![CDATA[Rückfragen zur Sendung]]></text>
 			</staticText>
 			<textField isBlankWhenNull="true">
-				<reportElement style="Value" x="291" y="312" width="270" height="13"/>
+				<reportElement style="Value" x="289" y="248" width="244" height="13"/>
 				<textFieldExpression><![CDATA[$F{delivery_contact_email}]]></textFieldExpression>
 			</textField>
 		</band>
@@ -256,15 +263,15 @@
 			  keiner gepflegt ist — alles darunter schwimmt (positionType Float).
 			-->
 			<frame>
-				<reportElement x="12" y="0" width="549" height="30" isRemoveLineWhenBlank="true">
+				<reportElement x="37" y="0" width="496" height="30" isRemoveLineWhenBlank="true">
 					<printWhenExpression><![CDATA[$F{shipping_note} != null && !$F{shipping_note}.trim().isEmpty()]]></printWhenExpression>
 				</reportElement>
-				<staticText><reportElement style="Label" x="0" y="0" width="549" height="12"/><text><![CDATA[Hinweis zur Sendung]]></text></staticText>
-				<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="13" width="549" height="13"/><textFieldExpression><![CDATA[$F{shipping_note}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="0" width="496" height="12"/><text><![CDATA[Hinweis zur Sendung]]></text></staticText>
+				<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="0" y="13" width="496" height="13"/><textFieldExpression><![CDATA[$F{shipping_note}]]></textFieldExpression></textField>
 			</frame>
-			<staticText><reportElement style="SectionTitle" positionType="Float" x="12" y="36" width="300" height="14"/><text><![CDATA[Sendungsinhalt]]></text></staticText>
+			<staticText><reportElement style="SectionTitle" positionType="Float" x="37" y="36" width="271" height="14"/><text><![CDATA[Sendungsinhalt]]></text></staticText>
 			<textField>
-				<reportElement style="Small" positionType="Float" x="300" y="37" width="261" height="13"/>
+				<reportElement style="Small" positionType="Float" x="297" y="37" width="236" height="13"/>
 				<textElement textAlignment="Right"/>
 				<textFieldExpression><![CDATA[($F{item_count} == null ? "" : ($F{item_count} + ($F{item_count}.intValue() == 1 ? " Position" : " Positionen")))]]></textFieldExpression>
 			</textField>
@@ -279,7 +286,7 @@
 			  Ankreuzliste ohne Kopf auf Seite 2 ist nicht abhakbar.
 			-->
 			<subreport>
-				<reportElement positionType="Float" x="12" y="54" width="549" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="37" y="54" width="496" height="14" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("devices")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/devices.jasper"]]></subreportExpression>
 			</subreport>
@@ -288,23 +295,23 @@
 			  wird nicht am Tresen quittiert — abgehakt wird es trotzdem, beim
 			  Packen wie beim Auspacken.
 			-->
-			<line><reportElement positionType="Float" x="12" y="80" width="549" height="1"/></line>
+			<line><reportElement positionType="Float" x="37" y="80" width="496" height="1"/></line>
 			<rectangle>
-				<reportElement positionType="Float" x="12" y="88" width="9" height="9"/>
+				<reportElement positionType="Float" x="37" y="88" width="8" height="9"/>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</rectangle>
-			<staticText><reportElement style="Small" positionType="Float" x="26" y="87" width="280" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
-			<staticText><reportElement style="Label" positionType="Float" x="341" y="87" width="40" height="12"/><text><![CDATA[Datum]]></text></staticText>
-			<line><reportElement positionType="Float" x="381" y="98" width="180" height="1"/></line>
+			<staticText><reportElement style="Small" positionType="Float" x="50" y="87" width="253" height="12"/><text><![CDATA[Sendung vollständig und unbeschädigt erhalten]]></text></staticText>
+			<staticText><reportElement style="Label" positionType="Float" x="334" y="87" width="36" height="12"/><text><![CDATA[Datum]]></text></staticText>
+			<line><reportElement positionType="Float" x="370" y="98" width="163" height="1"/></line>
 		</band>
 	</detail>
 	<pageFooter>
 		<band height="36">
-			<line><reportElement x="12" y="0" width="549" height="1"/></line>
-			<staticText><reportElement x="12" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Leihschein / Versandschein · calServer V2]]></text></staticText>
-			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
-			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="12" y="18" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<line><reportElement x="37" y="0" width="496" height="1"/></line>
+			<staticText><reportElement x="37" y="4" width="361" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Leihschein / Versandschein · calServer V2]]></text></staticText>
+			<textField><reportElement x="406" y="4" width="99" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="505" y="4" width="28" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="37" y="18" width="496" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/LOCATION-JSON-SAMPLE/subreports/devices.jrxml
+++ b/LOCATION-JSON-SAMPLE/subreports/devices.jrxml
@@ -19,7 +19,7 @@
   Das Wurzelgerät steht immer an erster Stelle; bei einer Einzelbuchung enthält
   die Liste nur dieses eine.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="devices" pageWidth="496" pageHeight="842" columnWidth="496" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d7ddf600-0312-4d72-9f62-000000000312">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
 	<style name="Small" fontSize="8"/>
@@ -31,13 +31,13 @@
 	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[next_calibration_date]]></fieldDescription></field>
 	<columnHeader>
 		<band height="16">
-			<staticText><reportElement style="Label" x="12" y="0" width="22" height="13"/><text><![CDATA[Pos]]></text></staticText>
-			<staticText><reportElement style="Label" x="34" y="0" width="88" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
-			<staticText><reportElement style="Label" x="122" y="0" width="94" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
-			<staticText><reportElement style="Label" x="216" y="0" width="128" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
-			<staticText><reportElement style="Label" x="344" y="0" width="140" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
-			<staticText><reportElement style="Label" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><text><![CDATA[Nächste Kal.]]></text></staticText>
-			<line><reportElement x="0" y="14" width="549" height="1"/></line>
+			<staticText><reportElement style="Label" x="11" y="0" width="20" height="13"/><text><![CDATA[Pos]]></text></staticText>
+			<staticText><reportElement style="Label" x="31" y="0" width="79" height="13"/><text><![CDATA[Inventar-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="110" y="0" width="85" height="13"/><text><![CDATA[Serien-Nr.]]></text></staticText>
+			<staticText><reportElement style="Label" x="195" y="0" width="116" height="13"/><text><![CDATA[Hersteller / Typ]]></text></staticText>
+			<staticText><reportElement style="Label" x="311" y="0" width="126" height="13"/><text><![CDATA[Beschreibung]]></text></staticText>
+			<staticText><reportElement style="Label" x="437" y="0" width="59" height="13"/><textElement textAlignment="Right"/><text><![CDATA[Nächste Kal.]]></text></staticText>
+			<line><reportElement x="0" y="14" width="496" height="1"/></line>
 		</band>
 	</columnHeader>
 	<!--
@@ -51,17 +51,17 @@
 		<band height="16" splitType="Prevent">
 			<!-- Ankreuzfeld zum Abhaken der Position beim Packen bzw. Auspacken. -->
 			<rectangle>
-				<reportElement x="0" y="1" width="9" height="9"/>
+				<reportElement x="0" y="1" width="8" height="9"/>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</rectangle>
-			<textField><reportElement style="Small" x="12" y="0" width="22" height="13"/><textFieldExpression><![CDATA[String.valueOf($V{REPORT_COUNT})]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="34" y="0" width="88" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="122" y="0" width="94" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
-			<textField><reportElement style="Small" x="216" y="0" width="128" height="13"/><textFieldExpression><![CDATA[(($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})).trim()]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="344" y="0" width="140" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement style="Small" x="484" y="0" width="65" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="11" y="0" width="20" height="13"/><textFieldExpression><![CDATA[String.valueOf($V{REPORT_COUNT})]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="31" y="0" width="79" height="13"/><textFieldExpression><![CDATA[$F{asset_number}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="110" y="0" width="85" height="13"/><textFieldExpression><![CDATA[$F{serial_number}]]></textFieldExpression></textField>
+			<textField><reportElement style="Small" x="195" y="0" width="116" height="13"/><textFieldExpression><![CDATA[(($F{manufacturer} == null ? "" : $F{manufacturer}) + " " + ($F{model} == null ? "" : $F{model})).trim()]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Small" x="311" y="0" width="126" height="13"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement style="Small" x="437" y="0" width="59" height="13"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{next_calibration_date}]]></textFieldExpression></textField>
 			<!-- Zeilentrenner: eine Abhakliste braucht die Führung fürs Auge. -->
-			<line><reportElement positionType="Float" x="0" y="14" width="549" height="1"/><graphicElement><pen lineWidth="0.25" lineColor="#BBBBBB"/></graphicElement></line>
+			<line><reportElement positionType="Float" x="0" y="14" width="496" height="1"/><graphicElement><pen lineWidth="0.25" lineColor="#BBBBBB"/></graphicElement></line>
 		</band>
 	</detail>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/README.md
+++ b/ORDER-JSON-SAMPLE/README.md
@@ -18,7 +18,7 @@ andere den Auftraggeber. Das Template verzweigt nur noch auf `document.type`.
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/order-json-sample.jrxml` | Hauptbericht: **Fensterbrief nach DIN 5008 Form B** — Anschriftfeld mit Rücksendeangabe (`recipient` je Dokumenttyp), Informationsblock rechts (Belegnummer/Datum/Kunden-Nr./Kontakt/Lieferbedingung/-kosten), Betreffzeile bei 98,4 mm, Falz- und Lochmarken; darunter abweichende Liefer-/Rechnungsadresse als Info-Block, Positionstabelle + Statistik + Zusatzfelder, Rechnungs-/Lieferschein-Spezifika, Fußzeile mit Firmen-/Steuer-/Bankangaben. Alle Labels als `staticText` |
+| `main_reports/order-json-sample.jrxml` | Hauptbericht: **Fensterbrief nach DIN 5008 Form B, briefpapierfest** — Anschriftfeld mit Rücksendeangabe (`recipient` je Dokumenttyp), Informationsblock rechts (Belegnummer/Datum/Kunden-Nr./Kontakt/Lieferbedingung/-kosten), Betreffzeile bei 98,4 mm, Falz- und Lochmarken; darunter abweichende Liefer-/Rechnungsadresse als Info-Block, Positionstabelle + Statistik + Zusatzfelder, Rechnungs-/Lieferschein-Spezifika, Fußzeile mit Firmen-/Steuer-/Bankangaben. Alle Labels als `staticText` |
 | `subreports/positions.jrxml` | Positionen; `positions`-Array via `subDataSource("positions")` (Pos/Beschreibung/Menge/Einzelpreis/Rabatt/Betrag/MwSt). Gruppe `sourceOrder` je Quellauftrag — Kopfzeile nur bei einer Sammelrechnung (s.u.) |
 | `subreports/positions-delivery.jrxml` | Positionen **ohne Preise** für Lieferscheine (Pos/Beschreibung/Menge/Einheit); wird bei `document.type = delivery_note` automatisch gewählt. Dieselbe Gruppierung |
 | `subreports/tax-groups.jrxml` | Steuergruppen; `statistics.tax_groups`-Array via `subDataSource("statistics.tax_groups")` (USt. je Satz — § 14 UStG-Aufschlüsselung) |
@@ -34,20 +34,23 @@ Der Beleg ist ein **Fensterbrief nach DIN 5008 Form B** — dieselbe Geometrie
 wie beim Leihschein (`LOCATION-JSON-SAMPLE`) und beim Versandschein
 (`FREE-DELIVERY-JSON-SAMPLE`):
 
-| Element | Position | Im Template |
+| Element | Position auf dem Blatt | Im Template |
 |---|---|---|
-| Anschriftfeld | 20 mm von links, 45 mm von oben, 85 × 45 mm | Rahmen `x=40 y=116 241×128` im Titelband |
+| Anschriftfeld | 20 mm von links, 45 mm von oben, 85 × 45 mm | Rahmen `x=37 y=52 241×128` im Titelband |
 | Rücksendeangabe | Zusatz-/Vermerkzone, 12 mm ab Feldoberkante | `y=34` im Anschriftfeld-Rahmen |
 | Anschrift | Beginn der Anschriftzone, 17,7 mm ab Feldoberkante | `y=50`, ein Textfeld mit `\n`-Zeilen |
-| Informationsblock | ab 125 mm, auf Höhe des Anschriftfelds | Rahmen `x=337 y=116` |
-| Betreffzeile | 98,4 mm ab Seitenoberkante | `y=267` |
+| Informationsblock | ab 125 mm, 50 mm von oben | Rahmen `x=297 y=66 236 pt` |
+| Betreffzeile | 98,4 mm ab Seitenoberkante | `y=203` |
 | Falz-/Lochmarken | 105 / 148,5 / 210 mm am linken Rand | Hintergrundband, abschaltbar über `Show_fold_marks` |
+
+Alle Bandkoordinaten liegen hinter `topMargin=76`: Bandzeile `y` steht auf dem
+Blatt bei `76 + y` Punkt.
 
 Damit zeigt ein DIN-lang-Fensterumschlag nach DIN 680 genau die Anschrift des
 Empfängers — und zwar bei **allen** Belegtypen: Angebot, Auftragsbestätigung,
 Lieferschein, Rechnung und dem neutralen Beleg teilen sich diesen Kopf, nur die
 Blöcke darunter unterscheiden sich. Wer auf **Form A** umstellt (Anschriftfeld
-ab 27 mm), ändert eine Zahl: `y=116` wird `y=64`.
+ab 27 mm), ändert eine Zahl: `y=52` wird `y=0`.
 
 Die Anschrift ist **ein** Textfeld mit `\n`-Zeilen, kein Stapel Einzelfelder:
 Fehlt der Ansprechpartner oder die Straße, rückt der Rest auf, statt eine Lücke
@@ -55,8 +58,47 @@ im Fenster zu lassen. Die Landzeile druckt nur, wenn `recipient.country` vom
 Absenderland (`supplier.country`, aus `company_country`) abweicht — „DE" unter
 einer deutschen Inlandsanschrift wäre schlicht falsch.
 
-Der Textblock beginnt bei `x=12` (10,2 mm) statt am Rand, damit die Falzmarken
-nicht in die Positionsspalte laufen; die Tabelle ist entsprechend 549 pt breit.
+Der Textblock beginnt bei `x=37` (20 mm ab Blattkante), damit die Falzmarken
+nicht in die Positionsspalte laufen; die Tabelle ist entsprechend 496 pt breit.
+
+## Der Beleg passt auf Briefpapier
+
+Der Auftragsbeleg ist das Papier, das am häufigsten das Haus verlässt — und in
+aller Regel auf **vorgedrucktem Briefpapier**. calServer legt die Bogenvorlage
+unter den Bericht (Berichtseinstellung `use_template` = `pdf` oder `html`,
+Seite 1 der Vorlage auf Belegseite 1, Seite 2 auf jede Folgeseite). Der Beleg
+hält deshalb eine feste **Freizone** ein und läuft nirgends in Kopf, Fuß oder
+Seitenränder des Bogens:
+
+| Zone | Grenze | Woher |
+|---|---|---|
+| Satzspiegel links | 20 mm (57 pt) | `leftMargin=20` + Inhalt ab `x=37` |
+| Satzspiegel rechts | 195 mm (553 pt) | `rightMargin=42`, `columnWidth=533` |
+| Oberkante Folgeseiten | 26,8 mm (76 pt) | `topMargin=76` |
+| Oberkante Seite 1 | 45 mm (128 pt), Anschriftfeld | Titelband |
+| Unterkante Inhalt | 249 mm (706 pt) | `bottomMargin=136` |
+
+Die 20 mm links sind kein DIN-Wert (DIN 5008 nennt 24,1 mm), sondern der Rand,
+den vorgedrucktes Briefpapier üblicherweise für seine Kopf- und Fußlinien
+benutzt — Tabelle und Trennlinien des Belegs stehen damit **bündig** unter dem
+Bogen statt daneben. Die 48 mm unten sind der Platz, den ein Fußblock mit
+Firmen-, Register-, Bank- und Akkreditierungsangaben braucht.
+
+Zwei Dinge druckt der Bogen meist schon selbst; dafür gibt es je einen
+Schalter, damit sie nicht doppelt erscheinen:
+
+- `Show_supplier_footer = 0` — lässt Anschrift, USt-IdNr./Steuernummer,
+  Handelsregister und Bankverbindung in der Fußzeile weg.
+- `Show_fold_marks = 0` — lässt Falz- und Lochmarken weg.
+
+Beide stehen per Default auf `1`: ohne Briefpapier muss der Beleg die
+Pflichtangaben nach § 14 UStG selbst tragen, und ein stillschweigend
+weggelassener Absender wäre der teurere Fehler. Wer Briefpapier benutzt, setzt
+die beiden Berichtsvariablen `show_supplier_footer` und `show_fold_marks`
+einmal auf `0`.
+
+Ein Bogen mit **höherem** Kopf oder Fuß als oben angegeben braucht andere
+Ränder — das sind die vier Zahlen im `<jasperReport>`-Element, sonst nichts.
 
 ## Contract `order-document` (v1.8)
 
@@ -236,6 +278,7 @@ von Berichtsvariablen mit Beschreibung, Typ und Standardwert anbietet (siehe
 |-----------|-------|---------|
 | `Company_footer` | variable (type) | Optionale Fußzeile am unteren Rand jeder Seite (Auftragsbeleg). Leerer Default → keine Änderung am aktuellen Layout; nur wenn gesetzt (Berichtsvariable `company_footer`), erscheint die Zeile. |
 | `Show_fold_marks` | variable (type) | Falz- und Lochmarken am linken Blattrand (105 / 148,5 / 210 mm). Default `1`; auf `0` setzen, wenn vorgedrucktes Briefpapier sie schon trägt (Berichtsvariable `show_fold_marks`). |
+| `Show_supplier_footer` | variable (type) | Absender-, Steuer- und Bankangaben in der Fußzeile (§ 14 UStG). Default `1`; auf `0` setzen, wenn der Fußblock des Briefpapiers sie schon trägt (Berichtsvariable `show_supplier_footer`). |
 
 Gilt nur für V2-JSON-Bundles. Der optionale Fußzeilentext ist `isBlankWhenNull`
 und standardmäßig leer — die pixelgenaue Abnahme des Layouts (report-runner)

--- a/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
+++ b/ORDER-JSON-SAMPLE/main_reports/order-json-sample.jrxml
@@ -11,12 +11,23 @@
   Geometrie: Fensterbrief nach DIN 5008 Form B, wie Leihschein
   (LOCATION-JSON-SAMPLE) und Versandschein (FREE-DELIVERY-JSON-SAMPLE).
   Anschriftfeld 20 mm von links, 45 mm von oben, 85 x 45 mm (im Titelband
-  x=40, y=116, 241 x 128 pt), Informationsblock ab 125 mm, Betreffzeile bei
+  x=37, y=52, 241 x 128 pt), Informationsblock ab 125 mm, Betreffzeile bei
   98,4 mm, Falz- und Lochmarken im Hintergrundband (abschaltbar ueber
   Show_fold_marks). Ein DIN-lang-Umschlag nach DIN 680 zeigt damit genau die
   Anschrift des Empfaengers, und zwar in JEDER Variante: Angebot,
   Auftragsbestaetigung, Lieferschein, Rechnung und der neutrale Beleg teilen
-  sich diesen Kopf. Wer auf Form A umstellt, aendert eine Zahl: y=116 wird 64.
+  sich diesen Kopf. Wer auf Form A umstellt, aendert eine Zahl: y=52 wird 0.
+  Briefpapierfest: Die Seitenraender halten die Freizone eines vorgedruckten
+  Bogens frei, den calServer per ReportOverlayService unter den Beleg legt.
+  leftMargin=20 / rightMargin=42 / topMargin=76 / bottomMargin=136, Inhalt ab
+  x=37 (20 mm) bis 533 (195 mm), Folgeseiten ab 26,8 mm, Inhalt bis 249 mm.
+  Ein Bogen mit hoeherem Kopf oder Fuss braucht andere Raender — das sind diese
+  vier Zahlen, sonst nichts.
+
+  Zwei Schalter gegen doppelte Angaben auf Briefpapier: Show_supplier_footer=0
+  laesst Absender-, Steuer- und Bankzeile der Fusszeile weg, Show_fold_marks=0
+  die Falz- und Lochmarken. Beide Default 1 — ohne Bogen muss der Beleg die
+  Pflichtangaben nach Paragraf 14 UStG selbst tragen.
 
   Per-type behavior (standards-oriented):
   - heading = document.type_label (Angebot / Auftragsbestätigung / Lieferschein /
@@ -43,7 +54,7 @@
   are staticText (no report-level $V{} → no null-in-title risk); every nullable
   field prints blank, never "null". See main_reports/sample-data.json.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="order-json-sample" pageWidth="595" pageHeight="842" columnWidth="561" leftMargin="17" rightMargin="17" topMargin="12" bottomMargin="12" uuid="d6dcf500-0300-4d60-9f50-000000000300">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="order-json-sample" pageWidth="595" pageHeight="842" columnWidth="533" leftMargin="20" rightMargin="42" topMargin="76" bottomMargin="136" uuid="d6dcf500-0300-4d60-9f50-000000000300">
 	<property name="com.jaspersoft.studio.data.defadapter" value="order-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<style name="Label" fontSize="8" isBold="true"/>
@@ -57,6 +68,10 @@
 	<parameter name="Company_footer" class="java.lang.String">
 		<parameterDescription><![CDATA[Optionale Fußzeile am unteren Rand jeder Seite, z. B. Firmenname und Kontaktdaten. Leer = keine zusätzliche Fußzeile.]]></parameterDescription>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="Show_supplier_footer" class="java.lang.String">
+		<parameterDescription><![CDATA[Absender-, Steuer- und Bankangaben in der Fußzeile drucken. "0" = aus, wenn das Briefpapier sie schon trägt.]]></parameterDescription>
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="Show_fold_marks" class="java.lang.String">
 		<parameterDescription><![CDATA[Falz- und Lochmarken am linken Rand drucken (105 mm, 148,5 mm, 210 mm). "0" = aus, z. B. bei vorgedrucktem Briefpapier, das sie schon trägt.]]></parameterDescription>
@@ -123,21 +138,21 @@
 	  105 mm / 148,5 mm / 210 mm ab Seitenoberkante; die Lochmarke ist länger.
 	-->
 	<background>
-		<band height="818">
+		<band height="630">
 			<line>
-				<reportElement x="0" y="286" width="8" height="1">
+				<reportElement x="0" y="222" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="409" width="14" height="1">
+				<reportElement x="0" y="345" width="14" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="583" width="8" height="1">
+				<reportElement x="0" y="519" width="8" height="1">
 					<printWhenExpression><![CDATA[!"0".equals($P{Show_fold_marks})]]></printWhenExpression>
 				</reportElement>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
@@ -145,17 +160,17 @@
 		</band>
 	</background>
 	<title>
-		<band height="390">
+		<band height="326">
 			<!--
 			  Anschriftfeld (DIN 676 Form B). Der Frame IST das Feld: 85 × 45 mm
 			  an 20/45 mm, damit die Anschrift im Fenster eines DIN-lang-Umschlags
 			  nach DIN 680 steht. Innen liegt die Rücksendeangabe in der Zusatz- und
 			  Vermerkzone (12 mm ab Feldoberkante), die Anschrift am Beginn der
 			  Anschriftzone (17,7 mm = 50 pt ab Feldoberkante). Wer auf Form A
-			  umstellt (Anschriftfeld ab 27 mm), ändert eine Zahl: y=116 wird y=64.
+			  umstellt (Anschriftfeld ab 27 mm), ändert eine Zahl: y=52 wird y=0.
 			-->
 			<frame>
-				<reportElement x="40" y="116" width="241" height="128"/>
+				<reportElement x="37" y="52" width="241" height="128"/>
 				<!-- Rücksendeangabe: supplier.sender_line, sonst aus der Absenderanschrift gesetzt -->
 				<textField isBlankWhenNull="true">
 					<reportElement style="SenderLine" x="0" y="34" width="241" height="10"/>
@@ -200,24 +215,24 @@
 			  der Anschrift steht — zweimal derselbe Name ist keine Information.
 			-->
 			<frame>
-				<reportElement x="337" y="116" width="224" height="91"/>
-				<staticText><reportElement style="Label" x="0" y="0" width="104" height="12"/><text><![CDATA[Belegnummer]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="0" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="13" width="104" height="12"/><text><![CDATA[Datum]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="13" width="120" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" x="0" y="26" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{rcpt_number} != null]]></printWhenExpression></reportElement><text><![CDATA[Kunden-Nr.]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" x="104" y="26" width="120" height="12" isRemoveLineWhenBlank="true"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rcpt_number}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" positionType="Float" x="0" y="39" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{rcpt_contact} == null || !$F{rcpt_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="104" y="39" width="120" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{rcpt_contact} == null || !$F{rcpt_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" positionType="Float" x="0" y="52" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><text><![CDATA[Lieferung]]></text></staticText>
-				<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="104" y="52" width="120" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_condition}]]></textFieldExpression></textField>
-				<staticText><reportElement style="Label" positionType="Float" x="0" y="65" width="104" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><text><![CDATA[Lieferkosten]]></text></staticText>
-				<textField pattern="#,##0.00 €"><reportElement style="Value" positionType="Float" x="104" y="65" width="120" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_costs}]]></textFieldExpression></textField>
+				<reportElement x="297" y="66" width="236" height="91"/>
+				<staticText><reportElement style="Label" x="0" y="0" width="95" height="12"/><text><![CDATA[Belegnummer]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="0" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="13" width="95" height="12"/><text><![CDATA[Datum]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="13" width="141" height="12"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_date}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" x="0" y="26" width="95" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{rcpt_number} != null]]></printWhenExpression></reportElement><text><![CDATA[Kunden-Nr.]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" x="95" y="26" width="141" height="12" isRemoveLineWhenBlank="true"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{rcpt_number}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" positionType="Float" x="0" y="39" width="95" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{rcpt_contact} == null || !$F{rcpt_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><text><![CDATA[Kontakt]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="95" y="39" width="141" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{cust_contact} != null && !$F{cust_contact}.trim().isEmpty() && ($F{rcpt_contact} == null || !$F{rcpt_contact}.trim().equals($F{cust_contact}.trim()))]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{cust_contact}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" positionType="Float" x="0" y="52" width="95" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><text><![CDATA[Lieferung]]></text></staticText>
+				<textField isBlankWhenNull="true"><reportElement style="Value" positionType="Float" x="95" y="52" width="141" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_condition} != null && !$F{doc_delivery_condition}.isEmpty()]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_condition}]]></textFieldExpression></textField>
+				<staticText><reportElement style="Label" positionType="Float" x="0" y="65" width="95" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><text><![CDATA[Lieferkosten]]></text></staticText>
+				<textField pattern="#,##0.00 €"><reportElement style="Value" positionType="Float" x="95" y="65" width="141" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{doc_delivery_costs} != null && $F{doc_delivery_costs}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{doc_delivery_costs}]]></textFieldExpression></textField>
 			</frame>
 			<!-- Betreffzeile (DIN 5008: 98,4 mm ab Seitenoberkante), Belegtyp je Status -->
-			<textField><reportElement x="12" y="267" width="549" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "Beleg" : $F{doc_status})) + " " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
+			<textField><reportElement x="37" y="203" width="496" height="18"/><textElement><font size="13" isBold="true"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "Beleg" : $F{doc_status})) + " " + ($F{doc_number} == null ? "" : $F{doc_number})]]></textFieldExpression></textField>
 			<!-- Anschreiben aus dem Auftrag. Kollabiert, wenn keins gepflegt ist. -->
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="12" y="288" width="549" height="13" isRemoveLineWhenBlank="true"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement style="Value" x="37" y="224" width="496" height="13" isRemoveLineWhenBlank="true"/><textFieldExpression><![CDATA[$F{doc_comment}]]></textFieldExpression></textField>
 			<!--
 			  Abweichende Liefer-/Rechnungsadresse. Sie stehen UNTER der
 			  Betreffzeile, nicht im Kopf: Im Fensterbereich ist nur Platz für eine
@@ -225,93 +240,114 @@
 			  gemeinsam, wenn keiner druckt.
 			-->
 			<frame>
-				<reportElement positionType="Float" x="12" y="308" width="175" height="52" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{del_number} != null && !$F{del_number}.equals($F{cust_number}) && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement positionType="Float" x="37" y="244" width="175" height="52" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{del_number} != null && !$F{del_number}.equals($F{cust_number}) && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<staticText><reportElement style="Label" x="0" y="0" width="175" height="11"/><text><![CDATA[Lieferadresse]]></text></staticText>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="12" width="175" height="12"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{del_name}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="24" width="175" height="12"/><textFieldExpression><![CDATA[$F{del_street}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="36" width="175" height="12"/><textFieldExpression><![CDATA[($F{del_zip} == null ? "" : $F{del_zip}) + " " + ($F{del_city} == null ? "" : $F{del_city})]]></textFieldExpression></textField>
 			</frame>
 			<frame>
-				<reportElement positionType="Float" x="197" y="308" width="175" height="52" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{inv_number} != null && !$F{inv_number}.equals($F{cust_number}) && !"invoice".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement positionType="Float" x="222" y="244" width="175" height="52" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[$F{inv_number} != null && !$F{inv_number}.equals($F{cust_number}) && !"invoice".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<staticText><reportElement style="Label" x="0" y="0" width="175" height="11"/><text><![CDATA[Rechnungsadresse]]></text></staticText>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="12" width="175" height="12"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[$F{inv_name}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="24" width="175" height="12"/><textFieldExpression><![CDATA[$F{inv_street}]]></textFieldExpression></textField>
 				<textField isBlankWhenNull="true"><reportElement x="0" y="36" width="175" height="12"/><textFieldExpression><![CDATA[($F{inv_zip} == null ? "" : $F{inv_zip}) + " " + ($F{inv_city} == null ? "" : $F{inv_city})]]></textFieldExpression></textField>
 			</frame>
 			<!-- Positions table header (full, priced document types) -->
-			<line><reportElement positionType="Float" x="12" y="368" width="549" height="1"/></line>
+			<line><reportElement positionType="Float" x="37" y="304" width="496" height="1"/></line>
 			<frame>
-				<reportElement positionType="Float" x="12" y="372" width="549" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
-				<staticText><reportElement style="Label" x="0" y="0" width="28" height="14"/><text><![CDATA[Pos]]></text></staticText>
-				<staticText><reportElement style="Label" x="28" y="0" width="228" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
-				<staticText><reportElement style="Label" x="256" y="0" width="60" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
-				<staticText><reportElement style="Label" x="316" y="0" width="70" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Einzelpreis]]></text></staticText>
-				<staticText><reportElement style="Label" x="386" y="0" width="45" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Rabatt]]></text></staticText>
-				<staticText><reportElement style="Label" x="431" y="0" width="78" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Betrag]]></text></staticText>
-				<staticText><reportElement style="Label" x="509" y="0" width="40" height="14"/><textElement textAlignment="Right"/><text><![CDATA[MwSt]]></text></staticText>
+				<reportElement positionType="Float" x="37" y="308" width="496" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<staticText><reportElement style="Label" x="0" y="0" width="26" height="14"/><text><![CDATA[Pos]]></text></staticText>
+				<staticText><reportElement style="Label" x="26" y="0" width="180" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+				<staticText><reportElement style="Label" x="206" y="0" width="58" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+				<staticText><reportElement style="Label" x="266" y="0" width="64" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Einzelpreis]]></text></staticText>
+				<staticText><reportElement style="Label" x="330" y="0" width="42" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Rabatt]]></text></staticText>
+				<staticText><reportElement style="Label" x="372" y="0" width="76" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Betrag]]></text></staticText>
+				<staticText><reportElement style="Label" x="448" y="0" width="48" height="14"/><textElement textAlignment="Right"/><text><![CDATA[MwSt]]></text></staticText>
 			</frame>
 			<!-- Positions table header (delivery note: no prices) -->
 			<frame>
-				<reportElement positionType="Float" x="12" y="372" width="549" height="14"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
-				<staticText><reportElement style="Label" x="0" y="0" width="28" height="14"/><text><![CDATA[Pos]]></text></staticText>
-				<staticText><reportElement style="Label" x="28" y="0" width="360" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
-				<staticText><reportElement style="Label" x="388" y="0" width="80" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
-				<staticText><reportElement style="Label" x="478" y="0" width="71" height="14"/><text><![CDATA[Einheit]]></text></staticText>
+				<reportElement positionType="Float" x="37" y="308" width="496" height="14"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<staticText><reportElement style="Label" x="0" y="0" width="26" height="14"/><text><![CDATA[Pos]]></text></staticText>
+				<staticText><reportElement style="Label" x="26" y="0" width="304" height="14"/><text><![CDATA[Beschreibung]]></text></staticText>
+				<staticText><reportElement style="Label" x="330" y="0" width="70" height="14"/><textElement textAlignment="Right"/><text><![CDATA[Menge]]></text></staticText>
+				<staticText><reportElement style="Label" x="410" y="0" width="86" height="14"/><text><![CDATA[Einheit]]></text></staticText>
 			</frame>
 		</band>
 	</title>
+	<!--
+	  Drei Detailbaender statt eines: die typabhaengigen Bloecke bekommen ein
+	  eigenes Band mit printWhenExpression. Ein Band, das nicht druckt, kostet
+	  keine Hoehe — ein nicht gedrucktes ELEMENT in einem gemeinsamen Band
+	  schon, und zwar samt der Verschiebung durch positionType="Float" darueber.
+	  Genau daran ist die Empfangsbestaetigung des Lieferscheins vorher auf eine
+	  eigene Seite gerutscht, obwohl darunter noch Platz war.
+	-->
 	<detail>
-		<band height="230">
+		<band height="135">
 			<subreport>
-				<reportElement positionType="Float" x="12" y="0" width="549" height="14" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="37" y="0" width="496" height="14" isRemoveLineWhenBlank="true"/>
 				<subreportParameter name="Is_collective"><subreportParameterExpression><![CDATA[$F{collective_is}]]></subreportParameterExpression></subreportParameter>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("positions")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + ("delivery_note".equals($F{doc_type}) ? "/subreports/positions-delivery.jasper" : "/subreports/positions.jasper")]]></subreportExpression>
 			</subreport>
 			<!-- Totals (hidden on delivery notes — a Lieferschein carries no prices) -->
-			<line><reportElement positionType="Float" x="330" y="24" width="231" height="1"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
-			<staticText><reportElement style="Label" positionType="Float" x="330" y="28" width="150" height="13"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><text><![CDATA[Zwischensumme netto]]></text></staticText>
-			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="480" y="28" width="81" height="13"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{net_total}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight"><reportElement style="Label" positionType="Float" x="330" y="44" width="150" height="13"><printWhenExpression><![CDATA[$F{discount_amount} != null && $F{discount_amount}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textFieldExpression><![CDATA["Rabatt " + ($F{order_discount_percent} == null ? "" : $F{order_discount_percent}) + " %"]]></textFieldExpression></textField>
-			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="480" y="44" width="81" height="13"><printWhenExpression><![CDATA[$F{discount_amount} != null && $F{discount_amount}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount_amount} == null ? null : (-$F{discount_amount})]]></textFieldExpression></textField>
+			<line><reportElement positionType="Float" x="302" y="24" width="231" height="1"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
+			<staticText><reportElement style="Label" positionType="Float" x="302" y="28" width="150" height="13"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><text><![CDATA[Zwischensumme netto]]></text></staticText>
+			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="452" y="28" width="81" height="13"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{net_total}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight"><reportElement style="Label" positionType="Float" x="302" y="44" width="150" height="13"><printWhenExpression><![CDATA[$F{discount_amount} != null && $F{discount_amount}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textFieldExpression><![CDATA["Rabatt " + ($F{order_discount_percent} == null ? "" : $F{order_discount_percent}) + " %"]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="452" y="44" width="81" height="13"><printWhenExpression><![CDATA[$F{discount_amount} != null && $F{discount_amount}.doubleValue() != 0.0 && !"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount_amount} == null ? null : (-$F{discount_amount})]]></textFieldExpression></textField>
 			<!-- Tax groups (USt. je Steuersatz — § 14 UStG: Aufschlüsselung nach Steuersätzen) -->
 			<subreport>
-				<reportElement positionType="Float" x="330" y="60" width="231" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
+				<reportElement positionType="Float" x="302" y="60" width="231" height="12" isRemoveLineWhenBlank="true"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("statistics.tax_groups")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/tax-groups.jasper"]]></subreportExpression>
 			</subreport>
-			<line><reportElement positionType="Float" x="330" y="84" width="231" height="1"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
-			<staticText><reportElement style="Label" positionType="Float" x="330" y="88" width="150" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="10" isBold="true"/></textElement><text><![CDATA[Gesamtbetrag]]></text></staticText>
-			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="470" y="88" width="91" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{gross_total}]]></textFieldExpression></textField>
+			<line><reportElement positionType="Float" x="302" y="84" width="231" height="1"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
+			<staticText><reportElement style="Label" positionType="Float" x="302" y="88" width="150" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="10" isBold="true"/></textElement><text><![CDATA[Gesamtbetrag]]></text></staticText>
+			<textField pattern="#,##0.00 €"><reportElement style="Money" positionType="Float" x="442" y="88" width="91" height="14"><printWhenExpression><![CDATA[!"delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement textAlignment="Right"><font size="10" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{gross_total}]]></textFieldExpression></textField>
 			<!-- Weitere Angaben: Zusatzfelder (W41xx) generisch aus custom_fields_list (Contract 1.1) -->
 			<subreport>
-				<reportElement positionType="Float" x="12" y="30" width="320" height="12" isRemoveLineWhenBlank="true"/>
+				<reportElement positionType="Float" x="37" y="30" width="255" height="12" isRemoveLineWhenBlank="true"/>
 				<dataSourceExpression><![CDATA[((net.sf.jasperreports.engine.data.JsonDataSource)$P{REPORT_DATA_SOURCE}).subDataSource("document.custom_fields_list")]]></dataSourceExpression>
 				<subreportExpression><![CDATA[$P{Reportpath} + "/subreports/custom-fields.jasper"]]></subreportExpression>
 			</subreport>
 			<!-- Status-specific description text (booking_offer/order/billing/delivery_report_description) -->
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="12" y="120" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{doc_description}]]></textFieldExpression></textField>
-			<!-- Invoice only: § 14 Abs. 4 Nr. 6 UStG — Leistungsdatum + Zahlungsbedingungen -->
-			<staticText><reportElement positionType="Float" x="12" y="136" width="549" height="12"><printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Soweit nicht anders angegeben, entspricht das Liefer-/Leistungsdatum dem Rechnungsdatum.]]></text></staticText>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="12" y="150" width="549" height="12"><printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="8" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{sup_payment_terms}]]></textFieldExpression></textField>
-			<!-- Delivery note only: receipt confirmation -->
-			<staticText><reportElement positionType="Float" x="12" y="150" width="549" height="12"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="8" isBold="true"/></textElement><text><![CDATA[Empfang der aufgeführten Positionen bestätigt:]]></text></staticText>
-			<line><reportElement positionType="Float" x="12" y="196" width="150" height="1"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
-			<staticText><reportElement positionType="Float" x="12" y="199" width="150" height="10"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Datum]]></text></staticText>
-			<line><reportElement positionType="Float" x="212" y="196" width="220" height="1"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement></line>
-			<staticText><reportElement positionType="Float" x="212" y="199" width="220" height="10"><printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression></reportElement><textElement><font size="7"/></textElement><text><![CDATA[Name, Unterschrift Empfänger]]></text></staticText>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement positionType="Float" x="37" y="120" width="496" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$F{doc_description}]]></textFieldExpression></textField>
+		</band>
+		<!-- Rechnung: § 14 Abs. 4 Nr. 6 UStG — Leistungsdatum + Zahlungsbedingungen -->
+		<band height="28">
+			<printWhenExpression><![CDATA["invoice".equals($F{doc_type})]]></printWhenExpression>
+			<staticText><reportElement x="37" y="0" width="496" height="12"/><textElement><font size="7"/></textElement><text><![CDATA[Soweit nicht anders angegeben, entspricht das Liefer-/Leistungsdatum dem Rechnungsdatum.]]></text></staticText>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="37" y="14" width="496" height="12"/><textElement><font size="8" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{sup_payment_terms}]]></textFieldExpression></textField>
+		</band>
+		<!-- Lieferschein: Empfangsbestaetigung mit Unterschriftszeilen -->
+		<band height="62">
+			<printWhenExpression><![CDATA["delivery_note".equals($F{doc_type})]]></printWhenExpression>
+			<staticText><reportElement x="37" y="0" width="496" height="12"/><textElement><font size="8" isBold="true"/></textElement><text><![CDATA[Empfang der aufgeführten Positionen bestätigt:]]></text></staticText>
+			<line><reportElement x="37" y="46" width="150" height="1"/></line>
+			<staticText><reportElement x="37" y="49" width="150" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Datum]]></text></staticText>
+			<line><reportElement x="237" y="46" width="220" height="1"/></line>
+			<staticText><reportElement x="237" y="49" width="220" height="10"/><textElement><font size="7"/></textElement><text><![CDATA[Name, Unterschrift Empfänger]]></text></staticText>
 		</band>
 	</detail>
+	<!--
+	  Fusszone. Sie endet bei 706 pt (249 mm) und damit ueber dem Fussblock des
+	  Briefpapiers, der bei 714 pt mit seiner Trennlinie beginnt. Die Absender-,
+	  Steuer- und Bankangaben stehen hier nur, wenn das Papier sie nicht schon
+	  traegt (Show_supplier_footer) — zweimal dieselbe Anschrift ist der
+	  haeufigste Fehler beim Druck auf Briefpapier.
+	-->
 	<pageFooter>
-		<band height="52">
-			<line><reportElement x="12" y="0" width="549" height="1"/></line>
-			<textField isBlankWhenNull="true"><reportElement x="12" y="4" width="400" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "" : $F{doc_status})) + (($F{doc_number} == null) ? "" : (" · " + $F{doc_number}))]]></textFieldExpression></textField>
-			<textField><reportElement x="420" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
-			<textField evaluationTime="Report"><reportElement x="530" y="4" width="31" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
+		<band height="50">
+			<line><reportElement x="37" y="0" width="496" height="1"/></line>
+			<textField isBlankWhenNull="true"><reportElement x="37" y="4" width="340" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[($F{doc_type_label} != null ? $F{doc_type_label} : ($F{doc_status} == null ? "" : $F{doc_status})) + (($F{doc_number} == null) ? "" : (" · " + $F{doc_number}))]]></textFieldExpression></textField>
+			<textField><reportElement x="380" y="4" width="110" height="12"/><textElement textAlignment="Right"><font size="7"/></textElement><textFieldExpression><![CDATA["Seite " + $V{PAGE_NUMBER} + " von "]]></textFieldExpression></textField>
+			<textField evaluationTime="Report"><reportElement x="490" y="4" width="43" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[" " + String.valueOf($V{PAGE_NUMBER})]]></textFieldExpression></textField>
 			<!-- Supplier identity (§ 14 UStG: vollständige Anschrift + Steuernummer/USt-IdNr. des Ausstellers) -->
-			<textField isBlankWhenNull="true"><reportElement x="12" y="17" width="549" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_name} == null ? "" : $F{sup_name}) + ($F{sup_street} == null ? "" : " · " + $F{sup_street}) + (($F{sup_zip} == null && $F{sup_city} == null) ? "" : " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city})) + ($F{sup_vat_id} == null ? "" : " · USt-IdNr. " + $F{sup_vat_id}) + ($F{sup_tax_number} == null ? "" : " · Steuernummer " + $F{sup_tax_number}) + ($F{sup_register} == null ? "" : " · " + $F{sup_register}))]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="12" y="27" width="549" height="10"/><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_bank_name} == null ? "" : $F{sup_bank_name}) + ($F{sup_iban} == null ? "" : " · IBAN " + $F{sup_iban}) + ($F{sup_bic} == null ? "" : " · BIC " + $F{sup_bic}))]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="12" y="38" width="549" height="12"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="37" y="18" width="496" height="10"><printWhenExpression><![CDATA[!"0".equals($P{Show_supplier_footer})]]></printWhenExpression></reportElement><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_name} == null ? "" : $F{sup_name}) + ($F{sup_street} == null ? "" : " · " + $F{sup_street}) + (($F{sup_zip} == null && $F{sup_city} == null) ? "" : " · " + ($F{sup_zip} == null ? "" : $F{sup_zip}) + " " + ($F{sup_city} == null ? "" : $F{sup_city})) + ($F{sup_vat_id} == null ? "" : " · USt-IdNr. " + $F{sup_vat_id}) + ($F{sup_tax_number} == null ? "" : " · Steuernummer " + $F{sup_tax_number}) + ($F{sup_register} == null ? "" : " · " + $F{sup_register}))]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="37" y="28" width="496" height="10"><printWhenExpression><![CDATA[!"0".equals($P{Show_supplier_footer})]]></printWhenExpression></reportElement><textElement><font size="6"/></textElement><textFieldExpression><![CDATA[(($F{sup_bank_name} == null ? "" : $F{sup_bank_name}) + ($F{sup_iban} == null ? "" : " · IBAN " + $F{sup_iban}) + ($F{sup_bic} == null ? "" : " · BIC " + $F{sup_bic}))]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="37" y="39" width="496" height="11"/><textElement><font size="7"/></textElement><textFieldExpression><![CDATA[$P{Company_footer}]]></textFieldExpression></textField>
 		</band>
 	</pageFooter>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/parameters.json
+++ b/ORDER-JSON-SAMPLE/parameters.json
@@ -38,6 +38,24 @@
       "example": "1"
     },
     {
+      "name": "Show_supplier_footer",
+      "label": {
+        "de": "Absenderangaben in der Fußzeile",
+        "en": "Supplier details in the footer"
+      },
+      "description": {
+        "de": "Druckt Anschrift, USt-IdNr./Steuernummer, Handelsregister und Bankverbindung des Ausstellers in die Fußzeile (§ 14 UStG). Auf \"0\" setzen, wenn auf vorgedrucktem Briefpapier gedruckt wird, das diese Angaben bereits im Fußblock trägt — sonst stehen sie zweimal auf dem Beleg.",
+        "en": "Prints the issuer's address, VAT/tax number, commercial register and bank details in the footer (§ 14 UStG). Set to \"0\" when printing on pre-printed stationery that already carries them in its footer block, otherwise they appear twice on the document."
+      },
+      "role": "variable",
+      "scope": "type",
+      "input": "text",
+      "required": false,
+      "group": "Layout",
+      "default": "1",
+      "example": "1"
+    },
+    {
       "name": "Reportpath",
       "label": {
         "de": "Bundle-Wurzelpfad",

--- a/ORDER-JSON-SAMPLE/subreports/custom-fields.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/custom-fields.jrxml
@@ -8,14 +8,14 @@
   meaning, so a re-configured field renders with its own label without a template
   change. Empty when no custom fields are populated.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="custom-fields" pageWidth="320" pageHeight="842" columnWidth="320" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0303-4d63-9f53-000000000303">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="custom-fields" pageWidth="255" pageHeight="842" columnWidth="255" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0303-4d63-9f53-000000000303">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="8"/>
 	<field name="label" class="java.lang.String"><fieldDescription><![CDATA[label]]></fieldDescription></field>
 	<field name="value" class="java.lang.String"><fieldDescription><![CDATA[value]]></fieldDescription></field>
 	<detail>
 		<band height="12">
-			<textField><reportElement x="0" y="0" width="130" height="11"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[($F{label} == null ? "" : $F{label}) + ":"]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="132" y="0" width="188" height="11"/><textFieldExpression><![CDATA[$F{value}]]></textFieldExpression></textField>
+			<textField><reportElement x="0" y="0" width="110" height="11"/><textElement><font isBold="true"/></textElement><textFieldExpression><![CDATA[($F{label} == null ? "" : $F{label}) + ":"]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="112" y="0" width="143" height="11"/><textFieldExpression><![CDATA[$F{value}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/subreports/positions-delivery.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions-delivery.jrxml
@@ -12,7 +12,7 @@
   einen Sammel-Lieferschein ist das noch wichtiger als fuer die Rechnung — wer
   die Ware annimmt, muss sehen, welche Zeilen zu welchem Auftrag gehoeren.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0304-4d64-9f54-000000000304">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions-delivery" pageWidth="496" pageHeight="842" columnWidth="496" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0304-4d64-9f54-000000000304">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Is_collective" class="java.lang.Boolean">
 		<parameterDescription><![CDATA[true = der Beleg fasst mehrere Auftraege zusammen; nur dann druckt die Gruppenkopfzeile je Quellauftrag. Wird vom Hauptbericht aus collective.is_collective gesetzt.]]></parameterDescription>
@@ -29,18 +29,21 @@
 		<groupHeader>
 			<band height="20">
 				<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{Is_collective})]]></printWhenExpression>
-				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="274" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
-				<textField isBlankWhenNull="true"><reportElement x="274" y="4" width="275" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
-				<line><reportElement x="0" y="18" width="549" height="1"/></line>
+				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="250" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement x="250" y="4" width="246" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
+				<line><reportElement x="0" y="18" width="496" height="1"/></line>
 			</band>
 		</groupHeader>
 	</group>
+	<!-- splitType="Prevent": eine Position wird nicht ueber den Seitenumbruch
+	     zerrissen — auf Briefpapier faellt der abgerissene Beschreibungsrest
+	     direkt unter der Kopflinie der Folgeseite sofort auf. -->
 	<detail>
-		<band height="15">
-			<textField isBlankWhenNull="true"><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="28" y="0" width="360" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##" isBlankWhenNull="true"><reportElement x="388" y="0" width="80" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="478" y="0" width="71" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+		<band height="15" splitType="Prevent">
+			<textField isBlankWhenNull="true"><reportElement x="0" y="0" width="26" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="26" y="0" width="304" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##" isBlankWhenNull="true"><reportElement x="330" y="0" width="70" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="410" y="0" width="86" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/ORDER-JSON-SAMPLE/subreports/positions.jrxml
+++ b/ORDER-JSON-SAMPLE/subreports/positions.jrxml
@@ -23,7 +23,7 @@
   eindeutige Zeilenbezeichner `line_id` (EN 16931 BT-126) wird nicht gedruckt; er
   ist fuer die E-Rechnung da, nicht fuer das Papier.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions" pageWidth="549" pageHeight="842" columnWidth="549" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0301-4d61-9f51-000000000301">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="positions" pageWidth="496" pageHeight="842" columnWidth="496" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d6dcf500-0301-4d61-9f51-000000000301">
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="9"/>
 	<parameter name="Is_collective" class="java.lang.Boolean">
 		<parameterDescription><![CDATA[true = der Beleg fasst mehrere Auftraege zusammen; nur dann druckt die Gruppenkopfzeile je Quellauftrag. Wird vom Hauptbericht aus collective.is_collective gesetzt.]]></parameterDescription>
@@ -49,27 +49,30 @@
 		<groupHeader>
 			<band height="20">
 				<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{Is_collective})]]></printWhenExpression>
-				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="274" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
+				<textField isBlankWhenNull="true"><reportElement x="0" y="4" width="250" height="12"/><textElement><font size="9" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{source_order_number} == null ? "" : ("Auftrag " + $F{source_order_number})]]></textFieldExpression></textField>
 				<!-- Der Warenempfaenger des Quellauftrags: V1 beschriftet seine
 				     Gruppen genau damit ("Lieferung: …"), und das ist der Fall,
 				     fuer den es die Sammelrechnung gibt — ein Rechnungsempfaenger,
 				     mehrere Warenempfaenger. Fehlt er (Contract < 1.7 oder kein
 				     abweichender Lieferkunde), bleibt die Zeile leer. -->
-				<textField isBlankWhenNull="true"><reportElement x="274" y="4" width="275" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
-				<line><reportElement x="0" y="18" width="549" height="1"/></line>
+				<textField isBlankWhenNull="true"><reportElement x="250" y="4" width="246" height="12"/><textElement textAlignment="Right"><font size="8"/></textElement><textFieldExpression><![CDATA[$F{source_order_recipient} == null || $F{source_order_recipient}.trim().isEmpty() ? null : ("Lieferung: " + $F{source_order_recipient})]]></textFieldExpression></textField>
+				<line><reportElement x="0" y="18" width="496" height="1"/></line>
 			</band>
 		</groupHeader>
 	</group>
+	<!-- splitType="Prevent": eine Position wird nicht ueber den Seitenumbruch
+	     zerrissen — auf Briefpapier faellt der abgerissene Beschreibungsrest
+	     direkt unter der Kopflinie der Folgeseite sofort auf. -->
 	<detail>
-		<band height="15">
-			<textField><reportElement x="0" y="0" width="28" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
-			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="28" y="0" width="228" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##"><reportElement x="256" y="0" width="32" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
-			<textField isBlankWhenNull="true"><reportElement x="294" y="0" width="22" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.00 €"><reportElement x="316" y="0" width="70" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{price}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##' %'"><reportElement x="386" y="0" width="45" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.00 €"><reportElement x="431" y="0" width="78" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{line_net}]]></textFieldExpression></textField>
-			<textField pattern="#,##0.##' %'"><reportElement x="509" y="0" width="40" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tax}]]></textFieldExpression></textField>
+		<band height="15" splitType="Prevent">
+			<textField><reportElement x="0" y="0" width="26" height="14"/><textFieldExpression><![CDATA[$F{pos_number}]]></textFieldExpression></textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true"><reportElement x="26" y="0" width="180" height="14"/><textFieldExpression><![CDATA[$F{name}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##"><reportElement x="206" y="0" width="32" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{quantity}]]></textFieldExpression></textField>
+			<textField isBlankWhenNull="true"><reportElement x="242" y="0" width="22" height="14"/><textFieldExpression><![CDATA[$F{unit}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="266" y="0" width="64" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{price}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##' %'"><reportElement x="330" y="0" width="42" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{discount}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.00 €"><reportElement x="372" y="0" width="76" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{line_net}]]></textFieldExpression></textField>
+			<textField pattern="#,##0.##' %'"><reportElement x="448" y="0" width="48" height="14"/><textElement textAlignment="Right"/><textFieldExpression><![CDATA[$F{tax}]]></textFieldExpression></textField>
 		</band>
 	</detail>
 </jasperReport>


### PR DESCRIPTION
Die vier Fensterbriefe standen seit #534 in DIN-Form, aber gemessen gegen ein **leeres Blatt**. Auf vorgedrucktem Briefpapier, das calServer per `ReportOverlayService` unter jeden Beleg legt, traf das an vier Stellen daneben.

## Was kollidiert ist

| Konflikt | Beleg vorher | Typischer Bogen |
|---|---|---|
| Satzspiegel | 29 … 578 pt (10,2 … 204 mm) | 57 … 553 pt (20 … 195 mm) |
| Informationsblock, erste Zeile | 128 pt | Akkreditierungszeile 129 … 137 pt |
| Fußzeile | 778 … 830 pt | Fußblock ab 714 pt |
| Folgeseiten, Oberkante | 12 pt | Kopflinie bis 70 pt |

Kein Randfall, sondern jede Seite: Die Tabelle stand links und rechts über die Trennlinien des Bogens hinaus, „Belegnummer" lag auf der DAkkS-Registriernummer, Absender- und Bankangaben der Fußzeile lagen auf dem Fußblock, der dieselben Angaben schon trug, und auf Folgeseiten lief die Positionstabelle durch das Kopflogo.

## Die Seitenränder tragen die Freizone

`leftMargin=20`, `rightMargin=42`, `topMargin=76`, `bottomMargin=136`; Inhalt bei `x=37 … 533`.

| Zone | Grenze auf dem Blatt |
|---|---|
| Satzspiegel links / rechts | 20 mm / 195 mm |
| Oberkante Folgeseiten | 26,8 mm |
| Oberkante Seite 1 (Anschriftfeld) | 45 mm |
| Unterkante Inhalt | 249 mm |

Ein Rand gilt für **jede** Seite und **jedes** Band. Der bisherige Einzug (`x=12`) hätte in der Fußzeile und auf Folgeseiten einzeln nachgezogen werden müssen, und genau dort war der Fehler.

Das korrigiert die Folgerung aus ADR 2026-10-02 („Die Alternative wäre gewesen, die Seitenränder zu ändern. Sie geht nicht"). Das Argument war richtig, die Folgerung zu kurz: Der Rand muss nur *kleiner als die Falzmarke* sein, nicht klein. `leftMargin=20` lässt die Marken bei 20 … 34 pt stehen und den Inhalt trotzdem erst bei 57 pt beginnen.

`topMargin=76` ist bewusst knapp über der Kopflinie gewählt (26,8 mm), damit das Anschriftfeld für **Form A** weiterhin auf `y=0` gesetzt werden kann. 82 pt wären sicherer gegen hohe Kopfzeilen gewesen und hätten Form A unmöglich gemacht.

## 20 mm links, nicht 24,1 mm

DIN 5008 nennt 24,1 mm. Vorgedrucktes Briefpapier setzt seine Kopf- und Fußlinien fast durchweg auf 20 mm. Bündig unter dem Bogen zu stehen ist der sichtbare Wert; 4 mm DIN-Treue, die den Beleg neben seinen eigenen Bogen schieben, sind keiner. Der Fensterausschnitt bleibt korrekt bedient.

## Zwei Schalter gegen doppelte Angaben

| Parameter | Wirkung | Default |
|---|---|---|
| `Show_supplier_footer` (neu, nur ORDER) | Absender, USt-IdNr./Steuernummer, Handelsregister, Bank in der Fußzeile | `1` |
| `Show_fold_marks` (vorhanden) | Falz- und Lochmarken | `1` |

Beide bleiben auf `1`: Ohne Briefpapier muss der Beleg die Pflichtangaben nach § 14 UStG selbst tragen. Ein stillschweigend weggelassener Absender ist der teurere Fehler als eine doppelte Zeile, die jeder sofort sieht. Wer Briefpapier benutzt, setzt beide Berichtsvariablen einmal auf `0`.

## Nebenbei, aus demselben knapperen Satzspiegel heraus

**Typabhängige Blöcke bekommen eigene Detailbänder.** Ein Band mit falscher `printWhenExpression` kostet keine Höhe. Ein nicht gedrucktes **Element** in einem gemeinsamen Band kostet sie sehr wohl, samt der Verschiebung durch `positionType="Float"` darüber. Daran rutschte die Empfangsbestätigung des Lieferscheins auf eine eigene Seite, obwohl darunter 8 cm frei waren, weil die nicht gedruckten Zahlungsbedingungen der Rechnung ihre Höhe reservierten. Ein `detail`-Abschnitt nimmt mehrere `band`-Elemente — jetzt drei: gemeinsamer Teil, Rechnungsteil, Lieferscheinteil.

**`splitType="Prevent"`** in `positions`/`positions-delivery`: Keine Position wird mehr über den Seitenumbruch zerrissen. Auf Briefpapier fällt ein abgerissener Beschreibungsrest direkt unter der Kopflinie der Folgeseite sofort auf.

## Betroffene Bundles

Alle vier Fensterbriefe: `ORDER-JSON-SAMPLE`, `DELIVERY-JSON-SAMPLE`, `FREE-DELIVERY-JSON-SAMPLE`, `LOCATION-JSON-SAMPLE`. Drei davon zu korrigieren hätte genau die Invariante gebrochen, die ADR 2026-10-02 aufgestellt hat: eine Geometrie, nicht vier.

## Trade-offs

- **Positionstabelle 549 → 496 pt.** Die Spalte „Beschreibung" verliert rund 36 pt. Preis dafür, bündig unter dem Bogen zu stehen; wer die volle Blattbreite braucht, druckt nicht auf Briefpapier und dreht die vier Randzahlen zurück.
- **Seite 1 trägt weniger Positionen.** Satzspiegel 574 statt 754 pt, davon 326 pt Titelband. Folgeseiten tragen die vollen 574 pt.
- **Eine Freizone, nicht beliebige.** JasperReports kann Seitenränder nicht aus einem Parameter beziehen. Ein Bogen mit höherem Kopf oder Fuß braucht eine angepasste Kopie; die READMEs nennen die vier Zahlen und ihre Bedeutung.
- **Kopfzeile wiederholt sich weiter nicht** auf Folgeseiten (außer bei den Abhaklisten von Leihschein und Versandschein). War vorher so, fällt jetzt nur häufiger auf, weil früher umbrochen wird. Eigener Punkt.
- **Bestandslayouts sind nicht betroffen.** Wer sein eigenes Bundle hochgeladen hat, behält es.

## Geprüft

26 Läufe gegen JasperReports mit den Beispieldatensätzen, jeweils geometrisch gegen die Freizone eines realen Bogens verglichen (Kopf bis 137 pt, Kopflinie Folgeseite bis 70 pt, Fußblock ab 714 pt, Spalte 57 … 553 pt):

- ORDER: Angebot, Auftragsbestätigung, Lieferschein, Rechnung, Statusfallback — je mit `Show_supplier_footer` 1 und 0
- ORDER: Sammelrechnung, sowie ein 40-Positionen-Fall über 4 Seiten
- DELIVERY / FREE-DELIVERY / LOCATION: Musterdatensatz und ein 45-Zeilen-Fall, je mit `Show_fold_marks` 1 und 0

Alle 26 ohne Ink außerhalb der Freizone. Repo-Checks (`check_jasper_version.sh`, `check_parameters_manifest.py`, Paket-Manifeste) laufen sauber durch.

Die pixelgenaue Abnahme gegen den report-runner bleibt wie gehabt maßgeblich.

## Dazugehörig

ADR und Admin-Doku in [calhelp/calServer-yii#3913](https://github.com/calhelp/calServer-yii/pull/3913).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQxkNBJfZnaWJbHzHSVXiR