### PR TITLE
feat(sticker): Geräteetikett 40×30 mm mit QR-Deep-Link statt Inventarnummer

### DIFF
--- a/.github/workflows/package-reports.yml
+++ b/.github/workflows/package-reports.yml
@@ -216,6 +216,13 @@ jobs:
           path: STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports
           if-no-files-found: error
 
+      - name: Upload STICKER-INV-40X30MM-QR-JSON-SAMPLE as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: STICKER-INV-40X30MM-QR-JSON-SAMPLE
+          path: STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports
+          if-no-files-found: error
+
       - name: Upload STICKER-CAL-INV-ZEBRA-JSON-SAMPLE as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -628,6 +635,7 @@ jobs:
           create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
           create_zip "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE" "sticker-dakks-40x30mm-qr-json-sample"
           create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
+          create_zip "STICKER-INV-40X30MM-QR-JSON-SAMPLE" "sticker-inv-40x30mm-qr-json-sample"
           create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
           create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
           create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"

--- a/.github/workflows/publish-downloads.yml
+++ b/.github/workflows/publish-downloads.yml
@@ -107,6 +107,7 @@ jobs:
           get_last_modified "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
           get_last_modified "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE" "sticker-dakks-40x30mm-qr-json-sample"
           get_last_modified "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
+          get_last_modified "STICKER-INV-40X30MM-QR-JSON-SAMPLE" "sticker-inv-40x30mm-qr-json-sample"
           get_last_modified "ORDER-JSON-SAMPLE" "order-json-sample"
           get_last_modified "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
           get_last_modified "REPAIR-JSON-SAMPLE" "repair-json-sample"
@@ -225,6 +226,7 @@ jobs:
               "sticker-dakks-18mm-json-sample":     "STICKER-DAKKS-18MM-JSON-SAMPLE/README.md",
               "sticker-dakks-40x30mm-qr-json-sample": "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/README.md",
               "sticker-cal-inv-zebra-json-sample":  "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE/README.md",
+              "sticker-inv-40x30mm-qr-json-sample": "STICKER-INV-40X30MM-QR-JSON-SAMPLE/README.md",
               "order-json-sample":                  "ORDER-JSON-SAMPLE/README.md",
               "delivery-json-sample":               "DELIVERY-JSON-SAMPLE/README.md",
               "repair-json-sample":                 "REPAIR-JSON-SAMPLE/README.md",
@@ -272,6 +274,7 @@ jobs:
               "sticker-dakks-18mm-json-sample":     "DAkkS-Aufkleber 18 mm",
               "sticker-dakks-40x30mm-qr-json-sample": "DAkkS-Aufkleber 40×30 mm mit QR",
               "sticker-cal-inv-zebra-json-sample":  "Zebra Inventar-/Kalibrier-Sticker",
+              "sticker-inv-40x30mm-qr-json-sample": "Geräteetikett 40×30 mm mit QR",
               "order-json-sample":                  "Auftragsbeleg",
               "delivery-json-sample":               "Lieferschein",
               "repair-json-sample":                 "Reparaturbericht",

--- a/.github/workflows/release-reports.yml
+++ b/.github/workflows/release-reports.yml
@@ -132,6 +132,7 @@ jobs:
           create_zip "STICKER-DAKKS-18MM-JSON-SAMPLE" "sticker-dakks-18mm-json-sample"
           create_zip "STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE" "sticker-dakks-40x30mm-qr-json-sample"
           create_zip "STICKER-CAL-INV-ZEBRA-JSON-SAMPLE" "sticker-cal-inv-zebra-json-sample"
+          create_zip "STICKER-INV-40X30MM-QR-JSON-SAMPLE" "sticker-inv-40x30mm-qr-json-sample"
           create_zip "ORDER-JSON-SAMPLE" "order-json-sample"
           create_zip "DELIVERY-JSON-SAMPLE" "delivery-json-sample"
           create_zip "REPAIR-JSON-SAMPLE" "repair-json-sample"

--- a/STICKER-INV-40X30MM-QR-JSON-SAMPLE/README.md
+++ b/STICKER-INV-40X30MM-QR-JSON-SAMPLE/README.md
@@ -1,0 +1,96 @@
+# STICKER-INV-40X30MM-QR-JSON-SAMPLE — Geräteetikett 40×30 mm mit QR (V2 / APEX)
+
+Geräteetikett **40×30 mm** (113×85 pt) mit **QR-Deep-Link auf die Geräteseite**,
+gefüllt aus einem **JSON-Datensatz** (Contract `inventory-datasheet` **v1.4**)
+statt aus SQL — DB-agnostisch, keine V1-Codespalten.
+
+## Aufbau
+
+| Datei | Zweck |
+|-------|-------|
+| `main_reports/inv-aufkleber-40x30mm-qr-json-sample.jrxml` | Etikett: Rahmen, links Inventarnummer + Bezeichnung + nächster Termin, rechts QR und lesbare Nummer |
+| `main_reports/sample-data.json` | Beispiel-Datensatz (Contract `inventory-datasheet` v1.4) |
+| `main_reports/inv-aufkleber-40x30mm-qr-json-sample_adapter.xml` | Jaspersoft-Studio-JSON-Data-Adapter für die Vorschau |
+
+## Was das von `STICKER-CAL-INV-ZEBRA-JSON-SAMPLE` unterscheidet
+
+Das Zebra-Etikett codiert `barcode.value` — die **Nummer**, die ein Handscanner
+als Text zurückliest. Dieses Etikett codiert `qr.url` — die **Adresse** der
+öffentlichen Geräteseite der QR-Code-Rolle (`/v2/qr/{uuid}`). Scannen mit dem
+Telefon öffnet ohne Anmeldung Stammdaten, Kalibrierstatus und Dokumente.
+
+Dasselbe Gerät, zwei verschiedene Aufgaben: Der Lagerscanner will die Nummer,
+der Techniker vor der Maschine will die Seite. Deshalb zwei Bundles und kein
+Schalter.
+
+**Voraussetzung:** QR-Links müssen eingeschaltet sein (QR-Code-Rolle mit
+`qrlink_enable` und ein öffentlicher Benutzer). Sind sie aus, liefert der
+Datensatz `qr.url = null` — dann codiert derselbe QR den konfigurierten
+Barcode-Wert und die Beschriftung wechselt von *Gerät scannen* auf
+*Inventar-Nr.* Das Etikett verhält sich dann wie das Zebra-Etikett, nur grösser.
+
+## Warum 40×30 mm
+
+Die Etikettengrösse folgt aus der URL-Länge, nicht aus Geschmack:
+
+| Grösse | Wert |
+|--------|------|
+| Deep-Link mit uuid | ~74 Zeichen |
+| QR-Version bei Fehlerkorrektur M | 5 (37×37 Module) |
+| Modulraster inkl. Ruhezone | ~45 Module |
+| QR-Feld in der Vorlage | 50×50 pt = 17,6 mm |
+| Modulgrösse auf Papier | **0,39 mm = 3,1 Punkte bei 203 dpi** |
+
+Drei Punkte je Modul ist die Grenze, ab der ein 203-dpi-Thermodrucker
+zuverlässig lesbare Symbole liefert. **Wer das QR-Feld verkleinert, macht das
+Etikett unscannbar.**
+
+Gleicher Zuschnitt wie [`STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE`](../STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE) —
+eine Rolle Etikettenmaterial bedient Geräteetikett und Kalibrieraufkleber.
+
+Die Fehlerkorrektur steht auf **M (15 %)**, nicht auf der Jasper-Vorgabe L
+(7 %): ein Etikett lebt am Gerät und sammelt Kratzer, Öl und angehobene Ecken.
+
+## Felder
+
+`device.asset_number`, `device.description` (ersatzweise `device.manufacturer` +
+`device.model`, damit die mittlere Zone nicht leer bleibt),
+`device.next_calibration_date`, `qr.url` und `barcode.value`.
+Dataset-Builder: Laravel `InventoryReportDataBuilder`.
+
+### Bekannte Grenze: lange Komposita
+
+Die Bezeichnung steht in einer 17-mm-Spalte. Ein deutsches Kompositum, das
+breiter ist als die Spalte, bricht **mitten im Wort** — JasperReports trennt
+nicht silbenweise. Die Schriftgrösse ist deshalb auf 4,5 pt gesetzt, womit
+Wörter bis etwa 20 Zeichen (`Buegelmessschraube`) in eine Zeile passen. Was
+darüber liegt (`Praezisionsdrehmomentschluessel`), bricht weiterhin hart. Das
+ist ein Schönheitsfehler, kein Informationsverlust: Identität trägt die
+Inventarnummer, Details trägt der QR.
+
+## Systembericht-Platzhalter und Stapeldruck
+
+Dieses Bundle gehört auf den Platzhalter **Geräteetikett** in
+**Administration > Berichtsverwaltung** (Grid `inventory`/Ordner `inventories`)
+— dieselbe Zeile, auf der sonst das Zebra-Bundle liegt. Der Platzhalter ist ab
+Werk da, trägt das Kennzeichen *Systembericht* und ist als Etikett markiert;
+das ist, was **„Etikett drucken"** an die Grid-Zeile hängt.
+
+**Stapeldruck.** Werden im Grid mehrere Zeilen markiert, druckt calServer sie in
+*einem* Lauf in eine PDF:
+
+```json
+{ "meta": { "count": 40 }, "stickers": [ <dokument>, <dokument>, … ] }
+```
+
+Jedes Element ist ein **vollständiges Dokument** in der Form, die
+`sample-data.json` zeigt — deshalb trägt jedes Etikett im Stapel seinen eigenen
+QR. **Es ist keine Stapel-Fassung der Vorlage nötig und keine gewünscht**: Wer
+hier auf ein Array umbaut, bricht den Einzeldruck.
+
+## ⚠️ Leeres Blatt = fehlende Datenquelle
+
+Ohne JSON-Datenquelle rendert das Etikett leer. Vorschau: mitgelieferter Adapter
+(Default über `com.jaspersoft.studio.data.defadapter`) → „Open → Preview". Live
+(calServer V2): Report-Setting-Variable `data_contract = inventory-datasheet`.
+JasperReports **6.20.6** verbindlich.

--- a/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/inv-aufkleber-40x30mm-qr-json-sample.jrxml
+++ b/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/inv-aufkleber-40x30mm-qr-json-sample.jrxml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.20.6  -->
+<!--
+  V2 device label 40x30 mm with QR deep link (ADR-009, contract
+  "inventory-datasheet" v1.4). Filled from a JSON data source — NO SQL.
+
+  WHAT MAKES THIS DIFFERENT from STICKER-CAL-INV-ZEBRA-JSON-SAMPLE: that label
+  encodes `barcode.value` — the asset NUMBER, which a scanner reads back as
+  text. This one encodes `qr.url` — the ADDRESS of the public device page of
+  the QR code role (`/v2/qr/{uuid}`). Scanning it with a phone opens master
+  data, calibration status and documents without a login. Same device, two
+  different jobs; a warehouse scanner wants the number, a technician standing
+  at the machine wants the page.
+
+  WHY THIS SIZE. The deep link is around 74 characters, so QR version 5 with 37
+  modules at error correction M. Printed on the house 203 dpi label printer at
+  three dots per module the symbol needs ~17 mm; the 50x50 pt square below is
+  17,6 mm. Same footprint as STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE so one roll
+  of label stock serves the device label and the calibration sticker.
+
+  Without a deep link (QR links switched off) the same square falls back to the
+  tenant's configured barcode value — then this label behaves like the Zebra
+  one, just bigger. The caption says which of the two it is.
+
+  113x85 pt = 39,9x30 mm. See main_reports/sample-data.json.
+-->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="inv-aufkleber-40x30mm-qr-json-sample" pageWidth="113" pageHeight="85" orientation="Portrait" columnWidth="113" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isTitleNewPage="true" whenNoDataType="AllSectionsNoDetail" uuid="c5cbf400-0221-4c51-9e41-000000000221">
+	<property name="com.jaspersoft.studio.data.defadapter" value="inv-aufkleber-40x30mm-qr-json-sample_adapter.xml"/>
+	<style name="UnicodeDefault" isDefault="true" fontName="DejaVu Sans" pdfFontName="DejaVu Sans" pdfEncoding="Identity-H" isPdfEmbedded="false" fontSize="5"/>
+	<field name="asset_number" class="java.lang.String"><fieldDescription><![CDATA[device.asset_number]]></fieldDescription></field>
+	<field name="description" class="java.lang.String"><fieldDescription><![CDATA[device.description]]></fieldDescription></field>
+	<field name="manufacturer" class="java.lang.String"><fieldDescription><![CDATA[device.manufacturer]]></fieldDescription></field>
+	<field name="model" class="java.lang.String"><fieldDescription><![CDATA[device.model]]></fieldDescription></field>
+	<field name="next_calibration_date" class="java.lang.String"><fieldDescription><![CDATA[device.next_calibration_date]]></fieldDescription></field>
+	<!-- Der Deep-Link auf die Geraeteseite der QR-Code-Rolle. Steht je Datensatz
+	     im Dokument, damit ein Stapel von vierzig Etiketten vierzig Geraete
+	     trifft. null, solange die QR-Links abgeschaltet sind. -->
+	<field name="qr_url" class="java.lang.String"><fieldDescription><![CDATA[qr.url]]></fieldDescription></field>
+	<!-- Was der Mandant codiert, entscheiden die Regeln (Grundeinstellungen >
+	     Barcode & Etikett); der Datensatz liefert es fertig aufgeloest. -->
+	<field name="barcode_value" class="java.lang.String"><fieldDescription><![CDATA[barcode.value]]></fieldDescription></field>
+	<!-- Ohne Beschreibung bliebe die mittlere Zone ein leerer Kasten. Hersteller
+	     und Modell sagen dasselbe in kuerzer und stehen fast immer. -->
+	<variable name="whatItIs" class="java.lang.String"><variableExpression><![CDATA[($F{description} != null && !$F{description}.trim().isEmpty())
+    ? $F{description}.trim()
+    : (($F{manufacturer} == null ? "" : $F{manufacturer}.trim())
+       + (($F{manufacturer} != null && !$F{manufacturer}.trim().isEmpty()
+           && $F{model} != null && !$F{model}.trim().isEmpty()) ? " " : "")
+       + ($F{model} == null ? "" : $F{model}.trim()))]]></variableExpression></variable>
+	<variable name="readable" class="java.lang.String"><variableExpression><![CDATA[($F{barcode_value} != null && !$F{barcode_value}.trim().isEmpty())
+    ? $F{barcode_value}.trim()
+    : ($F{asset_number} == null ? "" : $F{asset_number}.trim())]]></variableExpression></variable>
+	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())
+    ? $F{qr_url}.trim()
+    : $V{readable}]]></variableExpression></variable>
+	<variable name="isDeepLink" class="java.lang.Boolean"><variableExpression><![CDATA[Boolean.valueOf($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())]]></variableExpression></variable>
+	<detail>
+		<band height="85" splitType="Prevent">
+			<rectangle>
+				<reportElement x="2" y="2" width="109" height="81" uuid="c5cbf400-0221-4c51-9e41-000000000501"/>
+				<graphicElement><pen lineWidth="1.0" lineStyle="Solid"/></graphicElement>
+			</rectangle>
+			<line>
+				<reportElement x="55" y="2" width="1" height="81" uuid="c5cbf400-0221-4c51-9e41-000000000502"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="2" y="28" width="53" height="1" uuid="c5cbf400-0221-4c51-9e41-000000000503"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<line>
+				<reportElement x="2" y="52" width="53" height="1" uuid="c5cbf400-0221-4c51-9e41-000000000504"/>
+				<graphicElement><pen lineWidth="0.75"/></graphicElement>
+			</line>
+			<!-- Identitaet des Geraets. -->
+			<staticText>
+				<reportElement x="5" y="4" width="47" height="6" uuid="c5cbf400-0221-4c51-9e41-000000000505"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Inventar-Nr.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="4" y="11" width="49" height="15" uuid="c5cbf400-0221-4c51-9e41-000000000506"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="10" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{asset_number} == null ? "" : $F{asset_number}.trim()]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="4" y="30" width="49" height="20" uuid="c5cbf400-0221-4c51-9e41-000000000507"/>
+				<!-- 4,5 pt statt 5: deutsche Geraetebezeichnungen sind Komposita, und
+				     ein Wort, das breiter als die Spalte ist, bricht mitten im Wort
+				     statt an der Luecke. Bei 4,5 pt passt "Buegelmessschraube" in
+				     eine Zeile; ScaleFont faengt ab, was darueber hinausgeht. -->
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="4.5"/></textElement>
+				<textFieldExpression><![CDATA[$V{whatItIs}]]></textFieldExpression>
+			</textField>
+			<!-- Das eine Datum, das man am Geraet im Vorbeigehen prueft. -->
+			<staticText>
+				<reportElement x="4" y="54" width="49" height="7" uuid="c5cbf400-0221-4c51-9e41-000000000508">
+					<printWhenExpression><![CDATA[$F{next_calibration_date} != null && !$F{next_calibration_date}.trim().isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Nächste Kal.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="4" y="63" width="49" height="12" uuid="c5cbf400-0221-4c51-9e41-000000000509"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="9" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$F{next_calibration_date} == null ? "" : $F{next_calibration_date}.trim()]]></textFieldExpression>
+			</textField>
+			<!-- 50x50 pt = 17,6 mm. Bei QR-Version 5 (37 Module + Ruhezone) sind
+			     das ~0,39 mm je Modul, also gut drei Punkte auf 203 dpi. Wer das
+			     Feld verkleinert, macht das Etikett unscannbar. -->
+			<componentElement>
+				<reportElement x="58" y="6" width="50" height="50" uuid="c5cbf400-0221-4c51-9e41-00000000050a">
+					<printWhenExpression><![CDATA[$V{code} != null && !$V{code}.isEmpty()]]></printWhenExpression>
+				</reportElement>
+				<!-- Fehlerkorrektur M (15%), nicht die Jasper-Vorgabe L (7%). Ein
+				     Geraeteetikett lebt am Geraet: Kratzer, Oel, eine angehobene
+				     Ecke. L verzeiht davon fast nichts. -->
+				<jr:QRCode errorCorrectionLevel="M">
+					<jr:codeExpression><![CDATA[$V{code}]]></jr:codeExpression>
+				</jr:QRCode>
+			</componentElement>
+			<staticText>
+				<reportElement x="56" y="58" width="54" height="8" uuid="c5cbf400-0221-4c51-9e41-00000000050b">
+					<printWhenExpression><![CDATA[$V{isDeepLink}]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Gerät scannen]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="56" y="58" width="54" height="8" uuid="c5cbf400-0221-4c51-9e41-00000000050c">
+					<printWhenExpression><![CDATA[!$V{isDeepLink}.booleanValue()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<text><![CDATA[Inventar-Nr.]]></text>
+			</staticText>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="56" y="66" width="54" height="13" uuid="c5cbf400-0221-4c51-9e41-00000000050d"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$V{readable}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/inv-aufkleber-40x30mm-qr-json-sample_adapter.xml
+++ b/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/inv-aufkleber-40x30mm-qr-json-sample_adapter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Jaspersoft Studio JSON data adapter for the V2 device 40x30 mm QR label sample.
+  Authoring/preview aid only — Studio-namespaced, inert in the report-runner
+  (the calServer V2 backend supplies the JSON datasource at runtime; see README).
+-->
+<jsonDataAdapter class="net.sf.jasperreports.data.json.JsonDataAdapterImpl">
+	<name>Geraeteetikett 40x30mm QR JSON Sample (sample-data.json)</name>
+	<dataFile class="net.sf.jasperreports.data.StandardRepositoryDataLocation">
+		<location>sample-data.json</location>
+	</dataFile>
+	<language>json</language>
+	<useConnection>true</useConnection>
+	<selectExpression></selectExpression>
+</jsonDataAdapter>

--- a/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/sample-data.json
+++ b/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/sample-data.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "contract": "inventory-datasheet",
+    "schema_version": "1.4",
+    "generated_at": "2026-07-15T10:00:00+00:00",
+    "locale": "de-DE"
+  },
+  "device": {
+    "asset_number": "INV-9001",
+    "serial_number": "SN-12345",
+    "description": "Digitalmultimeter Fluke 87V",
+    "manufacturer": "Fluke",
+    "model": "87V",
+    "last_calibration_date": "2026-06-30",
+    "next_calibration_date": "2027-06-30"
+  },
+  "barcode": { "type": "datamatrix", "field": "asset_number", "value": "INV-9001" },
+  "qr": {
+    "enabled": true,
+    "target": "inventory",
+    "url": "https://calserver.example.com/v2/qr/8f14e45f-ceea-467a-9f6a-1c0b3b6c2f11"
+  }
+}


### PR DESCRIPTION
Nachfolger von #538. Neues Bundle `STICKER-INV-40X30MM-QR-JSON-SAMPLE`.

Braucht `inventory-datasheet` **v1.4** aus calhelp/calServer-yii#3920 — die beiden gehören zusammen.

## Warum

Das vorhandene `STICKER-CAL-INV-ZEBRA-JSON-SAMPLE` codiert `barcode.value` — die **Nummer**, die ein Handscanner als Text zurückliest. Dieses Etikett codiert `qr.url` — die **Adresse** der öffentlichen Geräteseite der QR-Code-Rolle (`/v2/qr/{uuid}`). Scannen mit dem Telefon öffnet ohne Anmeldung Stammdaten, Kalibrierstatus und Dokumente.

Dasselbe Gerät, zwei verschiedene Aufgaben: der Lagerscanner will die Nummer, der Techniker vor der Maschine will die Seite. Deshalb zwei Bundles und kein Schalter in einer Vorlage.

## Zuschnitt

Identisch zum DAkkS-QR-Aufkleber aus #538: 113×85 pt (40×30 mm), QR-Feld 50×50 pt = 17,6 mm, Fehlerkorrektur M, ~0,39 mm je Modul = 3,1 Punkte bei 203 dpi. Eine Rolle Etikettenmaterial bedient beide Etiketten.

Sind die QR-Links abgeschaltet, fällt der QR auf den konfigurierten Barcode-Wert zurück und die Beschriftung wechselt von *Gerät scannen* auf *Inventar-Nr.* — dann verhält sich das Etikett wie das Zebra-Etikett, nur grösser.

## Drei Layout-Befunde aus dem Rendern

Der erste Wurf sah im PNG falsch aus, nicht im XML:

1. **Datum brach nach `2027-06-`.** `textAdjust="ScaleFont"` verkleinert erst, wenn der Text die Box-**Höhe** sprengt — zwei Zeilen passten in die Höhe, also blieb die Schrift gross und der Text brach in der Breite. Das Datumsfeld ist jetzt eine Zeile hoch, damit ScaleFont wirklich greift.
2. **Bezeichnung brach mitten im Wort** (`Digitalmultimet / er`). Steht jetzt auf 4,5 pt: deutsche Komposita bis etwa 20 Zeichen passen in eine Zeile der 17-mm-Spalte. JasperReports trennt nicht silbenweise, längere Wörter brechen weiterhin hart — als bekannte Grenze im README vermerkt, weil kein Schriftgrad ein 31-Zeichen-Wort auf 17 mm lesbar unterbringt.
3. **Ohne Bezeichnung blieb ein leerer Kasten.** Fällt jetzt auf Hersteller + Modell zurück.

## Prüfung

Gegen **JasperReports 6.21.5** gerendert, die Version des `report-runner`:

- Einzeldruck gegen `sample-data.json` — 113×85 pt, nichts abgeschnitten.
- Stapeldruck über `dataSelect=stickers` mit drei Datensätzen; die Symbole mit ZXing zurückgelesen: Seite 1 und 2 tragen die URL **ihres eigenen** Geräts, Seite 3 (QR-Links aus) trägt `HAUS-4711` — also den Mandanten-Barcodewert und nicht die Inventarnummer `INV-9003`, was die Vorrangregel bestätigt.
- Grenzfälle gerendert: überlange Inventarnummer (`WERKSTATT-2026-000042`), fehlende Bezeichnung, fehlendes Datum.
- `scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` sauber; `yamllint` meldet dieselben neun Altbefunde wie vorher.

Das Bundle ist in `package-reports.yml`, `release-reports.yml` und `publish-downloads.yml` eingetragen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qtkn6dkBYSxzsTSMZt8yEP)_