### PR TITLE
feat(sticker): DAkkS-Aufkleber 40×30 mm mit QR-Deep-Link auf die Geräteseite

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -209,6 +209,13 @@ jobs:
           path: STICKER-DAKKS-18MM-JSON-SAMPLE/main_reports
           if-no-files-found: error
 
+      - name: Upload STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE
+          path: STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
       - name: Upload STICKER-CAL-INV-ZEBRA-JSON-SAMPLE as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -619,6 +626,7 @@ jobs:
           create_zip "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
           create_zip "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
+          create_zip "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE" "sticker-dakks-40x30mm-qr-json-sample"
           create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
           create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
           create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -105,6 +105,7 @@ jobs:
           get_last_modified "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
           get_last_modified "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           get_last_modified "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
+          get_last_modified "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE" "sticker-dakks-40x30mm-qr-json-sample"
           get_last_modified "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
           get_last_modified "ORDER-JSON-SAMPLE" "order-json-sample"
           get_last_modified "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
@@ -222,6 +223,7 @@ jobs:
               "kalibrierkontrollblatt-json-sample": "KALIBRIERKONTROLLBLATT-JSON-SAMPLE/README.md",
               "sticker-dakks-12mm-json-sample":     "STICKER-DAKKS-12MM-JSON-SAMPLE/README.md",
               "sticker-dakks-18mm-json-sample":     "STICKER-DAKKS-18MM-JSON-SAMPLE/README.md",
+              "sticker-dakks-40x30mm-qr-json-sample": "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/README.md",
               "sticker-cal-inv-zebra-json-sample":  "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md",
               "order-json-sample":                  "ORDER-JSON-SAMPLE/README.md",
               "delivery-json-sample":               "DELIVERY-JSON-SAMPLE/README.md",
@@ -268,6 +270,7 @@ jobs:
               "kalibrierkontrollblatt-json-sample": "Kalibrierkontrollblatt",
               "sticker-dakks-12mm-json-sample":     "DAkkS-Aufkleber 12 mm",
               "sticker-dakks-18mm-json-sample":     "DAkkS-Aufkleber 18 mm",
+              "sticker-dakks-40x30mm-qr-json-sample": "DAkkS-Aufkleber 40×30 mm mit QR",
               "sticker-cal-inv-zebra-json-sample":  "Zebra Inventar-/Kalibrier-Sticker",
               "order-json-sample":                  "Auftragsbeleg",
               "delivery-json-sample":               "Lieferschein",

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -130,6 +130,7 @@ jobs:
           create_zip "KALIBRIERKONTROLLBLATT-JSON-SAMPLE" "kalibrierkontrollblatt-json-sample"
           create_zip "STICKER-DAKKS-12MM-JSON-SAMPLE" "sticker-dakks-12mm-json-sample"
           create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
+          create_zip "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE" "sticker-dakks-40x30mm-qr-json-sample"
           create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
           create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
           create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"

--- a/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/README.md
@@ -1,0 +1,110 @@
+# STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE — DAkkS-Aufkleber 40×30 mm mit QR (V2 / APEX)
+
+DAkkS-Kalibrieraufkleber **40×30 mm** (113×85 pt) mit **QR-Deep-Link auf die
+Geräteseite**, gefüllt aus einem **JSON-Datensatz** (Contract
+`calibration-certificate` **v1.6**) statt aus SQL — DB-agnostisch, keine
+V1-Codespalten.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/dakks-aufkleber-40x30mm-qr-json-sample.jrxml` | Etikett: Rahmen, links Kalibrierzeichen + Kalibrier-/Folgemonat, rechts QR und lesbare Nummer |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `calibration-certificate` v1.6) |
+| `main_reports/dakks-aufkleber-40x30mm-qr-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Gestaltung
+
+Dieselbe Anatomie wie die 12- und 18-mm-Bundles — geschlossener Rahmen, darin
+oben die Registrierdaten der Kalibrierung (*Kalibrierzeichen*), darunter der
+Kalibriermonat, unten der nächste Termin — plus den QR, den die
+DAkkS-Kalibriermarke als optionales Element zulässt.
+
+**Die Gewährleistungsmarke selbst zeichnet die Vorlage bewusst nicht.** Sie ist
+ein geschütztes Bild, das ein akkreditiertes Labor von der DAkkS erhält und
+selbst auf das Etikett setzt.
+
+Datumsfelder drucken **Jahr-Monat** (`2026-06`), wie in den kleineren Bundles.
+**Ohne Akkreditierung** trägt die obere Zone die **Schein-Nr.**
+(`calibration.certificate_display`) statt eines leeren Kastens. Leere Werte
+drucken leer, nie `null`.
+
+## Der QR
+
+Der QR codiert `qr.url` — den öffentlichen Deep-Link auf die Geräteseite der
+**QR-Code-Rolle** (`/v2/qr/{uuid}`). Scannen führt ohne Anmeldung auf
+Stammdaten, Kalibrierstatus und Dokumente des Geräts.
+
+**Voraussetzung:** QR-Links müssen eingeschaltet sein (QR-Code-Rolle mit
+`qrlink_enable` und ein öffentlicher Benutzer). Sind sie aus, liefert der
+Datensatz `qr.url = null` — dann codiert derselbe QR den konfigurierten
+Barcode-Wert (`barcode.value`, sonst `device.asset_number`), und die
+Beschriftung wechselt von *Gerät scannen* auf *Inventar-Nr.* Ein leeres weisses
+Quadrat wäre die schlechtere Vorgabe.
+
+Der Link steht **je Datensatz im Dokument**. Der alte V1-Jasper-Parameter
+`QR_Code_Value` gilt je Druckauftrag — im Stapeldruck zeigten damit alle vierzig
+Aufkleber auf dasselbe Gerät.
+
+### Warum 40×30 mm und nicht 18 mm
+
+Die Etikettengrösse folgt aus der URL-Länge, nicht aus Geschmack:
+
+| Grösse | Wert |
+|--------|------|
+| Deep-Link mit uuid | ~74 Zeichen |
+| QR-Version bei Fehlerkorrektur M | 5 (37×37 Module) |
+| Modulraster inkl. Ruhezone | ~45 Module |
+| QR-Feld in der Vorlage | 50×50 pt = 17,6 mm |
+| Modulgrösse auf Papier | **0,39 mm = 3,1 Punkte bei 203 dpi** |
+
+Drei Punkte je Modul ist die Grenze, ab der ein Thermodrucker mit 203 dpi
+zuverlässig lesbare Symbole liefert. Auf einem 18-mm-DAkkS-Etikett bliebe neben
+17,6 mm QR nichts mehr für Kalibrierzeichen und Datum — deshalb dieses Bundle
+statt einer Quetschung. **Wer das QR-Feld verkleinert, macht den Aufkleber
+unscannbar.**
+
+Die Fehlerkorrektur steht auf **M (15 %)**, nicht auf der Jasper-Vorgabe L
+(7 %): ein Aufkleber lebt am Gerät und sammelt Kratzer, Öl und angehobene Ecken.
+Für rauhe Umgebungen genügt ein `errorCorrectionLevel="Q"` im JRXML — das kostet
+vier weitere Module (Version 6), also 0,35 mm je Modul und 2,8 Punkte; auf
+300-dpi-Druckern unkritisch, auf 203 dpi grenzwertig.
+
+## Felder
+
+`accreditation.mark_number_1` (+ `mark_number_2`) — dieselben zwei Werte, die
+der Kalibrierschein in seinem Kalibrierzeichen-Block druckt. Dazu
+`calibration.calibration_date`, `calibration.next_calibration_date`,
+`calibration.certificate_display`, `qr.url`, `barcode.value` und
+`device.asset_number`. Dataset-Builder: Laravel `CalibrationReportDataBuilder`.
+
+## Systembericht-Platzhalter und Stapeldruck
+
+Dieses Bundle gehört auf den Platzhalter **Kalibrieraufkleber** in
+**Administration > Berichtsverwaltung** (Grid `calibration`/Ordner
+`calibrations`) — dieselbe Zeile, auf der sonst das 12- oder 18-mm-Bundle liegt.
+Der Platzhalter ist ab Werk da, trägt das Kennzeichen *Systembericht* und ist
+als Etikett markiert; das ist, was **„Etikett drucken"** an die Grid-Zeile hängt.
+
+Der Contract wird am Bundle erkannt; eine Report-Variable `data_contract` ist
+auf dem Platzhalter **nicht nötig** (der Grid-Standard ist bereits
+`calibration-certificate`).
+
+**Stapeldruck.** Werden im Grid mehrere Zeilen markiert, druckt calServer sie in
+*einem* Lauf in eine PDF:
+
+```json
+{ "meta": { "count": 40 }, "stickers": [ <dokument>, <dokument>, … ] }
+```
+
+Jedes Element ist ein **vollständiges Dokument** in der Form, die
+`sample-data.json` zeigt — deshalb trägt jeder Aufkleber im Stapel seinen
+eigenen QR. **Es ist keine Stapel-Fassung der Vorlage nötig und keine
+gewünscht**: Wer hier auf ein Array umbaut, bricht den Einzeldruck.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle rendert das Etikett leer. Vorschau: mitgelieferter Adapter
+(Default über `com.jaspersoft.studio.data.defadapter`) → „Open → Preview". Live
+(calServer V2): Report-Setting-Variable `data_contract = calibration-certificate`.
+JasperReports **6.20.6** verbindlich.

--- a/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/dakks-aufkleber-40x30mm-qr-json-sample.jrxml
+++ b/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/dakks-aufkleber-40x30mm-qr-json-sample.jrxml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 DAkkS calibration label 40x30 mm with QR deep link (ADR-009, contract
+  "calibration-certificate" v1.6). Filled from a JSON data source — NO SQL.
+
+  Same anatomy as the 12/18 mm DAkkS labels — a closed frame with the
+  registration data of the calibration ("Kalibrierzeichen") on top, the month of
+  calibration below it, the next month at the bottom — plus the QR the DAkkS
+  calibration label allows as an optional element. The DAkkS warranty mark
+  (Gewährleistungsmarke) itself is deliberately NOT drawn: it is a protected
+  image an accredited laboratory receives from the DAkkS and places itself.
+
+  WHY THIS SIZE. The QR carries `qr.url`, the public deep link onto the device
+  page of the QR code role (`/v2/qr/{uuid}`) — around 74 characters, so QR
+  version 5 with 37 modules. Printed on the house 203 dpi label printer at three
+  dots per module, the symbol needs ~17 mm; the 50x50 pt square below is 17,6 mm.
+  That is why this bundle exists instead of squeezing a QR onto 18 mm, where
+  nothing would be left for the DAkkS fields.
+
+  Without a deep link (QR links switched off) the same square carries the
+  tenant's configured barcode value instead of an empty white box — a plain
+  inventory QR, which is what the readable number underneath names either way.
+
+  113x85 pt = 39,9x30 mm. See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="dakks-aufkleber-40x30mm-qr-json-sample" pageWidth="113" pageHeight="85" orientation="Portrait" columnWidth="113" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c4cae300-0212-4c42-9e32-000000000212">
+	<property name="com.jaspersoft.studio.data.defadapter" value="dakks-aufkleber-40x30mm-qr-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="5"/>
+	<field name="mark_number_1" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_1]]></fieldDescription></field>
+	<field name="mark_number_2" class="java.lang.String"><fieldDescription><![CDATA[accreditation.mark_number_2]]></fieldDescription></field>
+	<field name="cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.calibration_date]]></fieldDescription></field>
+	<field name="next_cal_date" class="java.lang.String"><fieldDescription><![CDATA[calibration.next_calibration_date]]></fieldDescription></field>
+	<field name="certificate" class="java.lang.String"><fieldDescription><![CDATA[calibration.certificate_display]]></fieldDescription></field>
+	<!-- Der Deep-Link auf die Geräteseite der QR-Code-Rolle. Steht je Datensatz
+	     im Dokument, damit ein Stapel von vierzig Aufklebern vierzig Geräte
+	     trifft und nicht vierzigmal dasselbe. null, solange die QR-Links
+	     abgeschaltet sind. -->
+	<field name="qr_url" class="java.lang.String"><fieldDescription><![CDATA[qr.url]]></fieldDescription></field>
+	<!-- Was der Mandant codiert, entscheiden die Regeln (Grundeinstellungen >
+	     Barcode & Etikett); der Datensatz liefert es fertig aufgelöst. -->
+	<field name="barcode_value" class="java.lang.String"><fieldDescription><![CDATA[barcode.value]]></fieldDescription></field>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<variable name="hasMark" class="java.lang.Boolean"><variableExpression><![CDATA[Boolean.valueOf(
+    ($F{mark_number_1} != null && !$F{mark_number_1}.trim().isEmpty())
+    || ($F{mark_number_2} != null && !$F{mark_number_2}.trim().isEmpty()))]]></variableExpression></variable>
+	<variable name="readable" class="java.lang.String"><variableExpression><![CDATA[($F{barcode_value} != null && !$F{barcode_value}.trim().isEmpty())
+    ? $F{barcode_value}.trim()
+    : ($F{asset_number} == null ? "" : $F{asset_number}.trim())]]></variableExpression></variable>
+	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())
+    ? $F{qr_url}.trim()
+    : $V{readable}]]></variableExpression></variable>
+	<variable name="isDeepLink" class="java.lang.Boolean"><variableExpression><![CDATA[Boolean.valueOf($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())]]></variableExpression></variable>
+	<detail>
+		<band height="85" splitType="Prevent">
+			<!-- Rahmen des Kalibrieretiketts. Die DAkkS-Marke darf nur innerhalb
+			     dieses Rahmens verwendet werden; der QR ist ein zugelassenes
+			     optionales Element desselben Etiketts. -->
+			<rectangle>
+				<reportElement x="2" y="2" width="109" height="81" uuid="c4cae300-0212-4c42-9e32-000000000401"/>
+				<graphicElement><pen lineWidth="1.0" lineStyle="Solid"/></graphicElement>
+			</rectangle>
+			<line>
+				<reportElement x="55" y="2" width="1" height="81" uuid="c4cae300-0212-4c42-9e32-000000000402"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="2" y="33" width="53" height="1" uuid="c4cae300-0212-4c42-9e32-000000000403"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="2" y="57" width="53" height="1" uuid="c4cae300-0212-4c42-9e32-000000000404"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<!-- Registrierdaten der Kalibrierung (Kalibrierzeichen). -->
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="5" width="47" height="9" uuid="c4cae300-0212-4c42-9e32-000000000405">
+					<printWhenExpression><![CDATA[$V{hasMark}]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="6"/></textElement>
+				<textFieldExpression><![CDATA[($F{mark_number_1} == null || $F{mark_number_1}.trim().isEmpty())
+    ? ""
+    : $F{mark_number_1}.trim().split("\\s+")[0]]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="14" width="47" height="17" uuid="c4cae300-0212-4c42-9e32-000000000406">
+					<printWhenExpression><![CDATA[$V{hasMark}]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{mark_number_2} == null
+    ? ""
+    : $F{mark_number_2}.replace("/n", "\n").replace("\\n", "\n").trim()]]></textFieldExpression>
+			</textField>
+			<!-- Ohne Akkreditierung trägt dieselbe Zone die Schein-Nr. -->
+			<staticText>
+				<reportElement x="5" y="6" width="47" height="8" uuid="c4cae300-0212-4c42-9e32-000000000407">
+					<printWhenExpression><![CDATA[!$V{hasMark}.booleanValue()
+    && $F{certificate} != null && !$F{certificate}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Schein-Nr.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="14" width="47" height="16" uuid="c4cae300-0212-4c42-9e32-000000000408">
+					<printWhenExpression><![CDATA[!$V{hasMark}.booleanValue()
+    && $F{certificate} != null && !$F{certificate}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{certificate} == null ? "" : $F{certificate}.trim()]]></textFieldExpression>
+			</textField>
+			<!-- Kalibriermonat — das Datumsfeld, das die DAkkS-Marke verlangt. -->
+			<staticText>
+				<reportElement x="5" y="35" width="47" height="7" uuid="c4cae300-0212-4c42-9e32-000000000409"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Kalibriert]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="42" width="47" height="14" uuid="c4cae300-0212-4c42-9e32-00000000040a"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="10" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[($F{cal_date} == null || $F{cal_date}.trim().length() < 7)
+    ? ""
+    : $F{cal_date}.trim().substring(0, 7)]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="5" y="59" width="47" height="7" uuid="c4cae300-0212-4c42-9e32-00000000040b"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Nächste]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="66" width="47" height="14" uuid="c4cae300-0212-4c42-9e32-00000000040c"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[($F{next_cal_date} == null || $F{next_cal_date}.trim().length() < 7)
+    ? ""
+    : $F{next_cal_date}.trim().substring(0, 7)]]></textFieldExpression>
+			</textField>
+			<!-- 50x50 pt = 17,6 mm. Bei QR-Version 5 (37 Module + Ruhezone) sind
+			     das ~0,39 mm je Modul, also gut drei Punkte auf 203 dpi. Wer das
+			     Feld verkleinert, macht den Aufkleber unscannbar. -->
+			<componentElement>
+				<reportElement x="58" y="6" width="50" height="50" uuid="c4cae300-0212-4c42-9e32-00000000040d">
+					<printWhenExpression><![CDATA[$V{code} != null && !$V{code}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<!-- Fehlerkorrektur M (15%), nicht die Jasper-Vorgabe L (7%). Ein
+				     Kalibrieraufkleber lebt am Gerät: Kratzer, Öl, eine
+				     angehobene Ecke. L verzeiht davon fast nichts. M kostet
+				     vier Module (Version 5 statt 4) und die sind eingeplant.
+				     Für rauhe Umgebungen genügt hier ein "Q". -->
+				<jr:QRCode errorCorrectionLevel="M">
+					<jr:codeExpression><![CDATA[$V{code}]]></jr:codeExpression>
+				</jr:QRCode>
+			</componentElement>
+			<staticText>
+				<reportElement x="56" y="58" width="54" height="8" uuid="c4cae300-0212-4c42-9e32-00000000040e">
+					<printWhenExpression><![CDATA[$V{isDeepLink}]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Gerät scannen]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="56" y="58" width="54" height="8" uuid="c4cae300-0212-4c42-9e32-00000000040f">
+					<printWhenExpression><![CDATA[!$V{isDeepLink}.booleanValue()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Inventar-Nr.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="56" y="66" width="54" height="13" uuid="c4cae300-0212-4c42-9e32-000000000410"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$V{readable}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/dakks-aufkleber-40x30mm-qr-json-sample_adapter.xml
+++ b/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/dakks-aufkleber-40x30mm-qr-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 DAkkS 40x30 mm QR label sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>DAkkS Aufkleber 40x30mm QR JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "contract": "calibration-certificate",
+    "schema_version": "1.6",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE",
+    "certificate_number": "DAkkS-K-2026-0042"
+  },
+  "accreditation": {
+    "mark_number_1": "123456",
+    "mark_number_2": "D-K-\n15208-01-00",
+    "calibration_mark": "DAkkS-K-0815"
+  },
+  "calibration": {
+    "certificate_display": "K-2026-0042",
+    "calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30"
+  },
+  "device": {
+    "asset_number": "INV-9001"
+  },
+  "barcode": { "type": "datamatrix", "field": "asset_number", "value": "INV-9001" },
+  "qr": {
+    "enabled": true,
+    "target": "inventory",
+    "url": "https://calserver.example.com/v2/qr/8f14e45f-ceea-467a-9f6a-1c0b3b6c2f11"
+  }
+}


### PR DESCRIPTION
Nachfolger von #537 (dort war die Etiketten-Geometrie dran). Neues Bundle `STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE`.

Braucht `calibration-certificate` **v1.6** aus calhelp/calServer-yii#3914 — die beiden gehören zusammen.

## Was drin ist

Gleiche Anatomie wie die 12- und 18-mm-Etiketten — Rahmen, Kalibrierzeichen, Kalibriermonat, nächster Termin — plus den QR, den die DAkkS-Kalibriermarke als optionales Element zulässt. Die Gewährleistungsmarke zeichnet die Vorlage weiterhin nicht.

Der QR codiert `qr.url`, den öffentlichen Deep-Link auf die Geräteseite der QR-Code-Rolle (`/v2/qr/{uuid}`). Der Link steht **je Datensatz im Dokument**, nicht als Jasper-Parameter — sonst zeigten im Stapeldruck alle vierzig Aufkleber auf dasselbe Gerät.

## Warum ein eigenes Format statt QR auf 18 mm

Die Etikettengröße folgt aus der URL-Länge, nicht aus Geschmack:

| Grösse | Wert |
|--------|------|
| Deep-Link mit uuid | ~74 Zeichen |
| QR-Version bei Fehlerkorrektur M | 5 (37×37 Module) |
| Modulraster inkl. Ruhezone | 45 Module |
| QR-Feld in der Vorlage | 50×50 pt = 17,6 mm |
| Modulgrösse auf Papier | **0,39 mm = 3,1 Punkte bei 203 dpi** |

Drei Punkte je Modul ist die Grenze für zuverlässige Lesbarkeit auf dem Haus-Thermodrucker (Zebra ZD621, 203 dpi). Neben 17,6 mm QR bliebe auf einem 18-mm-Etikett nichts mehr für Kalibrierzeichen und Datum.

## Fehlerkorrektur M statt der Jasper-Vorgabe L

Beim Zurücklesen der gerenderten Symbole kam heraus, dass JasperReports die Fehlerkorrektur per Default auf **L (7 %)** setzt. Für einen Aufkleber, der am Gerät klebt und Kratzer, Öl und angehobene Ecken sammelt, ist das zu wenig. Steht jetzt auf **M (15 %)** — kostet vier Module (Version 5 statt 4), die in der Größenrechnung ohnehin eingeplant waren. Für rauhe Umgebungen genügt ein `errorCorrectionLevel="Q"`; das ist im README durchgerechnet.

## Ohne Deep-Link

Sind die QR-Links abgeschaltet, liefert der Datensatz `qr.url = null`. Dann codiert derselbe QR den konfigurierten Barcode-Wert (`barcode.value`, sonst `device.asset_number`) und die Beschriftung wechselt von *Gerät scannen* auf *Inventar-Nr.* Ein leeres weisses Quadrat wäre die schlechtere Vorgabe.

## Trade-offs

- **Eigenes Bundle statt Umbau der 18 mm**: mehr Dateien zu pflegen, aber die 12/18-mm-Etiketten bleiben unverändert für alle, die kein QR-Etikettenmaterial haben.
- **Der QR wechselt seinen Inhalt**, wenn kein Deep-Link da ist. Dokumentiert und beschriftet, aber es ist eine Fallunterscheidung, die ein Leser des JRXML kennen muss.
- **Jahr-Monat auch auf 40 mm**, obwohl Platz für das Tagesdatum wäre — Konsistenz innerhalb der DAkkS-Familie schlägt drei Zeichen mehr.

## Prüfung

Gegen **JasperReports 6.21.5** gerendert, die Version des `report-runner`:

- Einzeldruck gegen `sample-data.json` — 113×85 pt, nichts abgeschnitten.
- Stapeldruck über `dataSelect=stickers` — zwei Datensätze, zwei Seiten, und jede Seite trägt die URL **ihres eigenen** Geräts (mit ZXing zurückgelesen).
- Die erzeugten Symbole mit ZXing decodiert: QR-Version 5, 37 Module, Fehlerkorrektur M, korrekte URL. Modulraster nachgemessen: 44,9 Module über das 50-pt-Feld.
- Fall ohne Deep-Link gerendert — QR trägt die Inventarnummer, Beschriftung wechselt.
- `scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` laufen sauber durch; `yamllint` meldet nach der Änderung dieselben neun Altbefunde wie vorher.

Das Bundle ist in `package-reports.yml`, `release-reports.yml` und `publish-downloads.yml` eingetragen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qtkn6dkBYSxzsTSMZt8yEP)_