### PR TITLE
fix(sticker): DAkkS-Aufkleber folgen der Kalibriermarke statt einem gekippten Raster

### DIFF
--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/README.md
@@ -8,13 +8,32 @@ V2-Nachbildung des **DAkkS-Kalibrieraufklebers 12 mm** (Phase C). Micro-Label
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/dakks-aufkleber-12mm-json-sample.jrxml` | Micro-Label: Rahmen (Line-Art), „DAkkS", Akkreditierungs-Markennummer, Kalibrierdatum. Kein QR, keine Variablen |
+| `main_reports/dakks-aufkleber-12mm-json-sample.jrxml` | Micro-Label: Rahmen mit drei Feldern — Kalibrierzeichen (zwei Zeilen), Kalibriermonat. Kein QR, keine Variablen |
 | `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.1, minimal) |
 | `main_reports/dakks-aufkleber-12mm-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
+## Gestaltung
+
+Gleiche Anatomie wie das 18-mm-Etikett, ein Feld kürzer: geschlossener Rahmen,
+darin die Registrierdaten der Kalibrierung (*Kalibrierzeichen*) und der
+Kalibriermonat — das Minimum, das die DAkkS-Kalibriermarke verlangt. Das Datum
+der nächsten Kalibrierung ist bei der DAkkS optional und passt auf 12 mm nicht
+mehr; wer es braucht, nimmt das 18-mm-Bundle.
+
+**Die Gewährleistungsmarke selbst zeichnet die Vorlage bewusst nicht.** Sie ist
+ein geschütztes Bild, das ein akkreditiertes Labor von der DAkkS erhält und
+selbst auf das Etikett setzt.
+
+Das Kalibrierdatum wird als **Jahr-Monat** gedruckt (`2026-06`), so wie es die
+DAkkS-Marke vorsieht. **Ohne Akkreditierung** trägt die obere Zone die
+**Schein-Nr.** (`calibration.certificate_display`) statt eines leeren Kastens.
+Leere Werte drucken leer, nie `null`.
+
 ## Felder
 
-`accreditation.mark_number_1` (+ `mark_number_2`), `calibration.calibration_date`.
+`accreditation.mark_number_1` (+ `mark_number_2`) — dieselben zwei Werte, die der
+Kalibrierschein in seinem Kalibrierzeichen-Block druckt. Dazu
+`calibration.calibration_date` und `calibration.certificate_display`.
 Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
 
 ## Systembericht-Platzhalter und Stapeldruck (ab calServer V2)

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/dakks-aufkleber-12mm-json-sample.jrxml
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/dakks-aufkleber-12mm-json-sample.jrxml
@@ -2,27 +2,93 @@
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
   V2 DAkkS calibration label 12 mm (ADR-009, contract "calibration-certificate"
-  v1.1). Filled from a JSON data source — NO SQL. Reproduces the V1
-  DAKKS-Aufkleber_12mm micro-label (34x47 pt ≈ 12x16.6 mm) against readable
-  api_name fields: accreditation.mark_number_1/_2 + calibration.calibration_date.
-  No QR, no report-level variables. See main_reports/sample-data.json.
+  v1.1). Filled from a JSON data source — NO SQL.
+
+  Same anatomy as the 18 mm label, one field short: a closed frame divided into
+  the registration data of the calibration ("Kalibrierzeichen") and the month of
+  calibration — the minimum the DAkkS calibration label asks for. The next
+  calibration date is optional on a DAkkS label and does not fit on 12 mm; use
+  the 18 mm bundle when it is wanted. The DAkkS warranty mark
+  (Gewährleistungsmarke) is deliberately NOT drawn: it is a protected image an
+  accredited laboratory receives from the DAkkS and places itself.
+
+  34x47 pt = 12x16,6 mm. Fields: accreditation.mark_number_1 / mark_number_2
+  (report variables — the same two values the certificate prints in its
+  Kalibrierzeichen block), calibration.calibration_date (ISO Y-m-d, printed as
+  Y-m the way the DAkkS label does) and calibration.certificate_display, which
+  fills the mark zone when no accreditation is configured. Empty values print
+  empty, never "null". See main_reports/sample-data.json.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-12mm-json-sample" pageWidth="34" pageHeight="47" columnWidth="34" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0210-4c40-9e30-000000000210">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-12mm-json-sample" pageWidth="34" pageHeight="47" orientation="Portrait" columnWidth="34" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0210-4c40-9e30-000000000210">
 	<property name="com.jaspersoft.studio.data.defadapter" value="dakks-aufkleber-12mm-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="4"/>
 	<field name="mark_number_1" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_1]]></fieldDescription></field>
 	<field name="mark_number_2" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_2]]></fieldDescription></field>
 	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
+	<field name="certificate" class="java.lang.String"><fieldDescription><![CDATA[calibration.certificate_display]]></fieldDescription></field>
 	<detail>
-		<band height="47">
-			<line><reportElement x="1" y="1" width="32" height="1"/></line>
-			<line><reportElement x="1" y="46" width="32" height="1"/></line>
-			<line><reportElement x="1" y="1" width="1" height="45"/></line>
-			<line><reportElement x="33" y="1" width="1" height="45"/></line>
-			<staticText><reportElement x="2" y="3" width="30" height="6"/><textElement textAlignment="Center"><font size="5" isBold="true"/></textElement><text><![CDATA[DAkkS]]></text></staticText>
-			<textField><reportElement x="2" y="11" width="30" height="12"/><textElement textAlignment="Center"><font size="4"/></textElement><textFieldExpression><![CDATA[$F{mark_number_1}]]></textFieldExpression></textField>
-			<staticText><reportElement x="2" y="26" width="30" height="6"/><textElement textAlignment="Center"><font size="4"/></textElement><text><![CDATA[Kalibriert:]]></text></staticText>
-			<textField><reportElement x="2" y="33" width="30" height="8"/><textElement textAlignment="Center"><font size="5" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression></textField>
+		<band height="47" splitType="Prevent">
+			<rectangle>
+				<reportElement x="1" y="1" width="32" height="45" uuid="c4cae300-0210-4c40-9e30-000000000301"/>
+				<graphicElement><pen lineWidth="1.0" lineStyle="Solid"/></graphicElement>
+			</rectangle>
+			<line>
+				<reportElement x="1" y="15" width="32" height="1" uuid="c4cae300-0210-4c40-9e30-000000000302"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="1" y="31" width="32" height="1" uuid="c4cae300-0210-4c40-9e30-000000000303"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<!-- Registration data of the calibration (Kalibrierzeichen). -->
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="2" y="3" width="30" height="11" uuid="c4cae300-0210-4c40-9e30-000000000304">
+					<printWhenExpression><![CDATA[($F{mark_number_1} != null && !$F{mark_number_1}.trim().isEmpty())
+    || ($F{mark_number_2} != null && !$F{mark_number_2}.trim().isEmpty())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="6"/></textElement>
+				<textFieldExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    ? ""
+    : $F{mark_number_1}.trim().split("\\s+")[0]]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="2" y="16" width="30" height="14" uuid="c4cae300-0210-4c40-9e30-000000000305">
+					<printWhenExpression><![CDATA[($F{mark_number_1} != null && !$F{mark_number_1}.trim().isEmpty())
+    || ($F{mark_number_2} != null && !$F{mark_number_2}.trim().isEmpty())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="7" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{mark_number_2} == null
+    ? ""
+    : $F{mark_number_2}.replace("/n", "\n").replace("\\n", "\n").trim()]]></textFieldExpression>
+			</textField>
+			<!-- No accreditation configured: the certificate number takes the zone,
+			     captioned as what it is rather than posing as a mark. -->
+			<staticText>
+				<reportElement x="2" y="3" width="30" height="11" uuid="c4cae300-0210-4c40-9e30-000000000306">
+					<printWhenExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    && ($F{mark_number_2} == null || $F{mark_number_2}.trim().isEmpty())
+    && $F{certificate} != null && !$F{certificate}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Schein-Nr.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="2" y="16" width="30" height="14" uuid="c4cae300-0210-4c40-9e30-000000000307">
+					<printWhenExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    && ($F{mark_number_2} == null || $F{mark_number_2}.trim().isEmpty())
+    && $F{certificate} != null && !$F{certificate}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="7" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{certificate} == null ? "" : $F{certificate}.trim()]]></textFieldExpression>
+			</textField>
+			<!-- Month of calibration — the date field the DAkkS label requires. -->
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="2" y="32" width="30" height="14" uuid="c4cae300-0210-4c40-9e30-000000000308"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[($F{cal_date} == null || $F{cal_date}.trim().length() < 7)
+    ? ""
+    : $F{cal_date}.trim().substring(0, 7)]]></textFieldExpression>
+			</textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-DAKKS-12MM-JSON-SAMPLE/main_reports/sample-data.json
@@ -7,11 +7,12 @@
     "certificate_number": "DAkkS-K-2026-0042"
   },
   "accreditation": {
-    "mark_number_1": "D-K-12345-01-00",
-    "mark_number_2": "Deutsche Akkreditierungsstelle",
-    "calibration_mark": "DAkkS-K-12345"
+    "mark_number_1": "123456",
+    "mark_number_2": "D-K-\n15208-01-00",
+    "calibration_mark": "DAkkS-K-0815"
   },
   "calibration": {
+    "certificate_display": "K-2026-0042",
     "calibration_date": "2026-06-30",
     "next_calibration_date": "2027-06-30"
   },

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/README.md
@@ -1,21 +1,45 @@
 # STICKER-DAKKS-18MM-JSON-SAMPLE — DAkkS-Aufkleber 18 mm (V2 / APEX)
 
 V2-Nachbildung des **DAkkS-Kalibrieraufklebers 18 mm** (Phase C). Label 51×70 pt
-Landscape (≈ 18×24,7 mm), gefüllt aus einem **JSON-Datensatz** (Contract
+Hochformat (≈ 18×24,7 mm), gefüllt aus einem **JSON-Datensatz** (Contract
 `calibration-certificate` v1.1) statt aus SQL — DB-agnostisch, keine V1-Codespalten.
 
 ## Aufbau
 
 | Datei | Zweck |
 |-------|-------|
-| `main_reports/dakks-aufkleber-18mm-json-sample.jrxml` | Label: Rahmen (Line-Art), „DAkkS", Akkreditierungs-Markennummer, Kalibrier- + nächstes Datum. Kein QR, keine Variablen |
+| `main_reports/dakks-aufkleber-18mm-json-sample.jrxml` | Label: Rahmen mit drei Feldern — Kalibrierzeichen, Kalibriermonat, nächster Monat. Kein QR, keine Variablen |
 | `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.1, minimal) |
 | `main_reports/dakks-aufkleber-18mm-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
 
+## Gestaltung
+
+Der Aufkleber folgt der **DAkkS-Kalibriermarke**: ein geschlossener Rahmen, darin
+gestapelte Felder — oben die Registrierdaten der Kalibrierung
+(*Kalibrierzeichen*), darunter der Kalibriermonat, unten der nächste Termin.
+
+**Die Gewährleistungsmarke selbst zeichnet die Vorlage bewusst nicht.** Sie ist
+ein geschütztes Bild, das ein akkreditiertes Labor von der DAkkS erhält und
+selbst auf das Etikett setzt; eine Vorlage darf sie nicht nachbilden. Alles
+andere auf dem Etikett sind Kundendaten.
+
+Datumsfelder werden als **Jahr-Monat** gedruckt (`2026-06`), so wie es die
+DAkkS-Marke vorsieht — nicht als Tagesdatum. Der Rahmen ist Pflicht: die Marke
+darf laut Markenordnung nur innerhalb des Kalibrieretiketts verwendet werden.
+
+**Ohne Akkreditierung** stünde das obere Feld leer. Dann trägt dieselbe Zone die
+**Schein-Nr.** (`calibration.certificate_display`) — beschriftet als das, was sie
+ist, nie als Marke getarnt. Leere Werte drucken leer, nie `null`.
+
 ## Felder
 
-`accreditation.mark_number_1` (+ `mark_number_2`), `calibration.calibration_date`,
-`calibration.next_calibration_date`. Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
+`accreditation.mark_number_1` (+ `mark_number_2`) — dieselben zwei Werte, die der
+Kalibrierschein in seinem Kalibrierzeichen-Block druckt: `mark_number_1` die
+erste Kennziffer (z. B. Auftragsnummer), `mark_number_2` das mehrzeilige
+DAkkS-Kalibrierzeichen (`D-K-\nYYYYY-ZZ-N`). Dazu
+`calibration.calibration_date`, `calibration.next_calibration_date` und
+`calibration.certificate_display`. Dataset-Builder: Laravel
+`CalibrationReportDataBuilder`.
 
 ## Systembericht-Platzhalter und Stapeldruck (ab calServer V2)
 

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/dakks-aufkleber-18mm-json-sample.jrxml
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/dakks-aufkleber-18mm-json-sample.jrxml
@@ -2,30 +2,120 @@
 <!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
 <!--
   V2 DAkkS calibration label 18 mm (ADR-009, contract "calibration-certificate"
-  v1.1). Filled from a JSON data source — NO SQL. Reproduces the V1
-  DAKKS-Aufkleber_18mm label (51x70 pt Landscape ≈ 18x24.7 mm) against readable
-  api_name fields: accreditation.mark_number_1/_2 + calibration.calibration_date
-  (+ next). No QR, no report-level variables. See main_reports/sample-data.json.
+  v1.1). Filled from a JSON data source — NO SQL.
+
+  Layout follows the DAkkS calibration label (Kalibriermarke): one closed frame
+  divided into stacked fields — the registration data of the calibration
+  ("Kalibrierzeichen") on top, the month of calibration below it, the optional
+  next-calibration month at the bottom. The DAkkS warranty mark
+  (Gewährleistungsmarke) itself is deliberately NOT drawn: it is a protected
+  image an accredited laboratory receives from the DAkkS and places itself, and
+  a template must not fake it. Everything else on the label is customer data.
+
+  51x70 pt Portrait = 18x24,7 mm. Fields: accreditation.mark_number_1 /
+  mark_number_2 (report variables — the same two values the certificate prints
+  in its Kalibrierzeichen block), calibration.calibration_date /
+  next_calibration_date (ISO Y-m-d, printed as Y-m the way the DAkkS label
+  does) and calibration.certificate_display.
+
+  Without accreditation the mark block would be an empty box, so the same zone
+  then carries the certificate number instead — captioned as what it is, never
+  dressed up as a mark. Empty values print empty, never "null".
+  See main_reports/sample-data.json.
 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-18mm-json-sample" pageWidth="51" pageHeight="70" orientation="Landscape" columnWidth="51" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0211-4c41-9e31-000000000211">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-18mm-json-sample" pageWidth="51" pageHeight="70" orientation="Portrait" columnWidth="51" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0211-4c41-9e31-000000000211">
 	<property name="com.jaspersoft.studio.data.defadapter" value="dakks-aufkleber-18mm-json-sample_adapter.xml"/>
 	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="5"/>
 	<field name="mark_number_1" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_1]]></fieldDescription></field>
 	<field name="mark_number_2" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_2]]></fieldDescription></field>
 	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
 	<field name="next_cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription></field>
+	<field name="certificate" class="java.lang.String"><fieldDescription><![CDATA[calibration.certificate_display]]></fieldDescription></field>
 	<detail>
-		<band height="51">
-			<line><reportElement x="1" y="1" width="68" height="1"/></line>
-			<line><reportElement x="1" y="50" width="68" height="1"/></line>
-			<line><reportElement x="1" y="1" width="1" height="49"/></line>
-			<line><reportElement x="69" y="1" width="1" height="49"/></line>
-			<staticText><reportElement x="3" y="3" width="64" height="9"/><textElement textAlignment="Center"><font size="8" isBold="true"/></textElement><text><![CDATA[DAkkS]]></text></staticText>
-			<textField><reportElement x="3" y="13" width="64" height="8"/><textElement textAlignment="Center"><font size="5"/></textElement><textFieldExpression><![CDATA[$F{mark_number_1}]]></textFieldExpression></textField>
-			<staticText><reportElement x="3" y="24" width="30" height="7"/><textElement><font size="5"/></textElement><text><![CDATA[Kalibriert:]]></text></staticText>
-			<textField><reportElement x="33" y="24" width="34" height="7"/><textElement textAlignment="Right"><font size="6" isBold="true"/></textElement><textFieldExpression><![CDATA[$F{cal_date}]]></textFieldExpression></textField>
-			<staticText><reportElement x="3" y="33" width="30" height="7"/><textElement><font size="5"/></textElement><text><![CDATA[Nächste:]]></text></staticText>
-			<textField><reportElement x="33" y="33" width="34" height="7"/><textElement textAlignment="Right"><font size="6"/></textElement><textFieldExpression><![CDATA[$F{next_cal_date}]]></textFieldExpression></textField>
+		<band height="70" splitType="Prevent">
+			<!-- Frame of the calibration label. The DAkkS mark may be used only
+			     inside such a frame; the frame is what makes this a
+			     Kalibrieretikett rather than a loose date. -->
+			<rectangle>
+				<reportElement x="1" y="1" width="49" height="68" uuid="c4cae300-0211-4c41-9e31-000000000301"/>
+				<graphicElement><pen lineWidth="1.0" lineStyle="Solid"/></graphicElement>
+			</rectangle>
+			<line>
+				<reportElement x="1" y="30" width="49" height="1" uuid="c4cae300-0211-4c41-9e31-000000000302"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="1" y="50" width="49" height="1" uuid="c4cae300-0211-4c41-9e31-000000000303"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<!-- Registration data of the calibration (Kalibrierzeichen) — the two
+			     values the certificate prints next to the mark. -->
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="3" y="4" width="45" height="9" uuid="c4cae300-0211-4c41-9e31-000000000304">
+					<printWhenExpression><![CDATA[($F{mark_number_1} != null && !$F{mark_number_1}.trim().isEmpty())
+    || ($F{mark_number_2} != null && !$F{mark_number_2}.trim().isEmpty())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="6"/></textElement>
+				<textFieldExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    ? ""
+    : $F{mark_number_1}.trim().split("\\s+")[0]]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="3" y="13" width="45" height="16" uuid="c4cae300-0211-4c41-9e31-000000000305">
+					<printWhenExpression><![CDATA[($F{mark_number_1} != null && !$F{mark_number_1}.trim().isEmpty())
+    || ($F{mark_number_2} != null && !$F{mark_number_2}.trim().isEmpty())]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{mark_number_2} == null
+    ? ""
+    : $F{mark_number_2}.replace("/n", "\n").replace("\\n", "\n").trim()]]></textFieldExpression>
+			</textField>
+			<!-- No accreditation configured: the same zone carries the certificate
+			     number, captioned as a certificate number. -->
+			<staticText>
+				<reportElement x="3" y="5" width="45" height="7" uuid="c4cae300-0211-4c41-9e31-00000000030a">
+					<printWhenExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    && ($F{mark_number_2} == null || $F{mark_number_2}.trim().isEmpty())
+    && $F{certificate} != null && !$F{certificate}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Schein-Nr.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="3" y="13" width="45" height="15" uuid="c4cae300-0211-4c41-9e31-00000000030b">
+					<printWhenExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    && ($F{mark_number_2} == null || $F{mark_number_2}.trim().isEmpty())
+    && $F{certificate} != null && !$F{certificate}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{certificate} == null ? "" : $F{certificate}.trim()]]></textFieldExpression>
+			</textField>
+			<!-- Month of calibration — the one date field the DAkkS label requires. -->
+			<staticText>
+				<reportElement x="3" y="31" width="45" height="6" uuid="c4cae300-0211-4c41-9e31-000000000306"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Kalibriert]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="3" y="37" width="45" height="12" uuid="c4cae300-0211-4c41-9e31-000000000307"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="9" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[($F{cal_date} == null || $F{cal_date}.trim().length() < 7)
+    ? ""
+    : $F{cal_date}.trim().substring(0, 7)]]></textFieldExpression>
+			</textField>
+			<!-- Next calibration — optional on the DAkkS label, standard here. -->
+			<staticText>
+				<reportElement x="3" y="51" width="45" height="6" uuid="c4cae300-0211-4c41-9e31-000000000308"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Nächste]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="3" y="57" width="45" height="12" uuid="c4cae300-0211-4c41-9e31-000000000309"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="9"/></textElement>
+				<textFieldExpression><![CDATA[($F{next_cal_date} == null || $F{next_cal_date}.trim().length() < 7)
+    ? ""
+    : $F{next_cal_date}.trim().substring(0, 7)]]></textFieldExpression>
+			</textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports/sample-data.json
@@ -7,11 +7,12 @@
     "certificate_number": "DAkkS-K-2026-0042"
   },
   "accreditation": {
-    "mark_number_1": "D-K-12345-01-00",
-    "mark_number_2": "Deutsche Akkreditierungsstelle",
-    "calibration_mark": "DAkkS-K-12345"
+    "mark_number_1": "123456",
+    "mark_number_2": "D-K-\n15208-01-00",
+    "calibration_mark": "DAkkS-K-0815"
   },
   "calibration": {
+    "certificate_display": "K-2026-0042",
     "calibration_date": "2026-06-30",
     "next_calibration_date": "2027-06-30"
   },


### PR DESCRIPTION
## Problem

Der 18-mm-Kalibrieraufkleber war für Querformat gezeichnet, lag aber auf einer Hochformat-Seite (51×70 pt). Folge im Druck und in der Vorschau: alles rechts von 51 pt abgeschnitten, das untere Seitendrittel leer, Datumswerte auf `2026` und `202` gestutzt — und im Kalibrierzeichen-Feld stand `null`, sobald ein Mandant seine Markennummern nicht gesetzt hatte.

Dazu zwei inhaltliche Fehler: die Vorlagen lasen nur `mark_number_1`, und in den Beispieldaten waren `mark_number_1` und `mark_number_2` gegenüber Kalibrierschein und V1-Vorlage vertauscht.

## Änderung

Beide Aufkleber folgen jetzt der Anatomie der **DAkkS-Kalibriermarke**: ein geschlossener Rahmen, darin gestapelte Felder — oben die Registrierdaten der Kalibrierung (*Kalibrierzeichen*), darunter der Kalibriermonat, beim 18-mm-Etikett zusätzlich der nächste Termin.

Die **Gewährleistungsmarke selbst zeichnet keine Vorlage**. Sie ist ein geschütztes Bild, das ein akkreditiertes Labor von der DAkkS erhält und selbst auf das Etikett setzt; eine Vorlage darf sie nicht nachbilden. Der Rahmen bleibt, weil die Markenordnung die Marke nur innerhalb des Kalibrieretiketts erlaubt.

Weiter:

- `mark_number_1`/`_2` tragen dieselbe Bedeutung wie im Kalibrierschein: erste Kennziffer (z. B. Auftragsnummer) und mehrzeiliges `D-K-`-Zeichen, inklusive `\n`-Auflösung wie im Zertifikat.
- Datumsfelder drucken **Jahr-Monat** (`2026-06`), wie es die Marke vorsieht und wie es die V1-Vorlage tat.
- **Ohne Akkreditierung** trägt die obere Zone die *Schein-Nr.* (`calibration.certificate_display`) statt eines leeren Kastens — beschriftet als das, was sie ist, nie als Marke getarnt.
- Leere Werte drucken leer, nie `null`; überlange Werte skalieren (`ScaleFont`) statt überzulaufen.
- READMEs und Beispieldaten ziehen nach.

## Trade-offs

- **Jahr-Monat statt Tagesdatum**: entspricht der DAkkS-Marke und V1, kostet aber die Tagesgenauigkeit auf dem Aufkleber. Wer sie braucht, ändert eine Zeile in der eigenen Kopie der Vorlage.
- **Schein-Nr. als Ersatzinhalt**: fügt der Vorlage zwei bedingte Elemente je Zone hinzu. Die Alternative — ein leerer Kasten auf jeder nicht akkreditierten Installation — ist die schlechtere Vorgabe, gerade weil dieses Bundle am Systembericht-Platzhalter *Kalibrieraufkleber* hängt.
- **12 mm ohne nächsten Termin**: bei der DAkkS optional, auf 12 mm nicht lesbar unterzubringen. Das 18-mm-Bundle deckt den Fall ab.

## Prüfung

Gegen **JasperReports 6.21.5** gerendert, die Version des `report-runner`:

- Einzeldruck 18 mm und 12 mm gegen `sample-data.json` — 51×70 bzw. 34×47 pt, nichts abgeschnitten.
- Stapeldruck über `dataSelect=stickers` — drei Datensätze, drei Seiten, Einzelvorlage unverändert brauchbar.
- Grenzfälle: ohne Markennummern (Schein-Nr. greift), ohne Markennummern und ohne Schein-Nr. (Zone bleibt leer, kein `null`), ohne Kalibrierdatum, mit überlangen Werten (`K-2026-000123 Rev2`, `D-K-15208-01-00` einzeilig).
- `scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` laufen sauber durch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qtkn6dkBYSxzsTSMZt8yEP)_