### PR TITLE
fix(sticker): im QR steht der Link zur QR-Ansicht, sonst nichts

### DIFF
--- a/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/README.md
+++ b/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/README.md
@@ -35,12 +35,16 @@ Der QR codiert `qr.url` — den öffentlichen Deep-Link auf die Geräteseite der
 **QR-Code-Rolle** (`/v2/qr/{uuid}`). Scannen führt ohne Anmeldung auf
 Stammdaten, Kalibrierstatus und Dokumente des Geräts.
 
+**Im QR steht der Link — sonst nichts.** Kein Rückfall auf eine Nummer: Sonst
+wäre dasselbe Symbol mal eine Adresse und mal eine Nummer, je nach Einstellung,
+und wer den Aufkleber in der Hand hält, sähe dem QR nicht an, welches von beidem
+er gerade ist.
+
 **Voraussetzung:** QR-Links müssen eingeschaltet sein (QR-Code-Rolle mit
 `qrlink_enable` und ein öffentlicher Benutzer). Sind sie aus, liefert der
-Datensatz `qr.url = null` — dann codiert derselbe QR den konfigurierten
-Barcode-Wert (`barcode.value`, sonst `device.asset_number`), und die
-Beschriftung wechselt von *Gerät scannen* auf *Inventar-Nr.* Ein leeres weisses
-Quadrat wäre die schlechtere Vorgabe.
+Datensatz `qr.url = null` — dann wird **kein QR gedruckt**; die rechte Hälfte
+trägt stattdessen die lesbare Nummer gross, beschriftet als *Inventar-Nr.* Ein
+grosser Nummernblock ist ein brauchbares Etikett, ein weisses Feld ist keines.
 
 Der Link steht **je Datensatz im Dokument**. Der alte V1-Jasper-Parameter
 `QR_Code_Value` gilt je Druckauftrag — im Stapeldruck zeigten damit alle vierzig

--- a/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/dakks-aufkleber-40x30mm-qr-json-sample.jrxml
+++ b/STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE/main_reports/dakks-aufkleber-40x30mm-qr-json-sample.jrxml
@@ -18,9 +18,11 @@
   That is why this bundle exists instead of squeezing a QR onto 18 mm, where
   nothing would be left for the DAkkS fields.
 
-  Without a deep link (QR links switched off) the same square carries the
-  tenant's configured barcode value instead of an empty white box — a plain
-  inventory QR, which is what the readable number underneath names either way.
+  The QR carries the deep link and NOTHING ELSE. No fallback to a number: the
+  same symbol must not be an address on one installation and a number on the
+  next, because nobody holding the sticker can tell which one they are looking
+  at. Without a link (QR links switched off) no QR is printed at all; the right
+  half then carries the readable number large instead of an empty white box.
 
   113x85 pt = 39,9x30 mm. See main_reports/sample-data.json.
 -->
@@ -47,9 +49,15 @@
 	<variable name="readable" class="java.lang.String"><variableExpression><![CDATA[($F{barcode_value} != null && !$F{barcode_value}.trim().isEmpty())
     ? $F{barcode_value}.trim()
     : ($F{asset_number} == null ? "" : $F{asset_number}.trim())]]></variableExpression></variable>
-	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())
-    ? $F{qr_url}.trim()
-    : $V{readable}]]></variableExpression></variable>
+	<!-- Im QR steht der Link zur QR-Ansicht — sonst nichts. Frueher fiel er
+	     ohne Deep-Link auf den Barcodewert zurueck; das machte aus demselben
+	     Symbol mal eine Adresse und mal eine Nummer, je nach Einstellung, und
+	     wer den Aufkleber in der Hand hielt, sah dem QR nicht an, welches von
+	     beidem er gerade ist. Ohne Link wird kein QR gedruckt; die lesbare
+	     Nummer darunter bleibt und traegt die Identitaet. -->
+	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[($F{qr_url} == null || $F{qr_url}.trim().isEmpty())
+    ? ""
+    : $F{qr_url}.trim()]]></variableExpression></variable>
 	<variable name="isDeepLink" class="java.lang.Boolean"><variableExpression><![CDATA[Boolean.valueOf($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())]]></variableExpression></variable>
 	<detail>
 		<band height="85" splitType="Prevent">
@@ -156,15 +164,28 @@
 				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
 				<text><![CDATA[Gerät scannen]]></text>
 			</staticText>
+			<!-- Ohne Deep-Link wird kein QR gedruckt. Statt einer leeren
+			     Etikettenhaelfte uebernimmt die lesbare Nummer die Flaeche —
+			     ein grosser Nummernblock ist ein brauchbares Etikett, ein
+			     weisses Feld ist keines. -->
 			<staticText>
-				<reportElement x="56" y="58" width="54" height="8" uuid="c4cae300-0212-4c42-9e32-00000000040f">
+				<reportElement x="56" y="24" width="54" height="10" uuid="c4cae300-0212-4c42-9e32-00000000060a">
 					<printWhenExpression><![CDATA[!$V{isDeepLink}.booleanValue()]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="7"/></textElement>
 				<text><![CDATA[Inventar-Nr.]]></text>
 			</staticText>
 			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
-				<reportElement x="56" y="66" width="54" height="13" uuid="c4cae300-0212-4c42-9e32-000000000410"/>
+				<reportElement x="56" y="36" width="54" height="26" uuid="c4cae300-0212-4c42-9e32-00000000060b">
+					<printWhenExpression><![CDATA[!$V{isDeepLink}.booleanValue()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="14" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$V{readable}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="56" y="66" width="54" height="13" uuid="c4cae300-0212-4c42-9e32-000000000410">
+					<printWhenExpression><![CDATA[$V{isDeepLink}]]></printWhenExpression>
+				</reportElement>
 				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
 				<textFieldExpression><![CDATA[$V{readable}]]></textFieldExpression>
 			</textField>

--- a/STICKER-INV-40X30MM-QR-JSON-SAMPLE/README.md
+++ b/STICKER-INV-40X30MM-QR-JSON-SAMPLE/README.md
@@ -23,11 +23,17 @@ Dasselbe Gerät, zwei verschiedene Aufgaben: Der Lagerscanner will die Nummer,
 der Techniker vor der Maschine will die Seite. Deshalb zwei Bundles und kein
 Schalter.
 
+**Im QR steht der Link — sonst nichts.** Kein Rückfall auf eine Nummer: Sonst
+wäre dasselbe Symbol mal eine Adresse und mal eine Nummer, je nach Einstellung,
+und genau diese Zweideutigkeit ist der Grund, warum dieses Bundle neben dem
+Zebra-Etikett steht statt es zu ersetzen.
+
 **Voraussetzung:** QR-Links müssen eingeschaltet sein (QR-Code-Rolle mit
 `qrlink_enable` und ein öffentlicher Benutzer). Sind sie aus, liefert der
-Datensatz `qr.url = null` — dann codiert derselbe QR den konfigurierten
-Barcode-Wert und die Beschriftung wechselt von *Gerät scannen* auf
-*Inventar-Nr.* Das Etikett verhält sich dann wie das Zebra-Etikett, nur grösser.
+Datensatz `qr.url = null` — dann wird **kein QR gedruckt**; die rechte Hälfte
+trägt stattdessen die lesbare Nummer gross, beschriftet als *Inventar-Nr.* Wer
+dauerhaft ohne QR-Links arbeitet, nimmt besser das Zebra-Bundle: Das codiert die
+Nummer und ist für seinen Zweck gebaut.
 
 ## Warum 40×30 mm
 

--- a/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/inv-aufkleber-40x30mm-qr-json-sample.jrxml
+++ b/STICKER-INV-40X30MM-QR-JSON-SAMPLE/main_reports/inv-aufkleber-40x30mm-qr-json-sample.jrxml
@@ -18,9 +18,11 @@
   17,6 mm. Same footprint as STICKER-DAKKS-40X30MM-QR-JSON-SAMPLE so one roll
   of label stock serves the device label and the calibration sticker.
 
-  Without a deep link (QR links switched off) the same square falls back to the
-  tenant's configured barcode value — then this label behaves like the Zebra
-  one, just bigger. The caption says which of the two it is.
+  The QR carries the deep link and NOTHING ELSE. No fallback to a number — that
+  ambiguity is exactly why this bundle stands NEXT TO the Zebra label rather
+  than replacing it. Without a link (QR links switched off) no QR is printed at
+  all; the right half then carries the readable number large. An installation
+  that works without QR links is better served by the Zebra bundle.
 
   113x85 pt = 39,9x30 mm. See main_reports/sample-data.json.
 -->
@@ -50,9 +52,15 @@
 	<variable name="readable" class="java.lang.String"><variableExpression><![CDATA[($F{barcode_value} != null && !$F{barcode_value}.trim().isEmpty())
     ? $F{barcode_value}.trim()
     : ($F{asset_number} == null ? "" : $F{asset_number}.trim())]]></variableExpression></variable>
-	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())
-    ? $F{qr_url}.trim()
-    : $V{readable}]]></variableExpression></variable>
+	<!-- Im QR steht der Link zur QR-Ansicht — sonst nichts. Frueher fiel er
+	     ohne Deep-Link auf den Barcodewert zurueck; das machte aus demselben
+	     Symbol mal eine Adresse und mal eine Nummer, je nach Einstellung, und
+	     wer den Aufkleber in der Hand hielt, sah dem QR nicht an, welches von
+	     beidem er gerade ist. Ohne Link wird kein QR gedruckt; die lesbare
+	     Nummer darunter bleibt und traegt die Identitaet. -->
+	<variable name="code" class="java.lang.String"><variableExpression><![CDATA[($F{qr_url} == null || $F{qr_url}.trim().isEmpty())
+    ? ""
+    : $F{qr_url}.trim()]]></variableExpression></variable>
 	<variable name="isDeepLink" class="java.lang.Boolean"><variableExpression><![CDATA[Boolean.valueOf($F{qr_url} != null && !$F{qr_url}.trim().isEmpty())]]></variableExpression></variable>
 	<detail>
 		<band height="85" splitType="Prevent">
@@ -126,15 +134,28 @@
 				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
 				<text><![CDATA[Gerät scannen]]></text>
 			</staticText>
+			<!-- Ohne Deep-Link wird kein QR gedruckt. Statt einer leeren
+			     Etikettenhaelfte uebernimmt die lesbare Nummer die Flaeche —
+			     ein grosser Nummernblock ist ein brauchbares Etikett, ein
+			     weisses Feld ist keines. -->
 			<staticText>
-				<reportElement x="56" y="58" width="54" height="8" uuid="c5cbf400-0221-4c51-9e41-00000000050c">
+				<reportElement x="56" y="24" width="54" height="10" uuid="c5cbf400-0221-4c51-9e41-00000000060a">
 					<printWhenExpression><![CDATA[!$V{isDeepLink}.booleanValue()]]></printWhenExpression>
 				</reportElement>
-				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="5"/></textElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="7"/></textElement>
 				<text><![CDATA[Inventar-Nr.]]></text>
 			</staticText>
 			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
-				<reportElement x="56" y="66" width="54" height="13" uuid="c5cbf400-0221-4c51-9e41-00000000050d"/>
+				<reportElement x="56" y="36" width="54" height="26" uuid="c5cbf400-0221-4c51-9e41-00000000060b">
+					<printWhenExpression><![CDATA[!$V{isDeepLink}.booleanValue()]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="14" isBold="true"/></textElement>
+				<textFieldExpression><![CDATA[$V{readable}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="56" y="66" width="54" height="13" uuid="c5cbf400-0221-4c51-9e41-00000000050d">
+					<printWhenExpression><![CDATA[$V{isDeepLink}]]></printWhenExpression>
+				</reportElement>
 				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="8" isBold="true"/></textElement>
 				<textFieldExpression><![CDATA[$V{readable}]]></textFieldExpression>
 			</textField>


### PR DESCRIPTION
Korrektur an #538 und #539.

## Problem

Beide 40×30-QR-Bundles fielen ohne Deep-Link auf den konfigurierten Barcode-Wert zurück. Damit war dasselbe Symbol mal eine **Adresse** und mal eine **Nummer** — je nach Einstellung der Installation. Wer den Aufkleber in der Hand hält, sieht dem QR nicht an, welches von beidem er gerade ist, und ein Etikett, dessen Bedeutung von einer Serverkonfiguration abhängt, ist kein Etikett.

Ich hatte den Rückfall als Verbesserung gegen das leere Quadrat eingebaut. Das war die falsche Abwägung: das leere Quadrat war das kleinere Problem.

## Änderung

Der QR trägt jetzt ausschliesslich `qr.url`. **Ohne Link wird kein QR gedruckt.**

Damit die rechte Etiketthälfte dann nicht leer bleibt, übernimmt die lesbare Nummer die Fläche — grosser Nummernblock mit der Beschriftung *Inventar-Nr.* Ein grosser Nummernblock ist ein brauchbares Etikett, ein weisses Feld ist keines.

Wer dauerhaft ohne QR-Links arbeitet, ist mit dem Zebra-Bundle bzw. den 12/18-mm-Bundles besser bedient: die codieren die Nummer und sind dafür gebaut. Steht jetzt so in beiden READMEs.

## Prüfung

Gegen **JasperReports 6.21.5** gerendert:

- Beide Bundles **mit** Deep-Link — Symbole mit ZXing zurückgelesen: QR-Version 5, 37 Module, Fehlerkorrektur M, korrekte URL.
- Beide Bundles **ohne** Deep-Link — die Seite enthält nachweislich kein Symbol mehr (die Modulerkennung findet nichts), stattdessen der grosse Nummernblock.
- Stapeldruck über `dataSelect=stickers` weiterhin geprüft, gemischt mit und ohne Link.
- `scripts/check_jasper_version.sh` und `scripts/check_parameters_manifest.py` sauber.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qtkn6dkBYSxzsTSMZt8yEP)_