### PR TITLE
fix(dakks): das Sternchen markiert die Ausnahme, nicht die Regel

### DIFF
--- a/DAKKS-JSON-SAMPLE/README.md
+++ b/DAKKS-JSON-SAMPLE/README.md
@@ -186,7 +186,14 @@ vier Schreibweisen — MET/TEAMs `Points.cPointPassFailStatus`:
 | `Fail Indeterminate` | `!?` | außerhalb, aber keine negative Konformitätsaussage möglich |
 
 Alles andere — auch leer, auch `P`/`F`, auch `Conditional` — druckt eine leere
-Zelle. In der Variante `MeasurementDetails=1` kommt ein zweites Gatter dazu:
+Zelle.
+
+Das `*` daneben ist eine eigene Aussage und hängt an `results[].accred`: es
+bedeutet „Messergebnisse nicht im Akkreditierungsumfang" und markiert damit die
+Ausnahme. `1`/`ja`/`true` = im Umfang (kein Zeichen), `0`/`nein`/`false` =
+nicht im Umfang (`*`), leer = keine Aussage erfasst (kein Zeichen). Der
+Contract liefert das Feld deshalb leer statt als `0`, wenn die Zeile es nicht
+trägt — sonst würde jede in calServer erfasste Zeile die Fußnote bekommen. In der Variante `MeasurementDetails=1` kommt ein zweites Gatter dazu:
 gedruckt wird nur, wenn `fsc` „EVAL" oder „PICE" enthält.
 
 Die Felder `conformity`, `test_status` und `guardband_meth` des Contracts sind

--- a/DAKKS-JSON-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-JSON-SAMPLE/subreports/Results.jrxml
@@ -545,8 +545,35 @@
          || ($F{uut_ind} != null && !$F{uut_ind}.trim().isEmpty())
         )]]></variableExpression>
 	</variable>
+	<!--
+	    Das "*" der Legende bedeutet "Messergebnisse nicht im
+	    Akkreditierungsumfang des Kalibrierlaboratoriums" — es markiert also die
+	    AUSNAHME, nicht die Regel. Bis hierher setzte die Vorlage es bei
+	    `accred = 1`, also genau umgekehrt: auf einem Schein, dessen Zeilen alle
+	    akkreditiert waren, trug jede Zeile die Fussnote "nicht im
+	    Akkreditierungsumfang".
+
+	    Drei Zustaende, nicht zwei:
+
+	      1 / y / yes / ja / true   -> im Umfang            -> kein Zeichen
+	      0 / n / no / nein / false -> nicht im Umfang      -> "*"
+	      leer / nicht gesetzt      -> keine Aussage        -> kein Zeichen
+
+	    Der dritte Fall ist der Grund, warum die Abfrage `accred` nicht mehr auf
+	    0 zurueckfaellt (`COALESCE(accred, '')`): sonst waere "nie gepflegt"
+	    dasselbe wie "ausserhalb des Umfangs", und jede in calServer erfasste
+	    Zeile — die Messwertaufnahme schreibt das Feld nicht — bekaeme die
+	    Fussnote. Ein Schein behauptet nichts, was niemand erfasst hat.
+	-->
 	<variable name="AccredMark" class="java.lang.String">
-		<variableExpression><![CDATA[($F{accred}!=null && $F{accred}.toString().trim().equals("1")) ? "*" : ""]]></variableExpression>
+		<variableExpression><![CDATA[$F{accred} == null
+      ? ""
+      : (
+          $F{accred}.toString().trim().toLowerCase()
+            .matches("0|n|no|nein|false|f")
+          ? "*"
+          : ""
+        )]]></variableExpression>
 	</variable>
 	<columnHeader>
 		<band height="54">
@@ -2827,9 +2854,12 @@
 					<textElement verticalAlignment="Top">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
-					<textFieldExpression><![CDATA[!$F{test_desc}.trim().isEmpty()
+					<textFieldExpression><![CDATA[(
+              !$F{test_desc}.trim().isEmpty()
               ? $F{test_desc}.trim().replaceAll("(?i)ohm","Ω")
-              : ""]]></textFieldExpression>
+              : ""
+            )
+            + ($V{AccredMark}==null ? "" : $V{AccredMark})]]></textFieldExpression>
 				</textField>
 				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="ContainerHeight" x="156" y="0" width="96" height="14" uuid="9efcb26d-ce2d-4aeb-a0d4-23ede7e30e17"/>

--- a/DAKKS-SAMPLE/README.md
+++ b/DAKKS-SAMPLE/README.md
@@ -285,14 +285,28 @@ sowie optional `P_Image_Path`. `Cert_field` wird zusätzlich an
     die Varianten `3`/`4` ziehen den fertigen Text aus `exp_uncert_iso_e` bzw.
     `exp_uncert_iso_p` vor, sofern er gefüllt ist.
   * Die Konformitätsspalte übersetzt `pass_fail` in die Symbolik der Legende
-    (`i.T.`, `?`, `!?`, `!`) und hängt bei `accred = 1` das `*` der Legende an.
-    Sie erwartet MET/TEAMs Schreibweise (`Pass`, `Fail`, `Pass Indeterminate`,
-    `Fail Indeterminate`); alles andere — auch ein bereits übersetztes Symbol —
-    druckt eine leere Zelle.
-  * Variante `21` hat keine Konformitätsspalte und druckt damit auch das `*`
-    nicht. Wer die Kennzeichnung des Akkreditierungsumfangs auf dem Schein
-    braucht, nimmt `22` (dieselben Werte, mit Spezifikations-, Toleranz- und
-    Konformitätsspalte).
+    (`i.T.`, `?`, `!?`, `!`). Sie erwartet MET/TEAMs Schreibweise (`Pass`,
+    `Fail`, `Pass Indeterminate`, `Fail Indeterminate`); alles andere — auch
+    ein bereits übersetztes Symbol — druckt eine leere Zelle.
+  * **Akkreditierungsumfang (`accred`):** Das `*` der Legende bedeutet
+    „Messergebnisse nicht im Akkreditierungsumfang des Kalibrierlaboratoriums"
+    und markiert damit die Ausnahme, nicht die Regel. Drei Zustände:
+
+    | `accred` | Bedeutung | Druck |
+    | --- | --- | --- |
+    | `1`, `y`, `yes`, `ja`, `true` | im Akkreditierungsumfang | kein Zeichen |
+    | `0`, `n`, `no`, `nein`, `false` | **nicht** im Umfang, kennzeichnungspflichtig | `*` |
+    | leer / nicht gesetzt | keine Aussage erfasst | kein Zeichen |
+
+    Der dritte Zustand ist der Grund, warum die Abfrage `accred` nicht mehr auf
+    `0` zurückfallen lässt (`COALESCE(accred, '')`): sonst wäre „nie gepflegt"
+    dasselbe wie „außerhalb des Umfangs" und jede in calServer erfasste Zeile
+    trüge die Fußnote — die Messwertaufnahme schreibt das Feld nicht. Der
+    Schein behauptet nichts, was niemand erfasst hat.
+  * Das Zeichen steht in den Varianten `1`, `2`, `22`, `3` und `4` hinter der
+    Konformitätsaussage. Variante `21` hat keine Konformitätsspalte und hängt
+    es deshalb an die Messbedingung — die Kennzeichnungspflicht gilt in jeder
+    Variante.
   * **Zeilenumbruch statt Textverlust:** Jede Zelle des Detailbands wächst mit
     ihrem Inhalt (`textAdjust="StretchHeight"`), alle Zellen einer Zeile werden
     gleich hoch (`stretchType="ContainerHeight"`) und der Text sitzt oben. Ein

--- a/DAKKS-SAMPLE/subreports/Results.jrxml
+++ b/DAKKS-SAMPLE/subreports/Results.jrxml
@@ -56,7 +56,7 @@
       COALESCE(rel_err,'')             AS rel_err,
       COALESCE(pass_fail,'')           AS pass_fail,
       COALESCE(fsc,'')                 AS Fsc,
-      COALESCE(accred, 0)              AS accred,
+      COALESCE(accred, '')             AS accred,
       row_num
     FROM $P!{PrefixTable}results
     WHERE ctag = $P{P_CTAG}
@@ -519,8 +519,35 @@
          || ($F{uut_ind} != null && !$F{uut_ind}.trim().isEmpty())
         )]]></variableExpression>
 	</variable>
+	<!--
+	    Das "*" der Legende bedeutet "Messergebnisse nicht im
+	    Akkreditierungsumfang des Kalibrierlaboratoriums" — es markiert also die
+	    AUSNAHME, nicht die Regel. Bis hierher setzte die Vorlage es bei
+	    `accred = 1`, also genau umgekehrt: auf einem Schein, dessen Zeilen alle
+	    akkreditiert waren, trug jede Zeile die Fussnote "nicht im
+	    Akkreditierungsumfang".
+
+	    Drei Zustaende, nicht zwei:
+
+	      1 / y / yes / ja / true   -> im Umfang            -> kein Zeichen
+	      0 / n / no / nein / false -> nicht im Umfang      -> "*"
+	      leer / nicht gesetzt      -> keine Aussage        -> kein Zeichen
+
+	    Der dritte Fall ist der Grund, warum die Abfrage `accred` nicht mehr auf
+	    0 zurueckfaellt (`COALESCE(accred, '')`): sonst waere "nie gepflegt"
+	    dasselbe wie "ausserhalb des Umfangs", und jede in calServer erfasste
+	    Zeile — die Messwertaufnahme schreibt das Feld nicht — bekaeme die
+	    Fussnote. Ein Schein behauptet nichts, was niemand erfasst hat.
+	-->
 	<variable name="AccredMark" class="java.lang.String">
-		<variableExpression><![CDATA[($F{accred}!=null && $F{accred}.toString().trim().equals("1")) ? "*" : ""]]></variableExpression>
+		<variableExpression><![CDATA[$F{accred} == null
+      ? ""
+      : (
+          $F{accred}.toString().trim().toLowerCase()
+            .matches("0|n|no|nein|false|f")
+          ? "*"
+          : ""
+        )]]></variableExpression>
 	</variable>
 	<columnHeader>
 		<band height="54">
@@ -2801,9 +2828,12 @@
 					<textElement verticalAlignment="Top">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
-					<textFieldExpression><![CDATA[!$F{test_desc}.trim().isEmpty()
+					<textFieldExpression><![CDATA[(
+              !$F{test_desc}.trim().isEmpty()
               ? $F{test_desc}.trim().replaceAll("(?i)ohm","Ω")
-              : ""]]></textFieldExpression>
+              : ""
+            )
+            + ($V{AccredMark}==null ? "" : $V{AccredMark})]]></textFieldExpression>
 				</textField>
 				<textField textAdjust="StretchHeight">
 					<reportElement stretchType="ContainerHeight" x="156" y="0" width="96" height="14" uuid="9efcb26d-ce2d-4aeb-a0d4-23ede7e30e17"/>

--- a/DCC/main_reports/README.md
+++ b/DCC/main_reports/README.md
@@ -26,6 +26,9 @@ parallel deployed werden.
 5. Die Varianten `2`, `22`, `3` und `4` drucken Wert, SI-Vorsatz und Einheit als
    eine Angabe (`9.9 mg`). Variante `1` ist die Basisdarstellung und druckt die
    Rohwerte ohne Vorsatz und Einheit.
+6. Das `*` hinter der Konformitätsaussage markiert Messpunkte **außerhalb** des
+   Akkreditierungsumfangs (`accred` = `0`/`nein`/`false`). `1`/`ja` und ein
+   leeres Feld drucken kein Zeichen.
 
 ## XML + PDF im Paar
 1. Exportiere/baue den PDF-Report wie gewohnt (z. B. via Workflow oder calServer-UI).

--- a/DCC/subreports/DCC-Results.jrxml
+++ b/DCC/subreports/DCC-Results.jrxml
@@ -56,7 +56,7 @@
       COALESCE(rel_err,'')             AS rel_err,
       COALESCE(pass_fail,'')           AS pass_fail,
       COALESCE(fsc,'')                 AS Fsc,
-      COALESCE(accred, 0)              AS accred,
+      COALESCE(accred, '')             AS accred,
       row_num
     FROM $P!{PrefixTable}results
     WHERE ctag = $P{P_CTAG}
@@ -517,8 +517,35 @@
          || ($F{uut_ind} != null && !$F{uut_ind}.trim().isEmpty())
         )]]></variableExpression>
 	</variable>
+	<!--
+	    Das "*" der Legende bedeutet "Messergebnisse nicht im
+	    Akkreditierungsumfang des Kalibrierlaboratoriums" — es markiert also die
+	    AUSNAHME, nicht die Regel. Bis hierher setzte die Vorlage es bei
+	    `accred = 1`, also genau umgekehrt: auf einem Schein, dessen Zeilen alle
+	    akkreditiert waren, trug jede Zeile die Fussnote "nicht im
+	    Akkreditierungsumfang".
+
+	    Drei Zustaende, nicht zwei:
+
+	      1 / y / yes / ja / true   -> im Umfang            -> kein Zeichen
+	      0 / n / no / nein / false -> nicht im Umfang      -> "*"
+	      leer / nicht gesetzt      -> keine Aussage        -> kein Zeichen
+
+	    Der dritte Fall ist der Grund, warum die Abfrage `accred` nicht mehr auf
+	    0 zurueckfaellt (`COALESCE(accred, '')`): sonst waere "nie gepflegt"
+	    dasselbe wie "ausserhalb des Umfangs", und jede in calServer erfasste
+	    Zeile — die Messwertaufnahme schreibt das Feld nicht — bekaeme die
+	    Fussnote. Ein Schein behauptet nichts, was niemand erfasst hat.
+	-->
 	<variable name="AccredMark" class="java.lang.String">
-		<variableExpression><![CDATA[($F{accred}!=null && $F{accred}.toString().trim().equals("1")) ? "*" : ""]]></variableExpression>
+		<variableExpression><![CDATA[$F{accred} == null
+      ? ""
+      : (
+          $F{accred}.toString().trim().toLowerCase()
+            .matches("0|n|no|nein|false|f")
+          ? "*"
+          : ""
+        )]]></variableExpression>
 	</variable>
 	<columnHeader>
 		<band height="54">


### PR DESCRIPTION
Die Legende des Scheins erklärt `*` mit „Messergebnisse nicht im Akkreditierungsumfang des Kalibrierlaboratoriums" — dieselbe Formulierung wie in der akkreditierten V1-Vorlage. Das Zeichen kennzeichnet also die **Ausnahme**. Gesetzt hat die Vorlage es bei `accred = 1`, also genau umgekehrt: auf einem Schein, dessen Messpunkte sämtlich akkreditiert sind, trug **jede** Zeile die Fußnote „nicht im Akkreditierungsumfang". Im ausgelieferten Beispielschein als `i.T.*` in jeder Zeile sichtbar.

## Das zweite Problem

Beim Umdrehen kam heraus, was unter der alten Logik nie aufgefallen ist: **„nie gepflegt" und „außerhalb des Umfangs" waren derselbe Wert.** Die Abfrage las `COALESCE(accred, 0)`, und die V2-Messwertaufnahme schreibt das Feld überhaupt nicht — es kommt nur aus MET/TEAM (`Points.lAccredited`) oder von Hand.

Ein bloßes Umdrehen des Vergleichs hätte deshalb auf jedem in calServer erfassten Schein **jede** Zeile als außerhalb des Akkreditierungsumfangs gekennzeichnet. Also drei Zustände statt zwei:

| `accred` | Bedeutung | Druck |
| --- | --- | --- |
| `1`, `y`, `yes`, `ja`, `true` | im Akkreditierungsumfang | kein Zeichen |
| `0`, `n`, `no`, `nein`, `false` | **nicht** im Umfang, kennzeichnungspflichtig | `*` |
| leer, nicht gesetzt | keine Aussage erfasst | kein Zeichen |

Die Abfrage lässt `accred` dafür nicht mehr auf `0` zurückfallen (`COALESCE(accred, '')`). Ein Schein behauptet nichts, was niemand erfasst hat — dieselbe Grenze wie bei `rel_err` in ADR 2026-10-03. Die Richtung der Vorsicht ist damit gewählt: eine fehlende Kennzeichnung ist ein Pflegethema am Messpunkt, eine falsche wäre eine falsche Aussage über den Akkreditierungsumfang des Labors auf einem akkreditierten Dokument.

## Variante 21 konnte gar nicht kennzeichnen

Sie hat keine Konformitätsspalte, und dort hängt das Zeichen in allen anderen Varianten. Sie hängt es jetzt an die Messbedingung (`Wiederholbarkeit, zehn*`). Eine Kennzeichnungspflicht, die von der Layoutwahl abhängt, ist keine.

## Verifikation

Alle drei Results-Unterberichte (DAkkS, JSON-Zwilling, DCC) mit JasperReports 6.20.6 gerendert, über die Werte `1`, `ja`, `0`, `no`, `nein` und leer:

```
(leer)     -> i.T.
no         -> i.T.*
nein       -> i.T.*
0          -> i.T.*
1          -> i.T.
ja         -> i.T.
```

`*` erscheint genau bei den drei Nein-Schreibweisen, in jeder Variante, und in `21` an der Messbedingung. Repo-Checks grün: `check_jasper_version.sh`, `check_parameters_manifest.py`, `build_dakks_json_clone.py --check`, `check_dcc330.py`.

## Achtung beim Nachdruck

Das `*` verschwindet dort, wo es bisher stand, und erscheint dort, wo es fehlte. Das ist die einzige Änderung dieser Reihe, die eine **normative Aussage** des Scheins umkehrt. Bestehende Scheine bleiben, wie sie sind.

Aus MET/TEAM übernommene Zeilen mit `lAccredited = 0` werden jetzt gekennzeichnet. Das ist gewollt, sofern `0` dort „außerhalb des Umfangs" heißt und nicht „nie gesetzt" — vor dem ersten Serien-Nachdruck gehört ein importierter Schein daraufhin angesehen.

## Gegenstück

Der Contract liefert `accred` ab Schema 1.7 leer statt `'0'`, und der irreführende Kommentar im `ReleasePreconditionChecker` ist korrigiert: calhelp/calServer-yii#3939. Begründung und offene Punkte im ADR `2026-10-05-das-sternchen-markiert-die-ausnahme.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ2ckVRoiNnpNKbrzGd9gx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ2ckVRoiNnpNKbrzGd9gx)_